### PR TITLE
feat(forms): add required field option

### DIFF
--- a/prisma/migrations/20240822000000_add_required_field/migration.sql
+++ b/prisma/migrations/20240822000000_add_required_field/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "FormField" ADD COLUMN "required" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -76,6 +76,7 @@ model FormField {
   label   String
   type    String
   options Json?
+  required Boolean @default(false)
   order   Int
 }
 

--- a/src/app/admin/forms/[id]/edit/edit-form.tsx
+++ b/src/app/admin/forms/[id]/edit/edit-form.tsx
@@ -7,6 +7,7 @@ type Field = {
   label: string;
   type: string;
   options: string[];
+  required: boolean;
 };
 
 export default function EditForm({ form }: { form: any }) {
@@ -16,12 +17,16 @@ export default function EditForm({ form }: { form: any }) {
       label: f.label,
       type: f.type,
       options: Array.isArray(f.options) ? f.options : [],
+      required: f.required ?? false,
     }))
   );
   const router = useRouter();
 
   const addField = () => {
-    setFields([...fields, { label: '', type: 'text', options: [] }]);
+    setFields([
+      ...fields,
+      { label: '', type: 'text', options: [], required: false },
+    ]);
   };
 
   const updateField = (index: number, key: keyof Field, value: any) => {
@@ -84,6 +89,15 @@ export default function EditForm({ form }: { form: any }) {
               <option value="number">Number</option>
               <option value="select">Select</option>
             </select>
+            <label className="inline-flex items-center mb-1">
+              <input
+                type="checkbox"
+                className="mr-1"
+                checked={f.required}
+                onChange={(e) => updateField(i, 'required', e.target.checked)}
+              />
+              Required
+            </label>
             {f.type === 'select' && (
               <div className="space-y-1">
                 {f.options.map((opt, j) => (

--- a/src/app/admin/forms/new-form.tsx
+++ b/src/app/admin/forms/new-form.tsx
@@ -6,6 +6,7 @@ type Field = {
   label: string;
   type: string;
   options: string[];
+  required: boolean;
 };
 
 export default function NewForm() {
@@ -13,7 +14,10 @@ export default function NewForm() {
   const [fields, setFields] = useState<Field[]>([]);
 
   const addField = () => {
-    setFields([...fields, { label: '', type: 'text', options: [] }]);
+    setFields([
+      ...fields,
+      { label: '', type: 'text', options: [], required: false },
+    ]);
   };
 
   const updateField = (index: number, key: keyof Field, value: any) => {
@@ -77,6 +81,15 @@ export default function NewForm() {
               <option value="number">Number</option>
               <option value="select">Select</option>
             </select>
+            <label className="inline-flex items-center mb-1">
+              <input
+                type="checkbox"
+                className="mr-1"
+                checked={f.required}
+                onChange={(e) => updateField(i, 'required', e.target.checked)}
+              />
+              Required
+            </label>
             {f.type === 'select' && (
               <div className="space-y-1">
                 {f.options.map((opt, j) => (

--- a/src/app/api/forms/[id]/route.ts
+++ b/src/app/api/forms/[id]/route.ts
@@ -37,6 +37,7 @@ export async function PUT(
           label: f.label,
           type: f.type,
           options: f.options ? f.options : undefined,
+          required: f.required,
           order: index,
         })),
       },

--- a/src/app/api/forms/route.ts
+++ b/src/app/api/forms/route.ts
@@ -30,6 +30,7 @@ export async function POST(req: Request) {
           label: f.label,
           type: f.type,
           options: f.options ? f.options : undefined,
+          required: f.required,
           order: index,
         })),
       },

--- a/src/app/forms/[id]/form.tsx
+++ b/src/app/forms/[id]/form.tsx
@@ -23,12 +23,16 @@ export default function FormDisplay({ form }: { form: any }) {
     <form onSubmit={handleSubmit} className="space-y-4">
       {form.fields.map((f: any) => (
         <div key={f.id}>
-          <label className="block mb-1">{f.label}</label>
+          <label className="block mb-1">
+            {f.label}
+            {f.required && <span className="text-red-600 ml-1">*</span>}
+          </label>
           {f.type === 'text' && (
             <input
               className="border p-2 w-full"
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
+              required={f.required}
             />
           )}
           {f.type === 'number' && (
@@ -37,6 +41,7 @@ export default function FormDisplay({ form }: { form: any }) {
               className="border p-2 w-full"
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
+              required={f.required}
             />
           )}
           {f.type === 'select' && (
@@ -44,6 +49,7 @@ export default function FormDisplay({ form }: { form: any }) {
               className="border p-2 w-full"
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
+              required={f.required}
             >
               <option value=""></option>
               {Array.isArray(f.options) &&

--- a/src/lib/validations/form.ts
+++ b/src/lib/validations/form.ts
@@ -4,6 +4,7 @@ export const formFieldSchema = z.object({
   label: z.string(),
   type: z.enum(['text', 'number', 'select']),
   options: z.array(z.string()).optional(),
+  required: z.boolean().optional().default(false),
 });
 
 export const formCreateSchema = z.object({


### PR DESCRIPTION
## Summary
- support required flag on form fields in schema and API
- allow marking fields as required in admin form builder
- show required indicator and enforce in form submission

## Testing
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a69324b1f0833395b5bd95d3106e71