### PR TITLE
Allow public form responses and show counts

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,8 +82,8 @@ model FormResponse {
   id        String @id @default(cuid())
   formId    String
   form      Form   @relation(fields: [formId], references: [id])
-  userId    String
-  user      User   @relation(fields: [userId], references: [id])
+  userId    String?
+  user      User?  @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
 }

--- a/src/app/admin/forms/[id]/page.tsx
+++ b/src/app/admin/forms/[id]/page.tsx
@@ -33,7 +33,7 @@ export default async function FormResponsesPage({
       <ul className="space-y-2">
         {form.responses.map((r) => (
           <li key={r.id} className="border p-2">
-            {r.user.name || r.user.email}
+            {r.user?.name || r.user?.email || 'Anonymous'}
           </li>
         ))}
       </ul>

--- a/src/app/admin/forms/form-list.tsx
+++ b/src/app/admin/forms/form-list.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 interface Form {
   id: string;
   title: string;
+  responseCount: number;
 }
 
 export default function FormList({ forms }: { forms: Form[] }) {
@@ -21,6 +22,7 @@ export default function FormList({ forms }: { forms: Form[] }) {
       <thead>
         <tr>
           <th className="text-left p-2 border-b">Title</th>
+          <th className="text-left p-2 border-b">Responses</th>
           <th className="text-left p-2 border-b">Actions</th>
         </tr>
       </thead>
@@ -28,6 +30,7 @@ export default function FormList({ forms }: { forms: Form[] }) {
         {forms.map((f) => (
           <tr key={f.id}>
             <td className="p-2 border-b">{f.title}</td>
+            <td className="p-2 border-b">{f.responseCount}</td>
             <td className="p-2 border-b space-x-2">
               <Link href={`/admin/forms/${f.id}`} className="text-blue-600">
                 View
@@ -37,6 +40,13 @@ export default function FormList({ forms }: { forms: Form[] }) {
                 className="text-blue-600"
               >
                 Edit
+              </Link>
+              <Link
+                href={`/forms/${f.id}`}
+                className="text-blue-600"
+                target="_blank"
+              >
+                Public
               </Link>
               <button
                 onClick={() => handleDelete(f.id)}

--- a/src/app/admin/forms/page.tsx
+++ b/src/app/admin/forms/page.tsx
@@ -11,7 +11,11 @@ export default async function FormsPage() {
     redirect('/');
   }
   const forms = await prisma.form.findMany({
-    select: { id: true, title: true },
+    select: {
+      id: true,
+      title: true,
+      _count: { select: { responses: true } },
+    },
     orderBy: { createdAt: 'desc' },
   });
   return (
@@ -25,7 +29,13 @@ export default async function FormsPage() {
           New Form
         </Link>
       </div>
-      <FormList forms={forms} />
+      <FormList
+        forms={forms.map((f) => ({
+          id: f.id,
+          title: f.title,
+          responseCount: f._count.responses,
+        }))}
+      />
     </div>
   );
 }

--- a/src/app/api/forms/[id]/responses/route.ts
+++ b/src/app/api/forms/[id]/responses/route.ts
@@ -9,15 +9,12 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
   const { data } = formResponseSchema.parse(await req.json());
   const response = await prisma.formResponse.create({
     data: {
       formId: params.id,
-      userId: session.user.id,
       data,
+      ...(session ? { userId: session.user.id } : {}),
     },
   });
   return NextResponse.json(response);

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -5,6 +5,10 @@ import { prisma } from '@/lib/prisma';
 import { formCreateSchema } from '@/lib/validations/form';
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const forms = await prisma.form.findMany({
     select: { id: true, title: true },
     orderBy: { createdAt: 'desc' },


### PR DESCRIPTION
## Summary
- allow anonymous form responses by making user optional
- restrict forms API to admins and show response counts
- display response count and public link in admin form list

## Testing
- `npx prisma generate`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a669fb12a48333807ff00b6590227f