### PR TITLE
Display activities on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,47 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
+import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 
-export default function Home() {
+export default async function Home() {
+  type ActivityWithParticipants = Prisma.ActivityGetPayload<{
+    include: { participants: true };
+  }>;
+
+  let activities: ActivityWithParticipants[] = [];
+
+  try {
+    activities = await prisma.activity.findMany({
+      include: { participants: true },
+      orderBy: { date: 'asc' },
+    });
+  } catch (e) {
+    if (
+      e instanceof Prisma.PrismaClientKnownRequestError &&
+      e.code === 'P2021'
+    ) {
+      activities = [];
+    } else {
+      throw e;
+    }
+  }
+
   return (
     <main className="p-4">
-      <h1 className="text-2xl font-bold">Welcome to Club Hualas</h1>
-      <Link href="/activities/new">
-        <Button className="mt-4">Crear actividad</Button>
-      </Link>
+      <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
+      <ul className="space-y-4">
+        {activities.map((activity) => (
+          <li
+            key={activity.id}
+            className="flex items-center justify-between border p-4"
+          >
+            <span className="font-semibold">{activity.name}</span>
+            <Link href={`/activities/${activity.id}`}>
+              <Button>Inscribirse</Button>
+            </Link>
+          </li>
+        ))}
+      </ul>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- Show database activities on the main page
- Replace "Crear actividad" button with list of events and signup links

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a672ccbf088333b8dfb460bda86e5e