### PR TITLE
Run Prisma migrations automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ Full-stack application for Club Hualas built with Next.js 14, Prisma and Postgre
 
 1. Copy `.env.example` to `.env` and set the values.
 2. Install dependencies with `pnpm install`.
-3. Generate the Prisma client: `pnpm prisma:generate`.
+3. Apply database migrations and generate the Prisma client: `pnpm prisma migrate dev`.
 4. Start the dev server: `pnpm dev`.

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "packageManager": "pnpm@8.15.4",
   "scripts": {
     "dev": "next dev",
-    "build": "prisma generate && next build",
-    "start": "next start",
+    "build": "prisma migrate deploy && prisma generate && next build",
+    "start": "prisma migrate deploy && next start",
     "lint": "next lint",
     "format": "prettier --write .",
     "prisma:generate": "prisma generate"


### PR DESCRIPTION
## Summary
- run Prisma migrations before building or starting
- document running `prisma migrate dev` for setup

## Testing
- ⚠️ `pnpm lint` *(failed: Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a0374c3883339c600a338744bb07