### PR TITLE
Allow image upload for activity events

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -29,6 +29,16 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -72,11 +82,13 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         onChange={(e) => setDate(e.target.value)}
         className="w-full border px-2 py-1"
       />
+      {image && (
+        <img src={image} alt="Vista previa" className="w-full max-w-full" />
+      )}
       <input
-        type="url"
-        placeholder="URL de la imagen"
-        value={image}
-        onChange={(e) => setImage(e.target.value)}
+        type="file"
+        accept="image/*"
+        onChange={handleImageChange}
         className="w-full border px-2 py-1"
       />
       <select

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,6 +1,6 @@
+/* eslint-disable @next/next/no-img-element */
 import { prisma } from '@/lib/prisma';
 import RegisterButton from './register-button';
-import Image from 'next/image';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
@@ -48,11 +48,9 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         </Link>
       )}
       {activity.image && (
-        <Image
+        <img
           src={activity.image}
           alt={activity.name}
-          width={800}
-          height={600}
           className="mb-4 max-w-full"
         />
       )}

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -15,6 +15,16 @@ export default function CreateActivityForm() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
 
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onloadend = () => {
+      setImage(reader.result as string);
+    };
+    reader.readAsDataURL(file);
+  };
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
@@ -65,10 +75,9 @@ export default function CreateActivityForm() {
         className="w-full border px-2 py-1"
       />
       <input
-        type="url"
-        placeholder="URL de la imagen"
-        value={image}
-        onChange={(e) => setImage(e.target.value)}
+        type="file"
+        accept="image/*"
+        onChange={handleImageChange}
         className="w-full border px-2 py-1"
       />
       <select

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable @next/next/no-img-element */
 import Link from 'next/link';
-import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
@@ -34,11 +34,9 @@ export default async function Home() {
         {activities.map((activity) => (
           <li key={activity.id} className="flex flex-col border p-4">
             {activity.image && (
-              <Image
+              <img
                 src={activity.image}
                 alt={activity.name}
-                width={800}
-                height={600}
                 className="mb-2 max-w-full"
               />
             )}

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -4,7 +4,7 @@ export const activityCreateSchema = z.object({
   name: z.string(),
   date: z.string().transform((d) => new Date(d)),
   frequency: z.enum(['DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME']),
-  image: z.string().url().optional(),
+  image: z.string().optional(),
   description: z.string().optional(),
   price: z.number().int().nonnegative(),
 });


### PR DESCRIPTION
## Summary
- enable file upload in activity creation and edit forms
- relax activity image validation and render uploaded images

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a713af8b48833399702b5957d6c76e