### PR TITLE
feat: add contact page and navbar link

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,19 @@
+export default function ContactPage() {
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-2xl font-bold">¡Estamos en contacto!</h1>
+      <div>
+        <h2 className="font-semibold">Instagram</h2>
+        <p>@hualas_patagonico</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">Información general</h2>
+        <p>Info@clubhualas.com.ar</p>
+      </div>
+      <div>
+        <h2 className="font-semibold">Tesorería</h2>
+        <p>tesoreria@clubhualas.com.ar</p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,6 +13,7 @@ export default function Navbar() {
       </Link>
       <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
+        <Link href="/contact">Contacto</Link>
         {session && <Link href="/chat">Chat</Link>}
         {session?.user.role === 'ADMIN' && (
           <>


### PR DESCRIPTION
## Summary
- add Contacto page with social and email info
- link Contacto page in navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a66944810083338157f42f0675d1b4