### PR TITLE
feat: add admin user list

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,0 +1,28 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export default async function UsersPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+
+  const users = await prisma.user.findMany({
+    select: { id: true, name: true, email: true, role: true },
+  });
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Users</h1>
+      <ul className="space-y-2">
+        {users.map((u) => (
+          <li key={u.id}>
+            {u.name ?? 'Unnamed'} ({u.email}) - {u.role}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -14,6 +14,7 @@ export default function Navbar() {
       <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
         {session && <Link href="/chat">Chat</Link>}
+        {session?.user.role === 'ADMIN' && <Link href="/admin/users">Users</Link>}
         {session ? (
           <button
             onClick={() => signOut({ callbackUrl: '/login' })}


### PR DESCRIPTION
## Summary
- add admin-only page to list users
- show Users link in navbar only for admins

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: next not found)


------
https://chatgpt.com/codex/tasks/task_e_68a4e41e1b408333bbbc70aa8e64bcaf