### PR TITLE
Add activity model with participant counts and navbar link

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   conversations       ConversationParticipant[]
   passwordResetTokens PasswordResetToken[]
   formResponses       FormResponse[]
+  activityParticipants ActivityParticipant[]
 }
 
 model PasswordResetToken {
@@ -86,6 +87,26 @@ model FormResponse {
   user      User   @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
+}
+
+model Activity {
+  id          String             @id @default(cuid())
+  name        String
+  date        DateTime
+  image       String?
+  description String?
+  participants ActivityParticipant[]
+  createdAt   DateTime @default(now())
+}
+
+model ActivityParticipant {
+  id      String @id @default(cuid())
+  activityId String
+  userId  String
+  activity   Activity @relation(fields: [activityId], references: [id])
+  user    User  @relation(fields: [userId], references: [id])
+
+  @@unique([activityId, userId])
 }
 
 enum Role {

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,31 +1,39 @@
-'use client';
-
+import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
+import Image from 'next/image';
 
-export default function ActivityPage() {
-  const activity = {
-    name: 'Nombre de la actividad',
-    date: '2024-01-01',
-    image: 'https://via.placeholder.com/300',
-    description: 'Descripción de la actividad.',
-  };
+interface ActivityPageProps {
+  params: { id: string };
+}
 
-  const handleSignup = () => {
-    console.log('Usuario inscrito en la actividad');
-  };
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+    include: { participants: true },
+  });
+
+  if (!activity) {
+    return <main className="p-4">Activity not found</main>;
+  }
 
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
-      <img
-        src={activity.image}
-        alt={activity.name}
-        className="mb-4 max-w-full"
-      />
-      <p className="mb-2">Fecha: {activity.date}</p>
+      {activity.image && (
+        <Image
+          src={activity.image}
+          alt={activity.name}
+          width={800}
+          height={600}
+          className="mb-4 max-w-full"
+        />
+      )}
+      <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-4">{activity.description}</p>
-      <Button onClick={handleSignup}>Inscribirse</Button>
+      <p className="mb-4 font-semibold">
+        {activity.participants.length} participants
+      </p>
+      <Button>Register</Button>
     </main>
   );
 }
-

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,0 +1,30 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+
+export default async function ActivitiesPage() {
+  const activities = await prisma.activity.findMany({
+    include: { participants: true },
+    orderBy: { date: 'asc' },
+  });
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Activities</h1>
+      <ul className="space-y-4">
+        {activities.map((activity) => (
+          <li key={activity.id} className="border p-4">
+            <Link
+              href={`/activities/${activity.id}`}
+              className="text-xl font-semibold"
+            >
+              {activity.name}
+            </Link>
+            <p className="text-sm text-slate-600">
+              {activity.participants.length} participants
+            </p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,8 +13,11 @@ export default function Navbar() {
       </Link>
       <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
+        <Link href="/activities">Activities</Link>
         {session && <Link href="/chat">Chat</Link>}
-        {session?.user.role === 'ADMIN' && <Link href="/admin/users">Users</Link>}
+        {session?.user.role === 'ADMIN' && (
+          <Link href="/admin/users">Users</Link>
+        )}
         {session ? (
           <button
             onClick={() => signOut({ callbackUrl: '/login' })}


### PR DESCRIPTION
## Summary
- add Activity and ActivityParticipant models with image, description, and user link
- list activities with participant totals and link from navbar
- show activity details with English labels and optimized images

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a660a54924833390012e9212bf94e1