### PR TITLE
feat: allow image upload for activities

### DIFF
--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button';
 export default function CreateActivityForm() {
   const [name, setName] = useState('');
   const [date, setDate] = useState('');
-  const [image, setImage] = useState('');
+  const [image, setImage] = useState<File | null>(null);
   const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
   const [frequency, setFrequency] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'>('ONE_TIME');
@@ -15,21 +15,22 @@ export default function CreateActivityForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const formData = new FormData();
+    formData.append('name', name);
+    formData.append('date', date);
+    formData.append('description', description);
+    formData.append('frequency', frequency);
+    formData.append('price', price);
+    if (image) {
+      formData.append('image', image);
+    }
     await fetch('/api/activities', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name,
-        date,
-        image,
-        description,
-        frequency,
-        price: Number(price),
-      }),
+      body: formData,
     });
     setName('');
     setDate('');
-    setImage('');
+    setImage(null);
     setDescription('');
     setPrice('');
     setFrequency('ONE_TIME');
@@ -53,10 +54,9 @@ export default function CreateActivityForm() {
         className="w-full border px-2 py-1"
       />
       <input
-        type="url"
-        placeholder="URL de la imagen"
-        value={image}
-        onChange={(e) => setImage(e.target.value)}
+        type="file"
+        accept="image/*"
+        onChange={(e) => setImage(e.target.files?.[0] || null)}
         className="w-full border px-2 py-1"
       />
       <select

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -3,13 +3,38 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { activityCreateSchema } from '@/lib/validations/activity';
+import { promises as fs } from 'fs';
+import path from 'path';
 
 export async function POST(req: Request) {
   const session = await getServerSession(authOptions);
   if (!session || session.user.role !== 'ADMIN') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  const data = activityCreateSchema.parse(await req.json());
+
+  const formData = await req.formData();
+  const file = formData.get('image') as File | null;
+
+  let imageUrl: string | undefined;
+  if (file && file.size > 0) {
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const uploadDir = path.join(process.cwd(), 'public', 'uploads');
+    await fs.mkdir(uploadDir, { recursive: true });
+    const filePath = path.join(uploadDir, file.name);
+    await fs.writeFile(filePath, buffer);
+    imageUrl = `/uploads/${file.name}`;
+  }
+
+  const rawData = {
+    name: formData.get('name') as string,
+    date: formData.get('date') as string,
+    frequency: formData.get('frequency') as string,
+    description: (formData.get('description') as string) || undefined,
+    price: Number(formData.get('price')),
+    image: imageUrl,
+  };
+
+  const data = activityCreateSchema.parse(rawData);
   const activity = await prisma.activity.create({ data });
   return NextResponse.json(activity);
 }

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -4,7 +4,7 @@ export const activityCreateSchema = z.object({
   name: z.string(),
   date: z.string().transform((d) => new Date(d)),
   frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME']),
-  image: z.string().url().optional(),
+  image: z.string().optional(),
   description: z.string().optional(),
   price: z.number().int().nonnegative(),
 });


### PR DESCRIPTION
## Summary
- allow uploading an image when creating an activity
- handle multipart form data in activity API route and save image to `/public/uploads`
- relax activity image validation to accept any string

## Testing
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70fca888c8333b444039a590b4c9d