### PR TITLE
Add activity model with participant counts and navbar link

### DIFF
--- a/prisma/migrations/20240821000000_add_activity/migration.sql
+++ b/prisma/migrations/20240821000000_add_activity/migration.sql
@@ -1,0 +1,153 @@
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'MEMBER');
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "password" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'MEMBER',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ConversationParticipant" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+
+    CONSTRAINT "ConversationParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "readAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Form" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Form_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FormField" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "options" JSONB,
+    "order" INTEGER NOT NULL,
+
+    CONSTRAINT "FormField_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FormResponse" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FormResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Activity" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "image" TEXT,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ActivityParticipant" (
+    "id" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+
+    CONSTRAINT "ActivityParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_token_key" ON "PasswordResetToken"("token");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationParticipant_userId_conversationId_key" ON "ConversationParticipant"("userId", "conversationId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityParticipant_activityId_userId_key" ON "ActivityParticipant"("activityId", "userId");
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationParticipant" ADD CONSTRAINT "ConversationParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationParticipant" ADD CONSTRAINT "ConversationParticipant_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormField" ADD CONSTRAINT "FormField_formId_fkey" FOREIGN KEY ("formId") REFERENCES "Form"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormResponse" ADD CONSTRAINT "FormResponse_formId_fkey" FOREIGN KEY ("formId") REFERENCES "Form"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormResponse" ADD CONSTRAINT "FormResponse_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/migrations/migration_lock.toml
+++ b/prisma/migrations/migration_lock.toml
@@ -1,0 +1,1 @@
+provider = "postgresql"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   conversations       ConversationParticipant[]
   passwordResetTokens PasswordResetToken[]
   formResponses       FormResponse[]
+  activityParticipants ActivityParticipant[]
 }
 
 model PasswordResetToken {
@@ -86,6 +87,26 @@ model FormResponse {
   user      User   @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
+}
+
+model Activity {
+  id          String             @id @default(cuid())
+  name        String
+  date        DateTime
+  image       String?
+  description String?
+  participants ActivityParticipant[]
+  createdAt   DateTime @default(now())
+}
+
+model ActivityParticipant {
+  id      String @id @default(cuid())
+  activityId String
+  userId  String
+  activity   Activity @relation(fields: [activityId], references: [id])
+  user    User  @relation(fields: [userId], references: [id])
+
+  @@unique([activityId, userId])
 }
 
 enum Role {

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,31 +1,52 @@
-'use client';
-
+import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
+import Image from 'next/image';
+import { Prisma } from '@prisma/client';
 
-export default function ActivityPage() {
-  const activity = {
-    name: 'Nombre de la actividad',
-    date: '2024-01-01',
-    image: 'https://via.placeholder.com/300',
-    description: 'Descripción de la actividad.',
-  };
+interface ActivityPageProps {
+  params: { id: string };
+}
 
-  const handleSignup = () => {
-    console.log('Usuario inscrito en la actividad');
-  };
+export default async function ActivityPage({ params }: ActivityPageProps) {
+  let activity = null as Awaited<ReturnType<typeof prisma.activity.findUnique>>;
+  try {
+    activity = await prisma.activity.findUnique({
+      where: { id: params.id },
+      include: { participants: true },
+    });
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === 'P2021'
+    ) {
+      activity = null;
+    } else {
+      throw e;
+    }
+  }
+
+  if (!activity) {
+    return <main className="p-4">Activity not found</main>;
+  }
 
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
-      <img
-        src={activity.image}
-        alt={activity.name}
-        className="mb-4 max-w-full"
-      />
-      <p className="mb-2">Fecha: {activity.date}</p>
+      {activity.image && (
+        <Image
+          src={activity.image}
+          alt={activity.name}
+          width={800}
+          height={600}
+          className="mb-4 max-w-full"
+        />
+      )}
+      <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-4">{activity.description}</p>
-      <Button onClick={handleSignup}>Inscribirse</Button>
+      <p className="mb-4 font-semibold">
+        {activity.participants.length} participants
+      </p>
+      <Button>Register</Button>
     </main>
   );
 }
-

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -8,7 +8,11 @@ interface ActivityPageProps {
 }
 
 export default async function ActivityPage({ params }: ActivityPageProps) {
-  let activity = null as Awaited<ReturnType<typeof prisma.activity.findUnique>>;
+  type ActivityWithParticipants = Prisma.ActivityGetPayload<{
+    include: { participants: true };
+  }>;
+
+  let activity: ActivityWithParticipants | null = null;
   try {
     activity = await prisma.activity.findUnique({
       where: { id: params.id },

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -3,7 +3,11 @@ import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 
 export default async function ActivitiesPage() {
-  let activities = [] as Awaited<ReturnType<typeof prisma.activity.findMany>>;
+  type ActivityWithParticipants = Prisma.ActivityGetPayload<{
+    include: { participants: true };
+  }>;
+
+  let activities: ActivityWithParticipants[] = [];
 
   try {
     activities = await prisma.activity.findMany({

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
+
+export default async function ActivitiesPage() {
+  let activities = [] as Awaited<ReturnType<typeof prisma.activity.findMany>>;
+
+  try {
+    activities = await prisma.activity.findMany({
+      include: { participants: true },
+      orderBy: { date: 'asc' },
+    });
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === 'P2021'
+    ) {
+      activities = [];
+    } else {
+      throw e;
+    }
+  }
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Activities</h1>
+      <ul className="space-y-4">
+        {activities.map((activity) => (
+          <li key={activity.id} className="border p-4">
+            <Link
+              href={`/activities/${activity.id}`}
+              className="text-xl font-semibold"
+            >
+              {activity.name}
+            </Link>
+            <p className="text-sm text-slate-600">
+              {activity.participants.length} participants
+            </p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -13,8 +13,11 @@ export default function Navbar() {
       </Link>
       <div className="flex items-center gap-[5ch]">
         <Link href="/">Home</Link>
+        <Link href="/activities">Activities</Link>
         {session && <Link href="/chat">Chat</Link>}
-        {session?.user.role === 'ADMIN' && <Link href="/admin/users">Users</Link>}
+        {session?.user.role === 'ADMIN' && (
+          <Link href="/admin/users">Users</Link>
+        )}
         {session ? (
           <button
             onClick={() => signOut({ callbackUrl: '/login' })}


### PR DESCRIPTION
## Summary
- guard activity queries to return empty results if the Activity tables are missing
- include an initial Prisma migration for Activity and ActivityParticipant tables

## Testing
- `npx prisma generate`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a660a54924833390012e9212bf94e1