### PR TITLE
Add event model with participant counts and navbar link

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,7 +20,7 @@ model User {
   conversations       ConversationParticipant[]
   passwordResetTokens PasswordResetToken[]
   formResponses       FormResponse[]
-  eventParticipants   EventParticipant[]
+  activityParticipants ActivityParticipant[]
 }
 
 model PasswordResetToken {
@@ -89,24 +89,24 @@ model FormResponse {
   createdAt DateTime @default(now())
 }
 
-model Event {
+model Activity {
   id          String             @id @default(cuid())
   name        String
   date        DateTime
   image       String?
   description String?
-  participants EventParticipant[]
+  participants ActivityParticipant[]
   createdAt   DateTime @default(now())
 }
 
-model EventParticipant {
+model ActivityParticipant {
   id      String @id @default(cuid())
-  eventId String
+  activityId String
   userId  String
-  event   Event @relation(fields: [eventId], references: [id])
+  activity   Activity @relation(fields: [activityId], references: [id])
   user    User  @relation(fields: [userId], references: [id])
 
-  @@unique([eventId, userId])
+  @@unique([activityId, userId])
 }
 
 enum Role {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   conversations       ConversationParticipant[]
   passwordResetTokens PasswordResetToken[]
   formResponses       FormResponse[]
+  eventParticipants   EventParticipant[]
 }
 
 model PasswordResetToken {
@@ -86,6 +87,26 @@ model FormResponse {
   user      User   @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
+}
+
+model Event {
+  id          String             @id @default(cuid())
+  name        String
+  date        DateTime
+  image       String?
+  description String?
+  participants EventParticipant[]
+  createdAt   DateTime @default(now())
+}
+
+model EventParticipant {
+  id      String @id @default(cuid())
+  eventId String
+  userId  String
+  event   Event @relation(fields: [eventId], references: [id])
+  user    User  @relation(fields: [userId], references: [id])
+
+  @@unique([eventId, userId])
 }
 
 enum Role {

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
+import Image from 'next/image';
 
 interface ActivityPageProps {
   params: { id: string };
@@ -19,7 +20,13 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
       {activity.image && (
-        <img src={activity.image} alt={activity.name} className="mb-4 max-w-full" />
+        <Image
+          src={activity.image}
+          alt={activity.name}
+          width={800}
+          height={600}
+          className="mb-4 max-w-full"
+        />
       )}
       <p className="mb-2">Fecha: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-4">{activity.description}</p>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,31 +1,32 @@
-'use client';
-
+import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
 
-export default function ActivityPage() {
-  const activity = {
-    name: 'Nombre de la actividad',
-    date: '2024-01-01',
-    image: 'https://via.placeholder.com/300',
-    description: 'Descripción de la actividad.',
-  };
+interface ActivityPageProps {
+  params: { id: string };
+}
 
-  const handleSignup = () => {
-    console.log('Usuario inscrito en la actividad');
-  };
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  const activity = await prisma.event.findUnique({
+    where: { id: params.id },
+    include: { participants: true },
+  });
+
+  if (!activity) {
+    return <main className="p-4">Actividad no encontrada</main>;
+  }
 
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
-      <img
-        src={activity.image}
-        alt={activity.name}
-        className="mb-4 max-w-full"
-      />
-      <p className="mb-2">Fecha: {activity.date}</p>
+      {activity.image && (
+        <img src={activity.image} alt={activity.name} className="mb-4 max-w-full" />
+      )}
+      <p className="mb-2">Fecha: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-4">{activity.description}</p>
-      <Button onClick={handleSignup}>Inscribirse</Button>
+      <p className="mb-4 font-semibold">
+        {activity.participants.length} participantes
+      </p>
+      <Button>Inscribirse</Button>
     </main>
   );
 }
-

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -6,7 +6,7 @@ interface ActivityPageProps {
 }
 
 export default async function ActivityPage({ params }: ActivityPageProps) {
-  const activity = await prisma.event.findUnique({
+  const activity = await prisma.activity.findUnique({
     where: { id: params.id },
     include: { participants: true },
   });

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { prisma } from '@/lib/prisma';
 
 export default async function ActivitiesPage() {
-  const activities = await prisma.event.findMany({
+  const activities = await prisma.activity.findMany({
     include: { participants: true },
     orderBy: { date: 'asc' },
   });

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+
+export default async function ActivitiesPage() {
+  const activities = await prisma.event.findMany({
+    include: { participants: true },
+    orderBy: { date: 'asc' },
+  });
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Actividades</h1>
+      <ul className="space-y-4">
+        {activities.map((activity) => (
+          <li key={activity.id} className="border p-4">
+            <Link href={`/activities/${activity.id}`} className="text-xl font-semibold">
+              {activity.name}
+            </Link>
+            <p className="text-sm text-slate-600">
+              {activity.participants.length} participantes
+            </p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -13,7 +13,10 @@ export default async function ActivitiesPage() {
       <ul className="space-y-4">
         {activities.map((activity) => (
           <li key={activity.id} className="border p-4">
-            <Link href={`/activities/${activity.id}`} className="text-xl font-semibold">
+            <Link
+              href={`/activities/${activity.id}`}
+              className="text-xl font-semibold"
+            >
               {activity.name}
             </Link>
             <p className="text-sm text-slate-600">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,6 +13,7 @@ export default function Navbar() {
       </Link>
       <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
+        <Link href="/activities">Actividades</Link>
         {session && <Link href="/chat">Chat</Link>}
         {session?.user.role === 'ADMIN' && <Link href="/admin/users">Users</Link>}
         {session ? (

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -15,7 +15,9 @@ export default function Navbar() {
         <Link href="/">Home</Link>
         <Link href="/activities">Actividades</Link>
         {session && <Link href="/chat">Chat</Link>}
-        {session?.user.role === 'ADMIN' && <Link href="/admin/users">Users</Link>}
+        {session?.user.role === 'ADMIN' && (
+          <Link href="/admin/users">Users</Link>
+        )}
         {session ? (
           <button
             onClick={() => signOut({ callbackUrl: '/login' })}


### PR DESCRIPTION
## Summary
- add event and event participant models including image and description fields
- list activities and show participant counts
- link activities in navbar

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a660a54924833390012e9212bf94e1