### PR TITLE
Add frequency to activities

### DIFF
--- a/prisma/migrations/20240906000000_add_activity_frequency/migration.sql
+++ b/prisma/migrations/20240906000000_add_activity_frequency/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ActivityFrequency" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME');
+
+-- AlterTable
+ALTER TABLE "Activity" ADD COLUMN "frequency" "ActivityFrequency" NOT NULL DEFAULT 'ONE_TIME';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -94,6 +94,7 @@ model Activity {
   id          String             @id @default(cuid())
   name        String
   date        DateTime
+  frequency   ActivityFrequency @default(ONE_TIME)
   image       String?
   description String?
   participants ActivityParticipant[]
@@ -113,4 +114,11 @@ model ActivityParticipant {
 enum Role {
   ADMIN
   MEMBER
+}
+
+enum ActivityFrequency {
+  DAILY
+  WEEKLY
+  MONTHLY
+  ONE_TIME
 }

--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -9,6 +9,7 @@ interface EditActivityFormProps {
     id: string;
     name: string;
     date: string;
+    frequency: 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME';
     image?: string | null;
     description?: string | null;
   };
@@ -17,6 +18,9 @@ interface EditActivityFormProps {
 export default function EditActivityForm({ activity }: EditActivityFormProps) {
   const [name, setName] = useState(activity.name);
   const [date, setDate] = useState(activity.date);
+  const [frequency, setFrequency] = useState<
+    'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
+  >(activity.frequency);
   const [image, setImage] = useState(activity.image || '');
   const [description, setDescription] = useState(activity.description || '');
   const router = useRouter();
@@ -26,7 +30,7 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
     await fetch(`/api/activities/${activity.id}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, date, image, description }),
+      body: JSON.stringify({ name, date, image, description, frequency }),
     });
     router.push('/activities');
     router.refresh();
@@ -54,6 +58,20 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         onChange={(e) => setImage(e.target.value)}
         className="w-full border px-2 py-1"
       />
+      <select
+        value={frequency}
+        onChange={(e) =>
+          setFrequency(
+            e.target.value as 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
+          )
+        }
+        className="w-full border px-2 py-1"
+      >
+        <option value="ONE_TIME">Un solo pago</option>
+        <option value="DAILY">Diaria</option>
+        <option value="WEEKLY">Semanal</option>
+        <option value="MONTHLY">Mensual</option>
+      </select>
       <textarea
         placeholder="Descripción"
         value={description}

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -29,6 +29,7 @@ export default async function EditActivityPage({
           id: activity.id,
           name: activity.name,
           date: activity.date.toISOString().split('T')[0],
+          frequency: activity.frequency,
           image: activity.image ?? '',
           description: activity.description ?? '',
         }}

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -38,6 +38,16 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const session = await getServerSession(authOptions);
 
+  const frequencyLabels: Record<
+    ActivityWithParticipants['frequency'],
+    string
+  > = {
+    DAILY: 'Diaria',
+    WEEKLY: 'Semanal',
+    MONTHLY: 'Mensual',
+    ONE_TIME: 'Un solo pago',
+  };
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
@@ -59,6 +69,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         />
       )}
       <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
+      <p className="mb-2">Frecuencia: {frequencyLabels[activity.frequency]}</p>
       <p className="mb-4">{activity.description}</p>
       <p className="mb-4 font-semibold">
         {activity.participants.length} suscriptos

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -9,6 +9,7 @@ export default function CreateActivityForm() {
   const [date, setDate] = useState('');
   const [image, setImage] = useState('');
   const [description, setDescription] = useState('');
+  const [frequency, setFrequency] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'>('ONE_TIME');
   const router = useRouter();
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -16,12 +17,13 @@ export default function CreateActivityForm() {
     await fetch('/api/activities', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, date, image, description }),
+      body: JSON.stringify({ name, date, image, description, frequency }),
     });
     setName('');
     setDate('');
     setImage('');
     setDescription('');
+    setFrequency('ONE_TIME');
     router.push('/activities');
     router.refresh();
   };
@@ -48,6 +50,20 @@ export default function CreateActivityForm() {
         onChange={(e) => setImage(e.target.value)}
         className="w-full border px-2 py-1"
       />
+      <select
+        value={frequency}
+        onChange={(e) =>
+          setFrequency(
+            e.target.value as 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
+          )
+        }
+        className="w-full border px-2 py-1"
+      >
+        <option value="ONE_TIME">Un solo pago</option>
+        <option value="DAILY">Diaria</option>
+        <option value="WEEKLY">Semanal</option>
+        <option value="MONTHLY">Mensual</option>
+      </select>
       <textarea
         placeholder="Descripción"
         value={description}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -30,6 +30,13 @@ export default async function ActivitiesPage() {
     }
   }
 
+  const frequencyLabels: Record<ActivityWithParticipants['frequency'], string> = {
+    DAILY: 'Diaria',
+    WEEKLY: 'Semanal',
+    MONTHLY: 'Mensual',
+    ONE_TIME: 'Un solo pago',
+  };
+
   return (
     <main className="p-4">
       <div className="mb-4 flex items-center justify-between">
@@ -51,6 +58,9 @@ export default async function ActivitiesPage() {
             </Link>
             <p className="text-sm text-slate-600">
               {activity.participants.length} suscriptos
+            </p>
+            <p className="text-sm text-slate-600">
+              {frequencyLabels[activity.frequency]}
             </p>
             {session?.user.role === 'ADMIN' && (
               <Link

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,13 @@ export default async function Home() {
     }
   }
 
+  const frequencyLabels: Record<ActivityWithParticipants['frequency'], string> = {
+    DAILY: 'Diaria',
+    WEEKLY: 'Semanal',
+    MONTHLY: 'Mensual',
+    ONE_TIME: 'Un solo pago',
+  };
+
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
@@ -35,7 +42,12 @@ export default async function Home() {
             key={activity.id}
             className="flex items-center justify-between border p-4"
           >
-            <span className="font-semibold">{activity.name}</span>
+            <div className="flex flex-col">
+              <span className="font-semibold">{activity.name}</span>
+              <span className="text-sm text-slate-600">
+                {frequencyLabels[activity.frequency]}
+              </span>
+            </div>
             <Link href={`/activities/${activity.id}`}>
               <Button>Inscribirse</Button>
             </Link>

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const activityCreateSchema = z.object({
   name: z.string(),
   date: z.string().transform((d) => new Date(d)),
+  frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME']),
   image: z.string().url().optional(),
   description: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- add frequency field and enum for activities
- allow choosing frequency when creating or editing activities
- display frequency on activity listings and details

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npx prisma generate`

------
https://chatgpt.com/codex/tasks/task_e_68a6ad0277b0833380a0045d935fdcf0