### PR TITLE
Link footer to Instagram profile

### DIFF
--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -7,7 +7,13 @@ export default function Footer() {
       <p className="mt-2">
         ¡Seguinos en Instagram!
         <br />
-        @hualas_patagonico
+        <a
+          href="https://www.instagram.com/hualas_patagonico/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          @hualas_patagonico
+        </a>
       </p>
       <p className="mt-2">
         Club Social y Deportivo Hualas Patagónico.


### PR DESCRIPTION
## Summary
- make @hualas_patagonico in the footer link to its Instagram page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a66b710a9483339f2b46274ccf3310