### PR TITLE
feat: add navbar component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import Navbar from '@/components/navbar';
+import Providers from '@/components/providers';
 
 export const metadata = {
   title: 'Hualas Club',
@@ -10,7 +12,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-background text-foreground">
-        {children}
+        <Providers>
+          <Navbar />
+          {children}
+        </Providers>
       </body>
     </html>
   );

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { useSession, signOut } from 'next-auth/react';
+
+export default function Navbar() {
+  const { data: session } = useSession();
+  const pathname = usePathname();
+
+  const hideRoutes = ['/login', '/register'];
+  if (hideRoutes.includes(pathname)) {
+    return null;
+  }
+
+  return (
+    <nav className="flex items-center justify-between px-4 py-2 bg-slate-800 text-white">
+      <Link href="/" className="font-semibold">
+        Hualas Club
+      </Link>
+      <div className="flex items-center gap-4">
+        <Link href="/">Home</Link>
+        {session && <Link href="/chat">Chat</Link>}
+        {session ? (
+          <button
+            onClick={() => signOut({ callbackUrl: '/login' })}
+            className="hover:underline"
+          >
+            Logout
+          </button>
+        ) : (
+          <>
+            <Link href="/login" className="hover:underline">
+              Login
+            </Link>
+            <Link href="/register" className="hover:underline">
+              Register
+            </Link>
+          </>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { SessionProvider } from 'next-auth/react';
+import type { ReactNode } from 'react';
+
+export default function Providers({ children }: { children: ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>;
+}


### PR DESCRIPTION
## Summary
- add client-side navbar with links for home, chat, auth
- integrate navbar into layout via session provider

## Testing
- `npx next lint`
- `npx next build`


------
https://chatgpt.com/codex/tasks/task_e_68a4bd7c856c8333bae25271ccd867ab