### PR TITLE
feat: show event details on home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
@@ -26,28 +27,27 @@ export default async function Home() {
     }
   }
 
-  const frequencyLabels: Record<ActivityWithParticipants['frequency'], string> = {
-    DAILY: 'Diaria',
-    WEEKLY: 'Semanal',
-    MONTHLY: 'Mensual',
-    ONE_TIME: 'Un solo pago',
-  };
-
   return (
     <main className="p-4">
       <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
       <ul className="space-y-4">
         {activities.map((activity) => (
-          <li
-            key={activity.id}
-            className="flex items-center justify-between border p-4"
-          >
-            <div className="flex flex-col">
-              <span className="font-semibold">{activity.name}</span>
-              <span className="text-sm text-slate-600">
-                {frequencyLabels[activity.frequency]}
-              </span>
-            </div>
+          <li key={activity.id} className="flex flex-col border p-4">
+            {activity.image && (
+              <Image
+                src={activity.image}
+                alt={activity.name}
+                width={800}
+                height={600}
+                className="mb-2 max-w-full"
+              />
+            )}
+            <span className="mb-1 font-semibold">{activity.name}</span>
+            {activity.description && (
+              <p className="mb-2 text-sm text-slate-600">
+                {activity.description}
+              </p>
+            )}
             <Link href={`/activities/${activity.id}`}>
               <Button>Inscribirse</Button>
             </Link>


### PR DESCRIPTION
## Summary
- display activity image, title, and description on the home page
- restore inadvertent config changes

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6af966fc48333b7bb5dd9fa060684