### PR TITLE
feat: keep navbar visible on all pages

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,17 +1,10 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 
 export default function Navbar() {
   const { data: session } = useSession();
-  const pathname = usePathname();
-
-  const hideRoutes = ['/login', '/register'];
-  if (hideRoutes.includes(pathname)) {
-    return null;
-  }
 
   return (
     <nav className="flex items-center justify-between px-4 py-2 bg-slate-800 text-white">


### PR DESCRIPTION
## Summary
- render navbar on login and register pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a4cf4101908333b1d91b1697db3a66