### PR TITLE
feat(admin): list and manage forms

### DIFF
--- a/src/app/admin/forms/[id]/edit/edit-form.tsx
+++ b/src/app/admin/forms/[id]/edit/edit-form.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+type Field = {
+  label: string;
+  type: string;
+  options: string[];
+};
+
+export default function EditForm({ form }: { form: any }) {
+  const [title, setTitle] = useState(form.title);
+  const [fields, setFields] = useState<Field[]>(
+    form.fields.map((f: any) => ({
+      label: f.label,
+      type: f.type,
+      options: Array.isArray(f.options) ? f.options : [],
+    }))
+  );
+  const router = useRouter();
+
+  const addField = () => {
+    setFields([...fields, { label: '', type: 'text', options: [] }]);
+  };
+
+  const updateField = (index: number, key: keyof Field, value: any) => {
+    const newFields = [...fields];
+    (newFields[index] as any)[key] = value;
+    setFields(newFields);
+  };
+
+  const addOption = (index: number) => {
+    const newFields = [...fields];
+    newFields[index].options.push('');
+    setFields(newFields);
+  };
+
+  const updateOption = (
+    fieldIndex: number,
+    optIndex: number,
+    value: string
+  ) => {
+    const newFields = [...fields];
+    newFields[fieldIndex].options[optIndex] = value;
+    setFields(newFields);
+  };
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/forms/${form.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, fields }),
+    });
+    router.push('/admin/forms');
+  };
+
+  return (
+    <form onSubmit={submit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Title</label>
+        <input
+          className="border p-2 w-full"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2">
+        {fields.map((f, i) => (
+          <div key={i} className="border p-2">
+            <input
+              className="border p-1 w-full mb-1"
+              placeholder="Label"
+              value={f.label}
+              onChange={(e) => updateField(i, 'label', e.target.value)}
+            />
+            <select
+              className="border p-1 w-full mb-1"
+              value={f.type}
+              onChange={(e) => updateField(i, 'type', e.target.value)}
+            >
+              <option value="text">Text</option>
+              <option value="number">Number</option>
+              <option value="select">Select</option>
+            </select>
+            {f.type === 'select' && (
+              <div className="space-y-1">
+                {f.options.map((opt, j) => (
+                  <input
+                    key={j}
+                    className="border p-1 w-full"
+                    placeholder={`Option ${j + 1}`}
+                    value={opt}
+                    onChange={(e) => updateOption(i, j, e.target.value)}
+                  />
+                ))}
+                <button
+                  type="button"
+                  className="text-sm text-blue-600"
+                  onClick={() => addOption(i)}
+                >
+                  Add option
+                </button>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={addField}
+        className="px-2 py-1 bg-gray-200"
+      >
+        Add field
+      </button>
+      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
+        Save Form
+      </button>
+    </form>
+  );
+}

--- a/src/app/admin/forms/[id]/edit/page.tsx
+++ b/src/app/admin/forms/[id]/edit/page.tsx
@@ -1,0 +1,29 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import EditForm from './edit-form';
+
+export default async function EditFormPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const form = await prisma.form.findUnique({
+    where: { id: params.id },
+    include: { fields: { orderBy: { order: 'asc' } } },
+  });
+  if (!form) {
+    return <div className="p-4">Form not found</div>;
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Edit Form</h1>
+      <EditForm form={form} />
+    </div>
+  );
+}

--- a/src/app/admin/forms/[id]/page.tsx
+++ b/src/app/admin/forms/[id]/page.tsx
@@ -1,0 +1,42 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export default async function FormResponsesPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const form = await prisma.form.findUnique({
+    where: { id: params.id },
+    select: {
+      title: true,
+      responses: {
+        include: {
+          user: { select: { name: true, email: true } },
+        },
+        orderBy: { createdAt: 'desc' },
+      },
+    },
+  });
+  if (!form) {
+    return <div className="p-4">Form not found</div>;
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">{form.title} Responses</h1>
+      <ul className="space-y-2">
+        {form.responses.map((r) => (
+          <li key={r.id} className="border p-2">
+            {r.user.name || r.user.email}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/admin/forms/form-list.tsx
+++ b/src/app/admin/forms/form-list.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+interface Form {
+  id: string;
+  title: string;
+}
+
+export default function FormList({ forms }: { forms: Form[] }) {
+  const router = useRouter();
+
+  const handleDelete = async (id: string) => {
+    await fetch(`/api/forms/${id}`, { method: 'DELETE' });
+    router.refresh();
+  };
+
+  return (
+    <table className="w-full border-collapse">
+      <thead>
+        <tr>
+          <th className="text-left p-2 border-b">Title</th>
+          <th className="text-left p-2 border-b">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {forms.map((f) => (
+          <tr key={f.id}>
+            <td className="p-2 border-b">{f.title}</td>
+            <td className="p-2 border-b space-x-2">
+              <Link href={`/admin/forms/${f.id}`} className="text-blue-600">
+                View
+              </Link>
+              <Link
+                href={`/admin/forms/${f.id}/edit`}
+                className="text-blue-600"
+              >
+                Edit
+              </Link>
+              <button
+                onClick={() => handleDelete(f.id)}
+                className="text-red-600"
+              >
+                Delete
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/src/app/admin/forms/new/page.tsx
+++ b/src/app/admin/forms/new/page.tsx
@@ -1,0 +1,17 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import NewForm from '../new-form';
+
+export default async function NewFormPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">New Form</h1>
+      <NewForm />
+    </div>
+  );
+}

--- a/src/app/admin/forms/page.tsx
+++ b/src/app/admin/forms/page.tsx
@@ -2,7 +2,8 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import NewForm from './new-form';
+import Link from 'next/link';
+import FormList from './form-list';
 
 export default async function FormsPage() {
   const session = await getServerSession(authOptions);
@@ -15,13 +16,16 @@ export default async function FormsPage() {
   });
   return (
     <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Forms</h1>
-      <NewForm />
-      <ul className="mt-4 space-y-2">
-        {forms.map((f) => (
-          <li key={f.id}>{f.title}</li>
-        ))}
-      </ul>
+      <div className="flex items-center justify-between mb-4">
+        <h1 className="text-2xl font-bold">Forms</h1>
+        <Link
+          href="/admin/forms/new"
+          className="px-4 py-2 bg-blue-600 text-white rounded"
+        >
+          New Form
+        </Link>
+      </div>
+      <FormList forms={forms} />
     </div>
   );
 }

--- a/src/app/api/forms/[id]/responses/route.ts
+++ b/src/app/api/forms/[id]/responses/route.ts
@@ -22,3 +22,21 @@ export async function POST(
   });
   return NextResponse.json(response);
 }
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const responses = await prisma.formResponse.findMany({
+    where: { formId: params.id },
+    include: {
+      user: { select: { name: true, email: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+  });
+  return NextResponse.json(responses);
+}

--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -1,5 +1,8 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { formCreateSchema } from '@/lib/validations/form';
 
 export async function GET(
   req: Request,
@@ -13,4 +16,44 @@ export async function GET(
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
   return NextResponse.json(form);
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = formCreateSchema.parse(await req.json());
+  await prisma.formField.deleteMany({ where: { formId: params.id } });
+  const form = await prisma.form.update({
+    where: { id: params.id },
+    data: {
+      title: data.title,
+      fields: {
+        create: data.fields.map((f, index) => ({
+          label: f.label,
+          type: f.type,
+          options: f.options ? f.options : undefined,
+          order: index,
+        })),
+      },
+    },
+    include: { fields: true },
+  });
+  return NextResponse.json(form);
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  await prisma.form.delete({ where: { id: params.id } });
+  return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary
- list forms in admin area and provide link to create a new one
- add view, edit and delete actions for forms
- expose API endpoints to update, delete and fetch form responses

## Testing
- `npm run lint` *(fails: Using `<img>` could result in slower LCP and higher bandwidth. Consider using `<Image />` from `next/image` to automatically optimize images. This may incur additional usage or cost from your provider. See: https://nextjs.org/docs/messages/no-img-element  @next/next/no-img-element)*

------
https://chatgpt.com/codex/tasks/task_e_68a663f0c7d88333bd02df3441eda02f