### PR TITLE
Add 5-character spacing between navbar links

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -18,7 +18,7 @@ export default function Navbar() {
       <Link href="/" className="font-semibold">
         Hualas Club
       </Link>
-      <div className="flex items-center gap-4">
+      <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
         {session && <Link href="/chat">Chat</Link>}
         {session ? (


### PR DESCRIPTION
## Summary
- add 5ch gap between navbar links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4c81e15108333972539f100383e9c