### PR TITLE
feat: display event details on home page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
@@ -31,11 +32,22 @@ export default async function Home() {
       <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
       <ul className="space-y-4">
         {activities.map((activity) => (
-          <li
-            key={activity.id}
-            className="flex items-center justify-between border p-4"
-          >
-            <span className="font-semibold">{activity.name}</span>
+          <li key={activity.id} className="border p-4">
+            {activity.image && (
+              <Image
+                src={activity.image}
+                alt={activity.name}
+                width={800}
+                height={600}
+                className="mb-2 h-auto w-full"
+              />
+            )}
+            <h2 className="mb-1 text-xl font-semibold">{activity.name}</h2>
+            {activity.description && (
+              <p className="mb-2 text-sm text-slate-700">
+                {activity.description}
+              </p>
+            )}
             <Link href={`/activities/${activity.id}`}>
               <Button>Inscribirse</Button>
             </Link>


### PR DESCRIPTION
## Summary
- show event image, title, and description on home page

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz; Proxy response (403) !== 200 when HTTP Tunneling)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ae4431b48333b8f3b616be605416