### PR TITLE
feat: add basic internationalization

### DIFF
--- a/src/components/language-provider.tsx
+++ b/src/components/language-provider.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  translations,
+  availableLanguages,
+  defaultLang,
+  type Lang,
+} from '@/lib/i18n';
+
+interface LangContext {
+  lang: Lang;
+  setLang: (l: Lang) => void;
+}
+
+const LanguageContext = createContext<LangContext>({
+  lang: defaultLang,
+  setLang: () => {},
+});
+
+export function LanguageProvider({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState<Lang>(defaultLang);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('lang') as Lang | null;
+    if (stored) setLang(stored);
+  }, []);
+
+  useEffect(() => {
+    localStorage.setItem('lang', lang);
+  }, [lang]);
+
+  return (
+    <LanguageContext.Provider value={{ lang, setLang }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}
+
+export function useLang() {
+  return useContext(LanguageContext);
+}
+
+export function useTranslation() {
+  const { lang } = useLang();
+  return translations[lang];
+}
+
+export { availableLanguages };

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -4,6 +4,12 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { useSession, signOut } from 'next-auth/react';
 import type { SiteSettings } from '@/types/site';
+import {
+  useTranslation,
+  useLang,
+  availableLanguages,
+} from './language-provider';
+import type { Lang } from '@/lib/i18n';
 
 const defaultLogo =
   'https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383';
@@ -14,6 +20,8 @@ export default function Navbar({
   settings: SiteSettings | null;
 }) {
   const { data: session } = useSession();
+  const t = useTranslation().nav;
+  const { lang, setLang } = useLang();
 
   return (
     <nav
@@ -31,16 +39,16 @@ export default function Navbar({
         <span className="font-semibold">Hualas Patagónico</span>
       </Link>
       <div className="flex items-center gap-[5ch]">
-        <Link href="/">Home</Link>
-        <Link href="/activities">Activities</Link>
-        <Link href="/contact">Contacto</Link>
-        {session && <Link href="/chat">Chat</Link>}
-        {session && <Link href="/profile">Profile</Link>}
+        <Link href="/">{t.home}</Link>
+        <Link href="/activities">{t.activities}</Link>
+        <Link href="/contact">{t.contact}</Link>
+        {session && <Link href="/chat">{t.chat}</Link>}
+        {session && <Link href="/profile">{t.profile}</Link>}
         {session?.user.role === 'ADMIN' && (
           <>
-            <Link href="/admin/users">Users</Link>
-            <Link href="/admin/forms">Forms</Link>
-            <Link href="/admin/site">Site Administrator</Link>
+            <Link href="/admin/users">{t.users}</Link>
+            <Link href="/admin/forms">{t.forms}</Link>
+            <Link href="/admin/site">{t.admin}</Link>
           </>
         )}
         {session ? (
@@ -48,18 +56,29 @@ export default function Navbar({
             onClick={() => signOut({ callbackUrl: '/login' })}
             className="hover:underline"
           >
-            Logout
+            {t.logout}
           </button>
         ) : (
           <>
             <Link href="/login" className="hover:underline">
-              Login
+              {t.login}
             </Link>
             <Link href="/register" className="hover:underline">
-              Register
+              {t.register}
             </Link>
           </>
         )}
+        <select
+          value={lang}
+          onChange={(e) => setLang(e.target.value as Lang)}
+          className="bg-transparent text-black dark:text-white"
+        >
+          {availableLanguages.map(({ code, flag }) => (
+            <option key={code} value={code}>
+              {flag}
+            </option>
+          ))}
+        </select>
       </div>
     </nav>
   );

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -2,7 +2,12 @@
 
 import { SessionProvider } from 'next-auth/react';
 import type { ReactNode } from 'react';
+import { LanguageProvider } from './language-provider';
 
 export default function Providers({ children }: { children: ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>;
+  return (
+    <SessionProvider>
+      <LanguageProvider>{children}</LanguageProvider>
+    </SessionProvider>
+  );
 }

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,74 @@
+export const translations = {
+  es: {
+    nav: {
+      home: 'Inicio',
+      activities: 'Actividades',
+      contact: 'Contacto',
+      chat: 'Chat',
+      profile: 'Perfil',
+      users: 'Usuarios',
+      forms: 'Formularios',
+      admin: 'Administrador del sitio',
+      login: 'Ingresar',
+      register: 'Registrarse',
+      logout: 'Salir',
+    },
+  },
+  pt: {
+    nav: {
+      home: 'Início',
+      activities: 'Atividades',
+      contact: 'Contato',
+      chat: 'Bate-papo',
+      profile: 'Perfil',
+      users: 'Usuários',
+      forms: 'Formulários',
+      admin: 'Administrador do Site',
+      login: 'Entrar',
+      register: 'Registrar',
+      logout: 'Sair',
+    },
+  },
+  en: {
+    nav: {
+      home: 'Home',
+      activities: 'Activities',
+      contact: 'Contact',
+      chat: 'Chat',
+      profile: 'Profile',
+      users: 'Users',
+      forms: 'Forms',
+      admin: 'Site Administrator',
+      login: 'Login',
+      register: 'Register',
+      logout: 'Logout',
+    },
+  },
+  fr: {
+    nav: {
+      home: 'Accueil',
+      activities: 'Activités',
+      contact: 'Contact',
+      chat: 'Discussion',
+      profile: 'Profil',
+      users: 'Utilisateurs',
+      forms: 'Formulaires',
+      admin: 'Administrateur du Site',
+      login: 'Connexion',
+      register: 'Inscription',
+      logout: 'Déconnexion',
+    },
+  },
+};
+
+export type Lang = keyof typeof translations;
+
+export const availableLanguages: { code: Lang; flag: string; label: string }[] =
+  [
+    { code: 'es', flag: '🇪🇸', label: 'Español' },
+    { code: 'pt', flag: '🇵🇹', label: 'Português' },
+    { code: 'en', flag: '🇬🇧', label: 'English' },
+    { code: 'fr', flag: '🇫🇷', label: 'Français' },
+  ];
+
+export const defaultLang: Lang = 'es';


### PR DESCRIPTION
## Summary
- add translation dictionaries for Spanish, Portuguese, English and French
- provide LanguageProvider to switch languages and persist preference
- add navbar flag selector and translated labels

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a725a9329483338a47f3617542b9d3