### PR TITLE
feat: scaffold nextjs app with auth and chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/hualas"
+NEXTAUTH_SECRET="change-me"
+NEXTAUTH_URL="http://localhost:3000"

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  root: true,
+  extends: ['next/core-web-vitals', 'prettier'],
+  plugins: ['prettier'],
+  rules: {
+    'prettier/prettier': 'warn',
+  },
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+pnpm-lock.yaml
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Hualas
-Admnistrador de clubs
+
+Full-stack application for Club Hualas built with Next.js 14, Prisma and PostgreSQL.
+
+## Development
+
+1. Copy `.env.example` to `.env` and set the values.
+2. Install dependencies with `pnpm install`.
+3. Generate the Prisma client: `pnpm prisma:generate`.
+4. Start the dev server: `pnpm dev`.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "hualas",
+  "version": "0.1.0",
+  "private": true,
+  "packageManager": "pnpm@8.15.4",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --write .",
+    "prisma:generate": "prisma generate"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.9.0",
+    "bcrypt": "^5.1.1",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.0.0",
+    "lucide-react": "^0.368.0",
+    "next": "14.2.5",
+    "next-auth": "^4.24.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "socket.io": "^4.7.5",
+    "socket.io-client": "^4.7.5",
+    "tailwind-merge": "^2.2.0",
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/bcrypt": "^5.0.2",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.21",
+    "@types/react-dom": "^18.2.7",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "autoprefixer": "^10.4.14",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "postcss": "^8.4.31",
+    "prettier": "^3.2.5",
+    "prisma": "^5.9.0",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.3.3"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'es5',
+  tabWidth: 2,
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,63 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+model User {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  name      String?
+  password  String
+  role      Role     @default(MEMBER)
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  messages  Message[]
+  conversations ConversationParticipant[]
+}
+
+model PasswordResetToken {
+  id        String   @id @default(cuid())
+  token     String   @unique
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  expiresAt DateTime
+  createdAt DateTime @default(now())
+}
+
+model Conversation {
+  id        String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  messages  Message[]
+  participants ConversationParticipant[]
+}
+
+model ConversationParticipant {
+  id             String       @id @default(cuid())
+  userId         String
+  user           User         @relation(fields: [userId], references: [id])
+  conversationId String
+  conversation   Conversation @relation(fields: [conversationId], references: [id])
+  @@unique([userId, conversationId])
+}
+
+model Message {
+  id             String       @id @default(cuid())
+  conversationId String
+  conversation   Conversation @relation(fields: [conversationId], references: [id])
+  senderId       String
+  sender         User         @relation(fields: [senderId], references: [id])
+  body           String
+  readAt         DateTime?
+  createdAt      DateTime     @default(now())
+}
+
+enum Role {
+  ADMIN
+  MEMBER
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { hash } from 'bcrypt';
+import { prisma } from '@/lib/prisma';
+import { registerSchema } from '@/lib/validations/auth';
+
+export async function POST(req: Request) {
+  const data = await req.json();
+  const { email, password, name } = registerSchema.parse(data);
+  const existing = await prisma.user.findUnique({ where: { email } });
+  if (existing) {
+    return NextResponse.json({ error: 'User already exists' }, { status: 400 });
+  }
+  const hashed = await hash(password, 12);
+  const user = await prisma.user.create({
+    data: { email, password: hashed, name },
+  });
+  return NextResponse.json({ id: user.id, email: user.email });
+}

--- a/src/app/api/socket/route.ts
+++ b/src/app/api/socket/route.ts
@@ -1,0 +1,21 @@
+import { NextApiResponse } from 'next';
+import { Server } from 'socket.io';
+import type { NextRequest } from 'next/server';
+
+let io: Server | undefined;
+
+export async function GET(req: NextRequest) {
+  // @ts-ignore - Next.js types don't expose socket
+  const res = (req as any).socket?.server?.res as NextApiResponse | undefined;
+  if (res && !io) {
+    io = new Server(res.socket, {
+      path: '/api/socket',
+    });
+    io.on('connection', (socket) => {
+      socket.on('message', (message) => {
+        socket.broadcast.emit('message', message);
+      });
+    });
+  }
+  return new Response('Socket initialized');
+}

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { socket } from '@/lib/socket';
+import { Button } from '@/components/ui/button';
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<string[]>([]);
+  const [input, setInput] = useState('');
+
+  useEffect(() => {
+    socket.connect();
+    socket.on('message', (msg: string) => {
+      setMessages((prev) => [...prev, msg]);
+    });
+    return () => {
+      socket.disconnect();
+    };
+  }, []);
+
+  return (
+    <div className="p-4">
+      <div className="space-y-2">
+        {messages.map((m, i) => (
+          <div key={i}>{m}</div>
+        ))}
+      </div>
+      <div className="mt-4 flex gap-2">
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          className="border px-2 py-1"
+        />
+        <Button
+          onClick={() => {
+            socket.emit('message', input);
+            setMessages((prev) => [...prev, input]);
+            setInput('');
+          }}
+        >
+          Send
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Hualas Club',
+  description: 'Club Hualas management app',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background text-foreground">
+        {children}
+      </body>
+    </html>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { useState } from 'react';
+import { signIn } from 'next-auth/react';
+import { Button } from '@/components/ui/button';
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  return (
+    <div className="p-4 max-w-sm mx-auto space-y-2">
+      <input
+        className="w-full border px-2 py-1"
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="w-full border px-2 py-1"
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Button
+        className="w-full"
+        onClick={() =>
+          signIn('credentials', {
+            email,
+            password,
+            callbackUrl: '/',
+          })
+        }
+      >
+        Sign in
+      </Button>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <main className="p-4">
+      <h1 className="text-2xl font-bold">Welcome to Club Hualas</h1>
+    </main>
+  );
+}

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { registerSchema } from '@/lib/validations/auth';
+
+export default function RegisterPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+
+  async function submit() {
+    const parsed = registerSchema.safeParse({ email, password, name });
+    if (!parsed.success) {
+      setError('Invalid data');
+      return;
+    }
+    await fetch('/api/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(parsed.data),
+    });
+  }
+
+  return (
+    <div className="p-4 max-w-sm mx-auto space-y-2">
+      <input
+        className="w-full border px-2 py-1"
+        placeholder="Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <input
+        className="w-full border px-2 py-1"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        className="w-full border px-2 py-1"
+        placeholder="Password"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      <Button className="w-full" onClick={submit}>
+        Register
+      </Button>
+    </div>
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,56 @@
+import { compare } from 'bcrypt';
+import type { NextAuthOptions } from 'next-auth';
+import Credentials from 'next-auth/providers/credentials';
+import { prisma } from './prisma';
+
+export const authOptions: NextAuthOptions = {
+  providers: [
+    Credentials({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) return null;
+        const user = await prisma.user.findUnique({
+          where: { email: credentials.email },
+        });
+        if (!user || !user.password || !user.isActive) return null;
+        const valid = await compare(credentials.password, user.password);
+        if (!valid) return null;
+        return { id: user.id, email: user.email, name: user.name, role: user.role };
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+  cookies: {
+    sessionToken: {
+      name: `__Secure-next-auth.session-token`,
+      options: {
+        httpOnly: true,
+        sameSite: 'lax',
+        path: '/',
+        secure: process.env.NODE_ENV === 'production',
+      },
+    },
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (token && session.user) {
+        (session.user as any).id = token.sub;
+        (session.user as any).role = token.role;
+      }
+      return session;
+    },
+  },
+  secret: process.env.NEXTAUTH_SECRET,
+};

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from '@prisma/client';
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+
+export const prisma =
+  globalForPrisma.prisma ||
+  new PrismaClient({
+    log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+  });
+
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;

--- a/src/lib/socket.ts
+++ b/src/lib/socket.ts
@@ -1,0 +1,3 @@
+import { io } from 'socket.io-client';
+
+export const socket = io({ path: '/api/socket' });

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const loginSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(1),
+});
+
+export const registerSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(6),
+  name: z.string().optional(),
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+
+export async function middleware(req: NextRequest) {
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const { pathname } = req.nextUrl;
+
+  if (pathname.startsWith('/admin')) {
+    if (!token || token.role !== 'ADMIN') {
+      return NextResponse.redirect(new URL('/', req.url));
+    }
+  }
+
+  if (pathname.startsWith('/members')) {
+    if (!token) {
+      return NextResponse.redirect(new URL('/api/auth/signin', req.url));
+    }
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/admin/:path*', '/members/:path*'],
+};

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,21 @@
+import NextAuth, { DefaultSession } from 'next-auth';
+
+declare module 'next-auth' {
+  interface User {
+    id: string;
+    role: 'ADMIN' | 'MEMBER';
+  }
+
+  interface Session {
+    user: {
+      id: string;
+      role: 'ADMIN' | 'MEMBER';
+    } & DefaultSession['user'];
+  }
+}
+
+declare module 'next-auth/jwt' {
+  interface JWT {
+    role?: 'ADMIN' | 'MEMBER';
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  darkMode: ['class'],
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [require('tailwindcss-animate')],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app with Tailwind, shadcn/ui setup and ESLint + Prettier
- implement Prisma schema, credential-based NextAuth with role-based middleware
- add Socket.IO chat endpoint and basic UI pages

## Testing
- `pnpm install` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm lint` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*
- `pnpm prisma:generate` *(fails: Proxy response (403) !== 200 when HTTP Tunneling)*


------
https://chatgpt.com/codex/tasks/task_e_68a4b04134b08333aa9fe05565b00f86