### PR TITLE
feat: allow creating activities

### DIFF
--- a/src/app/activities/new/page.tsx
+++ b/src/app/activities/new/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
 export default function CreateActivityPage() {
@@ -8,14 +9,21 @@ export default function CreateActivityPage() {
   const [date, setDate] = useState('');
   const [image, setImage] = useState('');
   const [description, setDescription] = useState('');
+  const router = useRouter();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    console.log({ name, date, image, description });
+    await fetch('/api/activities', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, date, image, description }),
+    });
     setName('');
     setDate('');
     setImage('');
     setDescription('');
+    router.push('/activities');
+    router.refresh();
   };
 
   return (

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { activityCreateSchema } from '@/lib/validations/activity';
+
+export async function POST(req: Request) {
+  const data = activityCreateSchema.parse(await req.json());
+  const activity = await prisma.activity.create({ data });
+  return NextResponse.json(activity);
+}

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const activityCreateSchema = z.object({
+  name: z.string(),
+  date: z.string().transform((d) => new Date(d)),
+  image: z.string().url().optional(),
+  description: z.string().optional(),
+});


### PR DESCRIPTION
## Summary
- add API route to create activities in the database
- validate and store activity data with Prisma and Zod
- wire the new activity form to call the API and redirect to list

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a694b79fe8833391005a553a15f2e6