### PR TITLE
Restrict activity creation to administrators

### DIFF
--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export default function CreateActivityForm() {
+  const [name, setName] = useState('');
+  const [date, setDate] = useState('');
+  const [image, setImage] = useState('');
+  const [description, setDescription] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/activities', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, date, image, description }),
+    });
+    setName('');
+    setDate('');
+    setImage('');
+    setDescription('');
+    router.push('/activities');
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="text"
+        placeholder="Nombre de la actividad"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <input
+        type="url"
+        placeholder="URL de la imagen"
+        value={image}
+        onChange={(e) => setImage(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <textarea
+        placeholder="Descripción"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <Button type="submit">Guardar</Button>
+    </form>
+  );
+}

--- a/src/app/activities/new/page.tsx
+++ b/src/app/activities/new/page.tsx
@@ -1,63 +1,18 @@
-'use client';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import CreateActivityForm from './form';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
-
-export default function CreateActivityPage() {
-  const [name, setName] = useState('');
-  const [date, setDate] = useState('');
-  const [image, setImage] = useState('');
-  const [description, setDescription] = useState('');
-  const router = useRouter();
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    await fetch('/api/activities', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, date, image, description }),
-    });
-    setName('');
-    setDate('');
-    setImage('');
-    setDescription('');
-    router.push('/activities');
-    router.refresh();
-  };
+export default async function CreateActivityPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
 
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Crear actividad</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          type="text"
-          placeholder="Nombre de la actividad"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          className="w-full border px-2 py-1"
-        />
-        <input
-          type="date"
-          value={date}
-          onChange={(e) => setDate(e.target.value)}
-          className="w-full border px-2 py-1"
-        />
-        <input
-          type="url"
-          placeholder="URL de la imagen"
-          value={image}
-          onChange={(e) => setImage(e.target.value)}
-          className="w-full border px-2 py-1"
-        />
-        <textarea
-          placeholder="Descripción"
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          className="w-full border px-2 py-1"
-        />
-        <Button type="submit">Guardar</Button>
-      </form>
+      <CreateActivityForm />
     </main>
   );
 }

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,5 +1,7 @@
 import Link from 'next/link';
+import { getServerSession } from 'next-auth';
 import { Button } from '@/components/ui/button';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 
@@ -9,6 +11,8 @@ export default async function ActivitiesPage() {
   }>;
 
   let activities: ActivityWithParticipants[] = [];
+
+  const session = await getServerSession(authOptions);
 
   try {
     activities = await prisma.activity.findMany({
@@ -30,9 +34,11 @@ export default async function ActivitiesPage() {
     <main className="p-4">
       <div className="mb-4 flex items-center justify-between">
         <h1 className="text-2xl font-bold">Activities</h1>
-        <Link href="/activities/new">
-          <Button>Crear actividad</Button>
-        </Link>
+        {session?.user.role === 'ADMIN' && (
+          <Link href="/activities/new">
+            <Button>Crear actividad</Button>
+          </Link>
+        )}
       </div>
       <ul className="space-y-4">
         {activities.map((activity) => (

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -1,8 +1,14 @@
 import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { activityCreateSchema } from '@/lib/validations/activity';
 
 export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
   const data = activityCreateSchema.parse(await req.json());
   const activity = await prisma.activity.create({ data });
   return NextResponse.json(activity);


### PR DESCRIPTION
## Summary
- hide activity creation link from non-admin users
- protect activity creation page and API to allow only admins
- extract client-side activity form component

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69bc1031883338c17587bab4a53ae