### PR TITLE
Add profile page and navbar link for user updates

### DIFF
--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { hash } from 'bcrypt';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { profileUpdateSchema } from '@/lib/validations/profile';
+
+export async function PATCH(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const data = profileUpdateSchema.parse(await req.json());
+
+  if (data.email) {
+    const existing = await prisma.user.findUnique({
+      where: { email: data.email },
+    });
+    if (existing && existing.id !== session.user.id) {
+      return NextResponse.json(
+        { error: 'Email already in use' },
+        { status: 400 }
+      );
+    }
+  }
+
+  const updateData: any = {};
+  if (data.name !== undefined) updateData.name = data.name;
+  if (data.email !== undefined) updateData.email = data.email;
+  if (data.password !== undefined) {
+    updateData.password = await hash(data.password, 12);
+  }
+
+  const user = await prisma.user.update({
+    where: { id: (session.user as any).id },
+    data: updateData,
+    select: { id: true, email: true, name: true },
+  });
+
+  return NextResponse.json(user);
+}

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+type User = { name: string | null; email: string };
+
+export default function ProfileForm({ user }: { user: User }) {
+  const [name, setName] = useState(user.name ?? '');
+  const [email, setEmail] = useState(user.email);
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const router = useRouter();
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSuccess('');
+    try {
+      const res = await fetch('/api/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email,
+          ...(password ? { password } : {}),
+        }),
+      });
+      if (!res.ok) throw new Error('Request failed');
+      setSuccess('Profile updated');
+      setPassword('');
+      setTimeout(() => router.refresh(), 1000);
+    } catch (e) {
+      setError('Failed to update profile');
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="space-y-2 max-w-sm">
+      <input
+        className="w-full border px-2 py-1"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="Name"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        type="password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+        placeholder="New password"
+      />
+      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {success && <p className="text-green-600 text-sm">{success}</p>}
+      <Button type="submit" className="w-full">
+        Save
+      </Button>
+    </form>
+  );
+}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,25 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import ProfileForm from './form';
+
+export default async function ProfilePage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/login');
+  }
+  const user = await prisma.user.findUnique({
+    where: { id: (session.user as any).id },
+    select: { name: true, email: true },
+  });
+  if (!user) {
+    redirect('/');
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Profile</h1>
+      <ProfileForm user={user} />
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -24,6 +24,7 @@ export default function Navbar() {
         <Link href="/activities">Activities</Link>
         <Link href="/contact">Contacto</Link>
         {session && <Link href="/chat">Chat</Link>}
+        {session && <Link href="/profile">Profile</Link>}
         {session?.user.role === 'ADMIN' && (
           <>
             <Link href="/admin/users">Users</Link>

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -1,0 +1,7 @@
+import { z } from 'zod';
+
+export const profileUpdateSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().email().optional(),
+  password: z.string().min(6).optional(),
+});


### PR DESCRIPTION
## Summary
- add Profile link in navbar for logged users
- implement profile page with form to update name, email and password
- create API endpoint and validation schema for profile updates

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (warnings)


------
https://chatgpt.com/codex/tasks/task_e_68a720c4c18883338ed49c647841a7f8