### PR TITLE
Add basic multilingual support with language selector

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="es">
       <body className="min-h-screen bg-background text-foreground flex flex-col">
         <Providers>
           <Navbar />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,8 @@
-import Link from 'next/link';
-import Image from 'next/image';
-import { Button } from '@/components/ui/button';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
+import ActivityList, { ActivityWithParticipants } from '@/components/activity-list';
 
 export default async function Home() {
-  type ActivityWithParticipants = Prisma.ActivityGetPayload<{
-    include: { participants: true };
-  }>;
-
   let activities: ActivityWithParticipants[] = [];
 
   try {
@@ -27,33 +21,6 @@ export default async function Home() {
     }
   }
 
-  return (
-    <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
-      <ul className="space-y-4">
-        {activities.map((activity) => (
-          <li key={activity.id} className="flex flex-col border p-4">
-            {activity.image && (
-              <Image
-                src={activity.image}
-                alt={activity.name}
-                width={800}
-                height={600}
-                className="mb-2 max-w-full"
-              />
-            )}
-            <span className="mb-1 font-semibold">{activity.name}</span>
-            {activity.description && (
-              <p className="mb-2 text-sm text-slate-600">
-                {activity.description}
-              </p>
-            )}
-            <Link href={`/activities/${activity.id}`}>
-              <Button>Inscribirse</Button>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </main>
-  );
+  return <ActivityList activities={activities} />;
 }
+

--- a/src/components/activity-list.tsx
+++ b/src/components/activity-list.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import Link from 'next/link';
+import Image from 'next/image';
+import { Button } from '@/components/ui/button';
+import { useLanguage } from '@/lib/language-context';
+import { Prisma } from '@prisma/client';
+
+export type ActivityWithParticipants = Prisma.ActivityGetPayload<{ include: { participants: true } }>;
+
+export default function ActivityList({ activities }: { activities: ActivityWithParticipants[] }) {
+  const { t } = useLanguage();
+
+  return (
+    <main className="p-4">
+      <h1 className="mb-4 text-2xl font-bold">{t('welcome')}</h1>
+      <ul className="space-y-4">
+        {activities.map((activity) => (
+          <li key={activity.id} className="flex flex-col border p-4">
+            {activity.image && (
+              <Image
+                src={activity.image}
+                alt={activity.name}
+                width={800}
+                height={600}
+                className="mb-2 max-w-full"
+              />
+            )}
+            <span className="mb-1 font-semibold">{activity.name}</span>
+            {activity.description && (
+              <p className="mb-2 text-sm text-slate-600">{activity.description}</p>
+            )}
+            <Link href={`/activities/${activity.id}`}>
+              <Button>{t('enroll')}</Button>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}
+

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,11 +1,14 @@
 'use client';
 
+import { useLanguage } from '@/lib/language-context';
+
 export default function Footer() {
+  const { t } = useLanguage();
   return (
     <footer className="flex flex-col items-center justify-center px-4 py-6 bg-slate-800 text-white text-center">
       <p className="text-2xl">💚</p>
       <p className="mt-2">
-        ¡Seguinos en Instagram!
+        {t('followUs')}
         <br />
         <a
           href="https://www.instagram.com/hualas_patagonico/"
@@ -16,10 +19,11 @@ export default function Footer() {
         </a>
       </p>
       <p className="mt-2">
-        Club Social y Deportivo Hualas Patagónico.
+        {t('clubName')}
         <br />
-        ⛰️San Martín de los Andes, Neuquén, Patagonia Argentina. 🇦🇷
+        {t('clubLocation')}
       </p>
     </footer>
   );
 }
+

--- a/src/components/language-switcher.tsx
+++ b/src/components/language-switcher.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { languages, useLanguage, Language } from '@/lib/language-context';
+
+export default function LanguageSwitcher() {
+  const { language, setLanguage } = useLanguage();
+
+  return (
+    <select
+      value={language}
+      onChange={(e) => setLanguage(e.target.value as Language)}
+      className="bg-slate-800 text-white border-none focus:outline-none"
+    >
+      {Object.entries(languages).map(([code, { label, flag }]) => (
+        <option key={code} value={code}>
+          {flag} {label}
+        </option>
+      ))}
+    </select>
+  );
+}
+

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,9 +3,12 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useSession, signOut } from 'next-auth/react';
+import LanguageSwitcher from './language-switcher';
+import { useLanguage } from '@/lib/language-context';
 
 export default function Navbar() {
   const { data: session } = useSession();
+  const { t } = useLanguage();
 
   return (
     <nav className="flex items-center justify-between px-4 py-2 bg-slate-800 text-white">
@@ -20,14 +23,14 @@ export default function Navbar() {
         <span className="font-semibold">Hualas Patagónico</span>
       </Link>
       <div className="flex items-center gap-[5ch]">
-        <Link href="/">Home</Link>
-        <Link href="/activities">Activities</Link>
-        <Link href="/contact">Contacto</Link>
-        {session && <Link href="/chat">Chat</Link>}
+        <Link href="/">{t('home')}</Link>
+        <Link href="/activities">{t('activities')}</Link>
+        <Link href="/contact">{t('contact')}</Link>
+        {session && <Link href="/chat">{t('chat')}</Link>}
         {session?.user.role === 'ADMIN' && (
           <>
-            <Link href="/admin/users">Users</Link>
-            <Link href="/admin/forms">Forms</Link>
+            <Link href="/admin/users">{t('users')}</Link>
+            <Link href="/admin/forms">{t('forms')}</Link>
           </>
         )}
         {session ? (
@@ -35,19 +38,21 @@ export default function Navbar() {
             onClick={() => signOut({ callbackUrl: '/login' })}
             className="hover:underline"
           >
-            Logout
+            {t('logout')}
           </button>
         ) : (
           <>
             <Link href="/login" className="hover:underline">
-              Login
+              {t('login')}
             </Link>
             <Link href="/register" className="hover:underline">
-              Register
+              {t('register')}
             </Link>
           </>
         )}
+        <LanguageSwitcher />
       </div>
     </nav>
   );
 }
+

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -2,7 +2,13 @@
 
 import { SessionProvider } from 'next-auth/react';
 import type { ReactNode } from 'react';
+import { LanguageProvider } from '@/lib/language-context';
 
 export default function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <LanguageProvider>{children}</LanguageProvider>
+    </SessionProvider>
+  );
 }
+

--- a/src/lib/language-context.tsx
+++ b/src/lib/language-context.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { createContext, useContext, useState, ReactNode } from 'react';
+
+export const languages = {
+  es: { label: 'Español', flag: '🇪🇸' },
+  en: { label: 'English', flag: '🇺🇸' },
+  pt: { label: 'Português', flag: '🇧🇷' },
+  fr: { label: 'Français', flag: '🇫🇷' },
+} as const;
+
+export type Language = keyof typeof languages;
+
+const translations: Record<Language, Record<string, string>> = {
+  es: {
+    home: 'Inicio',
+    activities: 'Actividades',
+    contact: 'Contacto',
+    chat: 'Chat',
+    users: 'Usuarios',
+    forms: 'Formularios',
+    login: 'Iniciar sesión',
+    register: 'Registrarse',
+    logout: 'Cerrar sesión',
+    welcome: 'Bienvenido al Club Hualas',
+    enroll: 'Inscribirse',
+    followUs: '¡Seguinos en Instagram!',
+    clubName: 'Club Social y Deportivo Hualas Patagónico.',
+    clubLocation: '⛰️San Martín de los Andes, Neuquén, Patagonia Argentina. 🇦🇷',
+  },
+  en: {
+    home: 'Home',
+    activities: 'Activities',
+    contact: 'Contact',
+    chat: 'Chat',
+    users: 'Users',
+    forms: 'Forms',
+    login: 'Login',
+    register: 'Register',
+    logout: 'Logout',
+    welcome: 'Welcome to Club Hualas',
+    enroll: 'Enroll',
+    followUs: 'Follow us on Instagram!',
+    clubName: 'Hualas Patagónico Social and Sports Club.',
+    clubLocation: '⛰️San Martín de los Andes, Neuquén, Argentine Patagonia. 🇦🇷',
+  },
+  pt: {
+    home: 'Início',
+    activities: 'Atividades',
+    contact: 'Contato',
+    chat: 'Chat',
+    users: 'Usuários',
+    forms: 'Formulários',
+    login: 'Entrar',
+    register: 'Registrar',
+    logout: 'Sair',
+    welcome: 'Bem-vindo ao Clube Hualas',
+    enroll: 'Inscrever-se',
+    followUs: 'Siga-nos no Instagram!',
+    clubName: 'Clube Social e Esportivo Hualas Patagônico.',
+    clubLocation: '⛰️San Martín de los Andes, Neuquén, Patagônia Argentina. 🇦🇷',
+  },
+  fr: {
+    home: 'Accueil',
+    activities: 'Activités',
+    contact: 'Contact',
+    chat: 'Chat',
+    users: 'Utilisateurs',
+    forms: 'Formulaires',
+    login: 'Connexion',
+    register: 'Inscription',
+    logout: 'Déconnexion',
+    welcome: 'Bienvenue au Club Hualas',
+    enroll: "S'inscrire",
+    followUs: 'Suivez-nous sur Instagram !',
+    clubName: 'Club Social et Sportif Hualas Patagónico.',
+    clubLocation: '⛰️San Martín de los Andes, Neuquén, Patagonie argentine. 🇦🇷',
+  },
+};
+
+interface LanguageContextProps {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LanguageContextProps | undefined>(undefined);
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [language, setLanguage] = useState<Language>('es');
+
+  const t = (key: string) => translations[language][key] || key;
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLanguage() {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within LanguageProvider');
+  }
+  return context;
+}
+


### PR DESCRIPTION
## Summary
- introduce LanguageContext with translations for Spanish, English, Portuguese and French
- add LanguageSwitcher with flag emojis and integrate into navbar
- translate footer and homepage content and wrap app with LanguageProvider

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `pnpm build` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a72226007c833387c97a34b4c29ee7