### PR TITLE
Rename events to activities and add activity registration

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+export default function ActivityPage() {
+  const activity = {
+    name: 'Nombre de la actividad',
+    date: '2024-01-01',
+    image: 'https://via.placeholder.com/300',
+    description: 'Descripción de la actividad.',
+  };
+
+  const handleSignup = () => {
+    console.log('Usuario inscrito en la actividad');
+  };
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
+      <img
+        src={activity.image}
+        alt={activity.name}
+        className="mb-4 max-w-full"
+      />
+      <p className="mb-2">Fecha: {activity.date}</p>
+      <p className="mb-4">{activity.description}</p>
+      <Button onClick={handleSignup}>Inscribirse</Button>
+    </main>
+  );
+}
+

--- a/src/app/activities/new/page.tsx
+++ b/src/app/activities/new/page.tsx
@@ -3,24 +3,28 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 
-export default function CreateEventPage() {
+export default function CreateActivityPage() {
   const [name, setName] = useState('');
   const [date, setDate] = useState('');
+  const [image, setImage] = useState('');
+  const [description, setDescription] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    console.log({ name, date });
+    console.log({ name, date, image, description });
     setName('');
     setDate('');
+    setImage('');
+    setDescription('');
   };
 
   return (
     <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">Crear evento</h1>
+      <h1 className="mb-4 text-2xl font-bold">Crear actividad</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
         <input
           type="text"
-          placeholder="Nombre del evento"
+          placeholder="Nombre de la actividad"
           value={name}
           onChange={(e) => setName(e.target.value)}
           className="w-full border px-2 py-1"
@@ -29,6 +33,19 @@ export default function CreateEventPage() {
           type="date"
           value={date}
           onChange={(e) => setDate(e.target.value)}
+          className="w-full border px-2 py-1"
+        />
+        <input
+          type="url"
+          placeholder="URL de la imagen"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+          className="w-full border px-2 py-1"
+        />
+        <textarea
+          placeholder="Descripción"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
           className="w-full border px-2 py-1"
         />
         <Button type="submit">Guardar</Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,8 +5,8 @@ export default function Home() {
   return (
     <main className="p-4">
       <h1 className="text-2xl font-bold">Welcome to Club Hualas</h1>
-      <Link href="/events/new">
-        <Button className="mt-4">Crear evento</Button>
+      <Link href="/activities/new">
+        <Button className="mt-4">Crear actividad</Button>
       </Link>
     </main>
   );


### PR DESCRIPTION
## Summary
- rename event references to activities
- add image and description to activity creation
- provide activity detail page with sign-up button

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a65e8be37c8333a09d1a2841f5e0cc