### PR TITLE
fix: generate prisma client during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@8.15.4",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",
     "format": "prettier --write .",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,16 +8,17 @@ datasource db {
 }
 
 model User {
-  id        String   @id @default(cuid())
-  email     String   @unique
-  name      String?
-  password  String
-  role      Role     @default(MEMBER)
-  isActive  Boolean  @default(true)
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  messages  Message[]
-  conversations ConversationParticipant[]
+  id                  String                    @id @default(cuid())
+  email               String                    @unique
+  name                String?
+  password            String
+  role                Role                      @default(MEMBER)
+  isActive            Boolean                   @default(true)
+  createdAt           DateTime                  @default(now())
+  updatedAt           DateTime                  @updatedAt
+  messages            Message[]
+  conversations       ConversationParticipant[]
+  passwordResetTokens PasswordResetToken[]
 }
 
 model PasswordResetToken {
@@ -30,10 +31,10 @@ model PasswordResetToken {
 }
 
 model Conversation {
-  id        String   @id @default(cuid())
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  messages  Message[]
+  id           String                    @id @default(cuid())
+  createdAt    DateTime                  @default(now())
+  updatedAt    DateTime                  @updatedAt
+  messages     Message[]
   participants ConversationParticipant[]
 }
 
@@ -43,6 +44,7 @@ model ConversationParticipant {
   user           User         @relation(fields: [userId], references: [id])
   conversationId String
   conversation   Conversation @relation(fields: [conversationId], references: [id])
+
   @@unique([userId, conversationId])
 }
 


### PR DESCRIPTION
## Summary
- ensure Prisma Client is generated during `npm run build`
- define User relation for password reset tokens

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4b98a03088333aa5564ee6aa1262d