### PR TITLE
feat: move event form to standalone page

### DIFF
--- a/src/app/events/new/page.tsx
+++ b/src/app/events/new/page.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+export default function CreateEventPage() {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log({ name, date });
+    setName('');
+    setDate('');
+  };
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Crear evento</h1>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <input
+          type="text"
+          placeholder="Nombre del evento"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className="w-full border px-2 py-1"
+        />
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className="w-full border px-2 py-1"
+        />
+        <Button type="submit">Guardar</Button>
+      </form>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,13 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
 export default function Home() {
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Welcome to Club Hualas</h1>
+      <Link href="/events/new">
+        <Button className="mt-4">Crear evento</Button>
+      </Link>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- show only a "Crear evento" button on the homepage
- add /events/new page with event creation form

## Testing
- `npm run lint` (fails: prettier warnings)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4d090b01c83338fe5c58ce66db16e