### PR TITLE
feat: add dynamic form system

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   messages            Message[]
   conversations       ConversationParticipant[]
   passwordResetTokens PasswordResetToken[]
+  formResponses       FormResponse[]
 }
 
 model PasswordResetToken {
@@ -57,6 +58,34 @@ model Message {
   body           String
   readAt         DateTime?
   createdAt      DateTime     @default(now())
+}
+
+model Form {
+  id        String       @id @default(cuid())
+  title     String
+  fields    FormField[]
+  responses FormResponse[]
+  createdAt DateTime     @default(now())
+}
+
+model FormField {
+  id      String @id @default(cuid())
+  formId  String
+  form    Form   @relation(fields: [formId], references: [id])
+  label   String
+  type    String
+  options Json?
+  order   Int
+}
+
+model FormResponse {
+  id        String @id @default(cuid())
+  formId    String
+  form      Form   @relation(fields: [formId], references: [id])
+  userId    String
+  user      User   @relation(fields: [userId], references: [id])
+  data      Json
+  createdAt DateTime @default(now())
 }
 
 enum Role {

--- a/src/app/admin/forms/new-form.tsx
+++ b/src/app/admin/forms/new-form.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState } from 'react';
+
+type Field = {
+  label: string;
+  type: string;
+  options: string[];
+};
+
+export default function NewForm() {
+  const [title, setTitle] = useState('');
+  const [fields, setFields] = useState<Field[]>([]);
+
+  const addField = () => {
+    setFields([...fields, { label: '', type: 'text', options: [] }]);
+  };
+
+  const updateField = (index: number, key: keyof Field, value: any) => {
+    const newFields = [...fields];
+    (newFields[index] as any)[key] = value;
+    setFields(newFields);
+  };
+
+  const addOption = (index: number) => {
+    const newFields = [...fields];
+    newFields[index].options.push('');
+    setFields(newFields);
+  };
+
+  const updateOption = (
+    fieldIndex: number,
+    optIndex: number,
+    value: string
+  ) => {
+    const newFields = [...fields];
+    newFields[fieldIndex].options[optIndex] = value;
+    setFields(newFields);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/forms', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, fields }),
+    });
+    setTitle('');
+    setFields([]);
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Title</label>
+        <input
+          className="border p-2 w-full"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        {fields.map((f, i) => (
+          <div key={i} className="border p-2">
+            <input
+              className="border p-1 w-full mb-1"
+              placeholder="Label"
+              value={f.label}
+              onChange={(e) => updateField(i, 'label', e.target.value)}
+            />
+            <select
+              className="border p-1 w-full mb-1"
+              value={f.type}
+              onChange={(e) => updateField(i, 'type', e.target.value)}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="select">Select</option>
+            </select>
+            {f.type === 'select' && (
+              <div className="space-y-1">
+                {f.options.map((opt, j) => (
+                  <input
+                    key={j}
+                    className="border p-1 w-full"
+                    placeholder={`Option ${j + 1}`}
+                    value={opt}
+                    onChange={(e) => updateOption(i, j, e.target.value)}
+                  />
+                ))}
+                <button
+                  type="button"
+                  className="text-sm text-blue-600"
+                  onClick={() => addOption(i)}
+                >
+                  Add option
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={addField}
+        className="px-2 py-1 bg-gray-200"
+      >
+        Add field
+      </button>
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Save Form
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/forms/page.tsx
+++ b/src/app/admin/forms/page.tsx
@@ -1,0 +1,27 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import NewForm from './new-form';
+
+export default async function FormsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const forms = await prisma.form.findMany({
+    select: { id: true, title: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Forms</h1>
+      <NewForm />
+      <ul className="mt-4 space-y-2">
+        {forms.map((f) => (
+          <li key={f.id}>{f.title}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/api/forms/[id]/responses/route.ts
+++ b/src/app/api/forms/[id]/responses/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { formResponseSchema } from '@/lib/validations/form';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const { data } = formResponseSchema.parse(await req.json());
+  const response = await prisma.formResponse.create({
+    data: {
+      formId: params.id,
+      userId: session.user.id,
+      data,
+    },
+  });
+  return NextResponse.json(response);
+}

--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const form = await prisma.form.findUnique({
+    where: { id: params.id },
+    include: { fields: { orderBy: { order: 'asc' } } },
+  });
+  if (!form) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json(form);
+}

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { formCreateSchema } from '@/lib/validations/form';
+
+export async function GET() {
+  const forms = await prisma.form.findMany({
+    select: { id: true, title: true },
+    orderBy: { createdAt: 'desc' },
+  });
+  return NextResponse.json(forms);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = formCreateSchema.parse(await req.json());
+  const form = await prisma.form.create({
+    data: {
+      title: data.title,
+      fields: {
+        create: data.fields.map((f, index) => ({
+          label: f.label,
+          type: f.type,
+          options: f.options ? f.options : undefined,
+          order: index,
+        })),
+      },
+    },
+    include: { fields: true },
+  });
+  return NextResponse.json(form);
+}

--- a/src/app/forms/[id]/form.tsx
+++ b/src/app/forms/[id]/form.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+
+export default function FormDisplay({ form }: { form: any }) {
+  const [data, setData] = useState<Record<string, string>>({});
+
+  const handleChange = (id: string, value: string) => {
+    setData((prev) => ({ ...prev, [id]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/forms/${form.id}/responses`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ data }),
+    });
+    setData({});
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {form.fields.map((f: any) => (
+        <div key={f.id}>
+          <label className="block mb-1">{f.label}</label>
+          {f.type === 'text' && (
+            <input
+              className="border p-2 w-full"
+              value={data[f.id] || ''}
+              onChange={(e) => handleChange(f.id, e.target.value)}
+            />
+          )}
+          {f.type === 'number' && (
+            <input
+              type="number"
+              className="border p-2 w-full"
+              value={data[f.id] || ''}
+              onChange={(e) => handleChange(f.id, e.target.value)}
+            />
+          )}
+          {f.type === 'select' && (
+            <select
+              className="border p-2 w-full"
+              value={data[f.id] || ''}
+              onChange={(e) => handleChange(f.id, e.target.value)}
+            >
+              <option value=""></option>
+              {Array.isArray(f.options) &&
+                f.options.map((opt: string) => (
+                  <option key={opt} value={opt}>
+                    {opt}
+                  </option>
+                ))}
+            </select>
+          )}
+        </div>
+      ))}
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Submit
+      </button>
+    </form>
+  );
+}

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -1,0 +1,18 @@
+import { prisma } from '@/lib/prisma';
+import FormDisplay from './form';
+
+export default async function FormPage({ params }: { params: { id: string } }) {
+  const form = await prisma.form.findUnique({
+    where: { id: params.id },
+    include: { fields: { orderBy: { order: 'asc' } } },
+  });
+  if (!form) {
+    return <div className="p-4">Form not found</div>;
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">{form.title}</h1>
+      <FormDisplay form={form} />
+    </div>
+  );
+}

--- a/src/lib/validations/form.ts
+++ b/src/lib/validations/form.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+export const formFieldSchema = z.object({
+  label: z.string(),
+  type: z.enum(['text', 'number', 'select']),
+  options: z.array(z.string()).optional(),
+});
+
+export const formCreateSchema = z.object({
+  title: z.string(),
+  fields: z.array(formFieldSchema),
+});
+
+export const formResponseSchema = z.object({
+  data: z.record(z.string()),
+});


### PR DESCRIPTION
## Summary
- add Prisma models for dynamic forms and responses
- API endpoints for admin form creation and member submissions
- basic admin and member pages for managing and filling forms

## Testing
- `npx prisma generate`
- `npx next lint`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68a56e1fe0808333abb89f0ee8ed403f