### PR TITLE
feat: add activity payment type

### DIFF
--- a/prisma/migrations/20240821010000_add_activity_payment_type/migration.sql
+++ b/prisma/migrations/20240821010000_add_activity_payment_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "PaymentType" AS ENUM ('MONTHLY', 'ONE_TIME');
+
+-- AlterTable
+ALTER TABLE "Activity" ADD COLUMN "paymentType" "PaymentType" NOT NULL DEFAULT 'ONE_TIME';

--- a/prisma/migrations/20240821020000_add_more_payment_types/migration.sql
+++ b/prisma/migrations/20240821020000_add_more_payment_types/migration.sql
@@ -1,0 +1,3 @@
+-- AlterEnum
+ALTER TYPE "PaymentType" ADD VALUE 'WEEKLY';
+ALTER TYPE "PaymentType" ADD VALUE 'DAILY';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,7 @@ model Activity {
   date        DateTime
   image       String?
   description String?
+  paymentType PaymentType       @default(ONE_TIME)
   participants ActivityParticipant[]
   createdAt   DateTime @default(now())
 }
@@ -107,6 +108,13 @@ model ActivityParticipant {
   user    User  @relation(fields: [userId], references: [id])
 
   @@unique([activityId, userId])
+}
+
+enum PaymentType {
+  MONTHLY
+  WEEKLY
+  DAILY
+  ONE_TIME
 }
 
 enum Role {

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -33,6 +33,13 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     return <main className="p-4">Activity not found</main>;
   }
 
+  const paymentTypeLabels: Record<typeof activity.paymentType, string> = {
+    ONE_TIME: 'Pago único',
+    MONTHLY: 'Mensual',
+    WEEKLY: 'Semanal',
+    DAILY: 'Diario',
+  } as const;
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
@@ -46,6 +53,9 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         />
       )}
       <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
+      <p className="mb-2">
+        Tipo de pago: {paymentTypeLabels[activity.paymentType]}
+      </p>
       <p className="mb-4">{activity.description}</p>
       <p className="mb-4 font-semibold">
         {activity.participants.length} participants

--- a/src/app/activities/new/page.tsx
+++ b/src/app/activities/new/page.tsx
@@ -9,6 +9,7 @@ export default function CreateActivityPage() {
   const [date, setDate] = useState('');
   const [image, setImage] = useState('');
   const [description, setDescription] = useState('');
+  const [paymentType, setPaymentType] = useState('ONE_TIME');
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -16,12 +17,13 @@ export default function CreateActivityPage() {
     await fetch('/api/activities', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, date, image, description }),
+      body: JSON.stringify({ name, date, image, description, paymentType }),
     });
     setName('');
     setDate('');
     setImage('');
     setDescription('');
+    setPaymentType('ONE_TIME');
     router.push('/activities');
     router.refresh();
   };
@@ -56,6 +58,16 @@ export default function CreateActivityPage() {
           onChange={(e) => setDescription(e.target.value)}
           className="w-full border px-2 py-1"
         />
+        <select
+          value={paymentType}
+          onChange={(e) => setPaymentType(e.target.value)}
+          className="w-full border px-2 py-1"
+        >
+          <option value="ONE_TIME">Pago único</option>
+          <option value="MONTHLY">Mensual</option>
+          <option value="WEEKLY">Semanal</option>
+          <option value="DAILY">Diario</option>
+        </select>
         <Button type="submit">Guardar</Button>
       </form>
     </main>

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -26,6 +26,13 @@ export default async function ActivitiesPage() {
     }
   }
 
+  const paymentTypeLabels = {
+    ONE_TIME: 'Pago único',
+    MONTHLY: 'Mensual',
+    WEEKLY: 'Semanal',
+    DAILY: 'Diario',
+  } as const;
+
   return (
     <main className="p-4">
       <div className="mb-4 flex items-center justify-between">
@@ -44,7 +51,8 @@ export default async function ActivitiesPage() {
               {activity.name}
             </Link>
             <p className="text-sm text-slate-600">
-              {activity.participants.length} participants
+              {activity.participants.length} participants ·{' '}
+              {paymentTypeLabels[activity.paymentType]}
             </p>
           </li>
         ))}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,13 @@ export default async function Home() {
     }
   }
 
+  const paymentTypeLabels = {
+    ONE_TIME: 'Pago único',
+    MONTHLY: 'Mensual',
+    WEEKLY: 'Semanal',
+    DAILY: 'Diario',
+  } as const;
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
@@ -35,7 +42,12 @@ export default async function Home() {
             key={activity.id}
             className="flex items-center justify-between border p-4"
           >
-            <span className="font-semibold">{activity.name}</span>
+            <div>
+              <span className="font-semibold">{activity.name}</span>
+              <p className="text-sm text-slate-600">
+                {paymentTypeLabels[activity.paymentType]}
+              </p>
+            </div>
             <Link href={`/activities/${activity.id}`}>
               <Button>Inscribirse</Button>
             </Link>

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -5,4 +5,5 @@ export const activityCreateSchema = z.object({
   date: z.string().transform((d) => new Date(d)),
   image: z.string().url().optional(),
   description: z.string().optional(),
+  paymentType: z.enum(['MONTHLY', 'WEEKLY', 'DAILY', 'ONE_TIME']),
 });


### PR DESCRIPTION
## Summary
- support monthly, weekly, daily or one-time payment activities
- expose payment type in activity pages

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz; fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68a69ceb1d0c8333818aa13eba7b97de