### PR TITLE
Allow external images

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,16 @@ const nextConfig = {
     appDir: true
   },
   images: {
-    domains: ['lh6.googleusercontent.com']
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**'
+      },
+      {
+        protocol: 'http',
+        hostname: '**'
+      }
+    ]
   }
 };
 


### PR DESCRIPTION
## Summary
- allow Next.js to load remote images from any domain

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_68a710803f948333bfc7e8624d2fab51