### PR TITLE
feat: add edit and delete actions for users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env

--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+type User = { id: string; name: string | null; email: string; role: string };
+
+export default function EditUserForm({ user }: { user: User }) {
+  const [name, setName] = useState(user.name ?? '');
+  const [role, setRole] = useState(user.role);
+  const router = useRouter();
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    await fetch(`/api/users/${user.id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, role }),
+    });
+    router.push('/admin/users');
+    router.refresh();
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2 max-w-sm">
+      <input
+        className="w-full border px-2 py-1"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name"
+      />
+      <select
+        className="w-full border px-2 py-1"
+        value={role}
+        onChange={(e) => setRole(e.target.value)}
+      >
+        <option value="ADMIN">ADMIN</option>
+        <option value="MEMBER">MEMBER</option>
+      </select>
+      <Button type="submit" className="w-full">
+        Save
+      </Button>
+    </form>
+  );
+}

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -1,0 +1,30 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import EditUserForm from './form';
+
+export default async function EditUserPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const user = await prisma.user.findUnique({
+    where: { id: params.id },
+    select: { id: true, name: true, email: true, role: true },
+  });
+  if (!user) {
+    redirect('/admin/users');
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Edit User</h1>
+      <EditUserForm user={user} />
+    </div>
+  );
+}

--- a/src/app/admin/users/delete-button.tsx
+++ b/src/app/admin/users/delete-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export default function DeleteUserButton({ id }: { id: string }) {
+  const router = useRouter();
+
+  async function remove() {
+    await fetch(`/api/users/${id}`, { method: 'DELETE' });
+    router.refresh();
+  }
+
+  return (
+    <Button onClick={remove} className="bg-red-600 hover:bg-red-700">
+      Delete
+    </Button>
+  );
+}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,7 +1,9 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import DeleteUserButton from './delete-button';
 
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
@@ -18,8 +20,17 @@ export default async function UsersPage() {
       <h1 className="text-2xl font-bold mb-4">Users</h1>
       <ul className="space-y-2">
         {users.map((u) => (
-          <li key={u.id}>
-            {u.name ?? 'Unnamed'} ({u.email}) - {u.role}
+          <li key={u.id} className="flex items-center gap-2">
+            <span className="flex-1">
+              {u.name ?? 'Unnamed'} ({u.email}) - {u.role}
+            </span>
+            <Link
+              href={`/admin/users/${u.id}`}
+              className="text-blue-600 hover:underline"
+            >
+              Edit
+            </Link>
+            <DeleteUserButton id={u.id} />
           </li>
         ))}
       </ul>

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -1,0 +1,37 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { userUpdateSchema } from '@/lib/validations/user';
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const data = userUpdateSchema.parse(await req.json());
+  const user = await prisma.user.update({
+    where: { id: params.id },
+    data,
+    select: { id: true, email: true, name: true, role: true },
+  });
+
+  return NextResponse.json(user);
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  await prisma.user.delete({ where: { id: params.id } });
+  return NextResponse.json({ success: true });
+}

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const userUpdateSchema = z.object({
+  name: z.string().optional(),
+  role: z.enum(['ADMIN', 'MEMBER']),
+});


### PR DESCRIPTION
## Summary
- show edit and delete controls in admin user list
- add user edit form and API endpoints for updating and deleting users
- add validation schema for user updates

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4eb4ecd588333b4cdca3896136a5a