### PR TITLE
Add success and error messages to forms

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -26,23 +26,35 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
   const [description, setDescription] = useState(activity.description || '');
   const [price, setPrice] = useState(String(activity.price));
   const router = useRouter();
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(`/api/activities/${activity.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name,
-        date,
-        image,
-        description,
-        frequency,
-        price: Number(price),
-      }),
-    });
-    router.push('/activities');
-    router.refresh();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch(`/api/activities/${activity.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          date,
+          image,
+          description,
+          frequency,
+          price: Number(price),
+        }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Activity updated');
+      setTimeout(() => {
+        router.push('/activities');
+        router.refresh();
+      }, 1000);
+    } catch (e) {
+      setError('Failed to update activity');
+    }
   };
 
   return (
@@ -94,6 +106,8 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         onChange={(e) => setPrice(e.target.value)}
         className="w-full border px-2 py-1"
       />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button type="submit">Guardar</Button>
     </form>
   );

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -12,29 +12,41 @@ export default function CreateActivityForm() {
   const [price, setPrice] = useState('');
   const [frequency, setFrequency] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'>('ONE_TIME');
   const router = useRouter();
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('/api/activities', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name,
-        date,
-        image,
-        description,
-        frequency,
-        price: Number(price),
-      }),
-    });
-    setName('');
-    setDate('');
-    setImage('');
-    setDescription('');
-    setPrice('');
-    setFrequency('ONE_TIME');
-    router.push('/activities');
-    router.refresh();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/activities', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          date,
+          image,
+          description,
+          frequency,
+          price: Number(price),
+        }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Activity created');
+      setName('');
+      setDate('');
+      setImage('');
+      setDescription('');
+      setPrice('');
+      setFrequency('ONE_TIME');
+      setTimeout(() => {
+        router.push('/activities');
+        router.refresh();
+      }, 1000);
+    } catch (e) {
+      setError('Failed to create activity');
+    }
   };
 
   return (
@@ -86,6 +98,8 @@ export default function CreateActivityForm() {
         onChange={(e) => setPrice(e.target.value)}
         className="w-full border px-2 py-1"
       />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button type="submit">Guardar</Button>
     </form>
   );

--- a/src/app/admin/forms/[id]/edit/edit-form.tsx
+++ b/src/app/admin/forms/[id]/edit/edit-form.tsx
@@ -21,6 +21,8 @@ export default function EditForm({ form }: { form: any }) {
     }))
   );
   const router = useRouter();
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   const addField = () => {
     setFields([
@@ -53,12 +55,22 @@ export default function EditForm({ form }: { form: any }) {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(`/api/forms/${form.id}`, {
-      method: 'PUT',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, fields }),
-    });
-    router.push('/admin/forms');
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch(`/api/forms/${form.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, fields }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Form updated');
+      setTimeout(() => {
+        router.push('/admin/forms');
+      }, 1000);
+    } catch (e) {
+      setError('Failed to update form');
+    }
   };
 
   return (
@@ -128,6 +140,8 @@ export default function EditForm({ form }: { form: any }) {
       >
         Add field
       </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
         Save Form
       </button>

--- a/src/app/admin/forms/new-form.tsx
+++ b/src/app/admin/forms/new-form.tsx
@@ -12,6 +12,8 @@ type Field = {
 export default function NewForm() {
   const [title, setTitle] = useState('');
   const [fields, setFields] = useState<Field[]>([]);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   const addField = () => {
     setFields([
@@ -44,13 +46,21 @@ export default function NewForm() {
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch('/api/forms', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, fields }),
-    });
-    setTitle('');
-    setFields([]);
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/forms', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title, fields }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Form saved');
+      setTitle('');
+      setFields([]);
+    } catch (e) {
+      setError('Failed to save form');
+    }
   };
 
   return (
@@ -120,6 +130,8 @@ export default function NewForm() {
       >
         Add field
       </button>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
         Save Form
       </button>

--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -10,16 +10,28 @@ export default function EditUserForm({ user }: { user: User }) {
   const [name, setName] = useState(user.name ?? '');
   const [role, setRole] = useState(user.role);
   const router = useRouter();
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
-    await fetch(`/api/users/${user.id}`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, role }),
-    });
-    router.push('/admin/users');
-    router.refresh();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch(`/api/users/${user.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, role }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('User updated');
+      setTimeout(() => {
+        router.push('/admin/users');
+        router.refresh();
+      }, 1000);
+    } catch (e) {
+      setError('Failed to update user');
+    }
   }
 
   return (
@@ -38,6 +50,8 @@ export default function EditUserForm({ user }: { user: User }) {
         <option value="ADMIN">ADMIN</option>
         <option value="MEMBER">MEMBER</option>
       </select>
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button type="submit" className="w-full">
         Save
       </Button>

--- a/src/app/forms/[id]/form.tsx
+++ b/src/app/forms/[id]/form.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 
 export default function FormDisplay({ form }: { form: any }) {
   const [data, setData] = useState<Record<string, string>>({});
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   const handleChange = (id: string, value: string) => {
     setData((prev) => ({ ...prev, [id]: value }));
@@ -11,12 +13,20 @@ export default function FormDisplay({ form }: { form: any }) {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    await fetch(`/api/forms/${form.id}/responses`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ data }),
-    });
-    setData({});
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch(`/api/forms/${form.id}/responses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ data }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Form submitted');
+      setData({});
+    } catch (e) {
+      setError('Submission failed');
+    }
   };
 
   return (
@@ -62,6 +72,8 @@ export default function FormDisplay({ form }: { form: any }) {
           )}
         </div>
       ))}
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
         Submit
       </button>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,32 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const router = useRouter();
+
+  const submit = async () => {
+    setError('');
+    setSuccess('');
+    const res = await signIn('credentials', {
+      email,
+      password,
+      redirect: false,
+    });
+    if (res?.error) {
+      setError('Invalid credentials');
+    } else {
+      setSuccess('Login successful');
+      setTimeout(() => router.push('/'), 1000);
+    }
+  };
 
   return (
     <div className="p-4 max-w-sm mx-auto space-y-2">
@@ -24,16 +44,9 @@ export default function LoginPage() {
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
-      <Button
-        className="w-full"
-        onClick={() =>
-          signIn('credentials', {
-            email,
-            password,
-            callbackUrl: '/',
-          })
-        }
-      >
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
+      <Button className="w-full" onClick={submit}>
         Sign in
       </Button>
     </div>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -9,18 +9,30 @@ export default function RegisterPage() {
   const [password, setPassword] = useState('');
   const [name, setName] = useState('');
   const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
 
   async function submit() {
+    setError('');
+    setSuccess('');
     const parsed = registerSchema.safeParse({ email, password, name });
     if (!parsed.success) {
       setError('Invalid data');
       return;
     }
-    await fetch('/api/register', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(parsed.data),
-    });
+    try {
+      const res = await fetch('/api/register', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(parsed.data),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Registration successful');
+      setEmail('');
+      setPassword('');
+      setName('');
+    } catch (e) {
+      setError('Registration failed');
+    }
   }
 
   return (
@@ -45,6 +57,7 @@ export default function RegisterPage() {
         onChange={(e) => setPassword(e.target.value)}
       />
       {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button className="w-full" onClick={submit}>
         Register
       </Button>


### PR DESCRIPTION
## Summary
- show login result feedback and redirect after success
- display validation outcome on registration
- surface success and error notices across activity, admin, and dynamic forms

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a70ebae0e483339fbf94d0997b5893