### PR TITLE
feat: enable activity editing and show subscriber counts

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+interface EditActivityFormProps {
+  activity: {
+    id: string;
+    name: string;
+    date: string;
+    image?: string | null;
+    description?: string | null;
+  };
+}
+
+export default function EditActivityForm({ activity }: EditActivityFormProps) {
+  const [name, setName] = useState(activity.name);
+  const [date, setDate] = useState(activity.date);
+  const [image, setImage] = useState(activity.image || '');
+  const [description, setDescription] = useState(activity.description || '');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch(`/api/activities/${activity.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, date, image, description }),
+    });
+    router.push('/activities');
+    router.refresh();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <input
+        type="text"
+        placeholder="Nombre de la actividad"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <input
+        type="date"
+        value={date}
+        onChange={(e) => setDate(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <input
+        type="url"
+        placeholder="URL de la imagen"
+        value={image}
+        onChange={(e) => setImage(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <textarea
+        placeholder="Descripción"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        className="w-full border px-2 py-1"
+      />
+      <Button type="submit">Guardar</Button>
+    </form>
+  );
+}

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -1,0 +1,38 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import EditActivityForm from './form';
+
+interface EditActivityPageProps {
+  params: { id: string };
+}
+
+export default async function EditActivityPage({
+  params,
+}: EditActivityPageProps) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+  });
+  if (!activity) {
+    redirect('/activities');
+  }
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">Editar actividad</h1>
+      <EditActivityForm
+        activity={{
+          id: activity.id,
+          name: activity.name,
+          date: activity.date.toISOString().split('T')[0],
+          image: activity.image ?? '',
+          description: activity.description ?? '',
+        }}
+      />
+    </main>
+  );
+}

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -2,6 +2,9 @@ import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { Prisma } from '@prisma/client';
+import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 
 interface ActivityPageProps {
   params: { id: string };
@@ -33,9 +36,19 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     return <main className="p-4">Activity not found</main>;
   }
 
+  const session = await getServerSession(authOptions);
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
+      {session?.user.role === 'ADMIN' && (
+        <Link
+          href={`/activities/${activity.id}/edit`}
+          className="mb-4 inline-block text-blue-600"
+        >
+          Editar
+        </Link>
+      )}
       {activity.image && (
         <Image
           src={activity.image}
@@ -48,7 +61,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
       <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-4">{activity.description}</p>
       <p className="mb-4 font-semibold">
-        {activity.participants.length} participants
+        {activity.participants.length} suscriptos
       </p>
       <Button>Register</Button>
     </main>

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -50,8 +50,16 @@ export default async function ActivitiesPage() {
               {activity.name}
             </Link>
             <p className="text-sm text-slate-600">
-              {activity.participants.length} participants
+              {activity.participants.length} suscriptos
             </p>
+            {session?.user.role === 'ADMIN' && (
+              <Link
+                href={`/activities/${activity.id}/edit`}
+                className="text-sm text-blue-600"
+              >
+                Editar
+              </Link>
+            )}
           </li>
         ))}
       </ul>

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { activityCreateSchema } from '@/lib/validations/activity';
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = activityCreateSchema.parse(await req.json());
+  const activity = await prisma.activity.update({
+    where: { id: params.id },
+    data,
+  });
+  return NextResponse.json(activity);
+}


### PR DESCRIPTION
## Summary
- allow admins to update activities through a new edit page
- expose PUT endpoint for activity updates
- display subscriber counts and edit links in activity list and details

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a6a8ed288333b702305192a9f76c