### PR TITLE
Add site administrator settings for logo and colors

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -112,6 +112,15 @@ model ActivityParticipant {
   @@unique([activityId, userId])
 }
 
+model SiteSetting {
+  id              Int    @id
+  logo            String?
+  favicon         String?
+  navbarColor     String?
+  footerColor     String?
+  backgroundColor String?
+}
+
 enum Role {
   ADMIN
   MEMBER

--- a/src/app/admin/site/page.tsx
+++ b/src/app/admin/site/page.tsx
@@ -1,0 +1,19 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import SiteSettingsForm from './site-settings-form';
+
+export default async function SiteAdminPage() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    redirect('/');
+  }
+  const settings = await prisma.siteSetting.findUnique({ where: { id: 1 } });
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Site Administrator</h1>
+      <SiteSettingsForm settings={settings} />
+    </div>
+  );
+}

--- a/src/app/admin/site/site-settings-form.tsx
+++ b/src/app/admin/site/site-settings-form.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useState } from 'react';
+import type { SiteSettings } from '@/types/site';
+
+export default function SiteSettingsForm({
+  settings,
+}: {
+  settings: SiteSettings | null;
+}) {
+  const [logo, setLogo] = useState<string | null>(settings?.logo ?? null);
+  const [favicon, setFavicon] = useState<string | null>(
+    settings?.favicon ?? null
+  );
+  const [navbarColor, setNavbarColor] = useState(
+    settings?.navbarColor ?? '#1e293b'
+  );
+  const [footerColor, setFooterColor] = useState(
+    settings?.footerColor ?? '#1e293b'
+  );
+  const [backgroundColor, setBackgroundColor] = useState(
+    settings?.backgroundColor ?? '#ffffff'
+  );
+  const [message, setMessage] = useState('');
+
+  const handleFileChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    setter: (value: string | null) => void
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setter(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/site-settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        logo,
+        favicon,
+        navbarColor,
+        footerColor,
+        backgroundColor,
+      }),
+    });
+    if (res.ok) {
+      setMessage('Settings saved.');
+    } else {
+      setMessage('Error saving settings.');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block mb-1">Navbar Logo</label>
+        <input
+          type="file"
+          accept="image/*"
+          onChange={(e) => handleFileChange(e, setLogo)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Favicon (.ico)</label>
+        <input
+          type="file"
+          accept="image/x-icon"
+          onChange={(e) => handleFileChange(e, setFavicon)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Navbar Color</label>
+        <input
+          type="color"
+          value={navbarColor}
+          onChange={(e) => setNavbarColor(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Footer Color</label>
+        <input
+          type="color"
+          value={footerColor}
+          onChange={(e) => setFooterColor(e.target.value)}
+        />
+      </div>
+      <div>
+        <label className="block mb-1">Background Color</label>
+        <input
+          type="color"
+          value={backgroundColor}
+          onChange={(e) => setBackgroundColor(e.target.value)}
+        />
+      </div>
+      <button
+        type="submit"
+        className="px-4 py-2 bg-blue-600 text-white rounded"
+      >
+        Save
+      </button>
+      {message && <p>{message}</p>}
+    </form>
+  );
+}

--- a/src/app/api/site-settings/route.ts
+++ b/src/app/api/site-settings/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export async function GET() {
+  const settings = await prisma.siteSetting.findUnique({ where: { id: 1 } });
+  return NextResponse.json(settings);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = await req.json();
+  const settings = await prisma.siteSetting.upsert({
+    where: { id: 1 },
+    update: {
+      logo: data.logo,
+      favicon: data.favicon,
+      navbarColor: data.navbarColor,
+      footerColor: data.footerColor,
+      backgroundColor: data.backgroundColor,
+    },
+    create: {
+      id: 1,
+      logo: data.logo,
+      favicon: data.favicon,
+      navbarColor: data.navbarColor,
+      footerColor: data.footerColor,
+      backgroundColor: data.backgroundColor,
+    },
+  });
+  return NextResponse.json(settings);
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,20 +3,36 @@ import type { ReactNode } from 'react';
 import Navbar from '@/components/navbar';
 import Footer from '@/components/footer';
 import Providers from '@/components/providers';
+import { prisma } from '@/lib/prisma';
+import type { SiteSettings } from '@/types/site';
 
-export const metadata = {
-  title: 'Hualas Club',
-  description: 'Club Hualas management app',
-};
+export async function generateMetadata() {
+  const settings = await prisma.siteSetting.findUnique({ where: { id: 1 } });
+  return {
+    title: 'Hualas Club',
+    description: 'Club Hualas management app',
+    icons: settings?.favicon ? [{ url: settings.favicon }] : undefined,
+  };
+}
 
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default async function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const settings: SiteSettings | null = await prisma.siteSetting.findUnique({
+    where: { id: 1 },
+  });
   return (
     <html lang="en">
-      <body className="min-h-screen bg-background text-foreground flex flex-col">
+      <body
+        className="min-h-screen text-foreground flex flex-col"
+        style={{ backgroundColor: settings?.backgroundColor || undefined }}
+      >
         <Providers>
-          <Navbar />
+          <Navbar settings={settings} />
           <main className="flex-1">{children}</main>
-          <Footer />
+          <Footer settings={settings} />
         </Providers>
       </body>
     </html>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,8 +1,17 @@
 'use client';
 
-export default function Footer() {
+import type { SiteSettings } from '@/types/site';
+
+export default function Footer({
+  settings,
+}: {
+  settings: SiteSettings | null;
+}) {
   return (
-    <footer className="flex flex-col items-center justify-center px-4 py-6 bg-slate-800 text-white text-center">
+    <footer
+      className="flex flex-col items-center justify-center px-4 py-6 text-white text-center"
+      style={{ backgroundColor: settings?.footerColor || '#1e293b' }}
+    >
       <p className="text-2xl">💚</p>
       <p className="mt-2">
         ¡Seguinos en Instagram!

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,15 +3,26 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useSession, signOut } from 'next-auth/react';
+import type { SiteSettings } from '@/types/site';
 
-export default function Navbar() {
+const defaultLogo =
+  'https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383';
+
+export default function Navbar({
+  settings,
+}: {
+  settings: SiteSettings | null;
+}) {
   const { data: session } = useSession();
 
   return (
-    <nav className="flex items-center justify-between px-4 py-2 bg-slate-800 text-white">
+    <nav
+      className="flex items-center justify-between px-4 py-2 text-white"
+      style={{ backgroundColor: settings?.navbarColor || '#1e293b' }}
+    >
       <Link href="/" className="flex items-center gap-2">
         <Image
-          src="https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383"
+          src={settings?.logo || defaultLogo}
           alt="Hualas Club logo"
           width={40}
           height={40}
@@ -28,6 +39,7 @@ export default function Navbar() {
           <>
             <Link href="/admin/users">Users</Link>
             <Link href="/admin/forms">Forms</Link>
+            <Link href="/admin/site">Site Administrator</Link>
           </>
         )}
         {session ? (

--- a/src/types/site.ts
+++ b/src/types/site.ts
@@ -1,0 +1,7 @@
+export interface SiteSettings {
+  logo: string | null;
+  favicon: string | null;
+  navbarColor: string | null;
+  footerColor: string | null;
+  backgroundColor: string | null;
+}


### PR DESCRIPTION
## Summary
- allow admins to configure logo, favicon, and layout colors
- fetch site settings in layout and apply to navbar, footer, and background
- add API and admin page to manage site appearance

## Testing
- `npx prisma generate`
- `npm run lint` *(fails: prettier warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a7204e1a7883338eecd2b94058e7c5