### PR TITLE
Allow longer site setting image strings

### DIFF
--- a/prisma/migrations/20240907000000_extend_site_setting_logo/migration.sql
+++ b/prisma/migrations/20240907000000_extend_site_setting_logo/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "SiteSetting"
+  ALTER COLUMN "logo" TYPE TEXT,
+  ALTER COLUMN "favicon" TYPE TEXT;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,18 +8,18 @@ datasource db {
 }
 
 model User {
-  id                   String                    @id @default(cuid())
-  email                String                    @unique
-  name                 String?
-  password             String
-  role                 Role                      @default(MEMBER)
-  isActive             Boolean                   @default(true)
-  createdAt            DateTime                  @default(now())
-  updatedAt            DateTime                  @updatedAt
-  messages             Message[]
-  conversations        ConversationParticipant[]
-  passwordResetTokens  PasswordResetToken[]
-  formResponses        FormResponse[]
+  id                  String                    @id @default(cuid())
+  email               String                    @unique
+  name                String?
+  password            String
+  role                Role                      @default(MEMBER)
+  isActive            Boolean                   @default(true)
+  createdAt           DateTime                  @default(now())
+  updatedAt           DateTime                  @updatedAt
+  messages            Message[]
+  conversations       ConversationParticipant[]
+  passwordResetTokens PasswordResetToken[]
+  formResponses       FormResponse[]
   activityParticipants ActivityParticipant[]
 }
 
@@ -62,58 +62,58 @@ model Message {
 }
 
 model Form {
-  id        String         @id @default(cuid())
+  id        String       @id @default(cuid())
   title     String
   fields    FormField[]
   responses FormResponse[]
-  createdAt DateTime       @default(now())
+  createdAt DateTime     @default(now())
 }
 
 model FormField {
-  id       String  @id @default(cuid())
-  formId   String
-  form     Form    @relation(fields: [formId], references: [id])
-  label    String
-  type     String
-  options  Json?
+  id      String @id @default(cuid())
+  formId  String
+  form    Form   @relation(fields: [formId], references: [id])
+  label   String
+  type    String
+  options Json?
   required Boolean @default(false)
-  order    Int
+  order   Int
 }
 
 model FormResponse {
-  id        String   @id @default(cuid())
+  id        String @id @default(cuid())
   formId    String
-  form      Form     @relation(fields: [formId], references: [id])
+  form      Form   @relation(fields: [formId], references: [id])
   userId    String?
-  user      User?    @relation(fields: [userId], references: [id])
+  user      User?  @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
 }
 
 model Activity {
-  id           String                @id @default(cuid())
-  name         String
-  date         DateTime
-  frequency    ActivityFrequency     @default(ONE_TIME)
-  image        String?
-  description  String?
-  price        Int                   @default(0)
+  id          String             @id @default(cuid())
+  name        String
+  date        DateTime
+  frequency   ActivityFrequency @default(ONE_TIME)
+  image       String?
+  description String?
+  price       Int                @default(0)
   participants ActivityParticipant[]
-  createdAt    DateTime              @default(now())
+  createdAt   DateTime @default(now())
 }
 
 model ActivityParticipant {
-  id         String   @id @default(cuid())
+  id      String @id @default(cuid())
   activityId String
-  userId     String
+  userId  String
   activity   Activity @relation(fields: [activityId], references: [id])
-  user       User     @relation(fields: [userId], references: [id])
+  user    User  @relation(fields: [userId], references: [id])
 
   @@unique([activityId, userId])
 }
 
 model SiteSetting {
-  id              Int     @id
+  id              Int    @id
   logo            String? @db.Text
   favicon         String? @db.Text
   navbarColor     String?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,18 +8,18 @@ datasource db {
 }
 
 model User {
-  id                  String                    @id @default(cuid())
-  email               String                    @unique
-  name                String?
-  password            String
-  role                Role                      @default(MEMBER)
-  isActive            Boolean                   @default(true)
-  createdAt           DateTime                  @default(now())
-  updatedAt           DateTime                  @updatedAt
-  messages            Message[]
-  conversations       ConversationParticipant[]
-  passwordResetTokens PasswordResetToken[]
-  formResponses       FormResponse[]
+  id                   String                    @id @default(cuid())
+  email                String                    @unique
+  name                 String?
+  password             String
+  role                 Role                      @default(MEMBER)
+  isActive             Boolean                   @default(true)
+  createdAt            DateTime                  @default(now())
+  updatedAt            DateTime                  @updatedAt
+  messages             Message[]
+  conversations        ConversationParticipant[]
+  passwordResetTokens  PasswordResetToken[]
+  formResponses        FormResponse[]
   activityParticipants ActivityParticipant[]
 }
 
@@ -62,60 +62,60 @@ model Message {
 }
 
 model Form {
-  id        String       @id @default(cuid())
+  id        String         @id @default(cuid())
   title     String
   fields    FormField[]
   responses FormResponse[]
-  createdAt DateTime     @default(now())
+  createdAt DateTime       @default(now())
 }
 
 model FormField {
-  id      String @id @default(cuid())
-  formId  String
-  form    Form   @relation(fields: [formId], references: [id])
-  label   String
-  type    String
-  options Json?
+  id       String  @id @default(cuid())
+  formId   String
+  form     Form    @relation(fields: [formId], references: [id])
+  label    String
+  type     String
+  options  Json?
   required Boolean @default(false)
-  order   Int
+  order    Int
 }
 
 model FormResponse {
-  id        String @id @default(cuid())
+  id        String   @id @default(cuid())
   formId    String
-  form      Form   @relation(fields: [formId], references: [id])
+  form      Form     @relation(fields: [formId], references: [id])
   userId    String?
-  user      User?  @relation(fields: [userId], references: [id])
+  user      User?    @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
 }
 
 model Activity {
-  id          String             @id @default(cuid())
-  name        String
-  date        DateTime
-  frequency   ActivityFrequency @default(ONE_TIME)
-  image       String?
-  description String?
-  price       Int                @default(0)
+  id           String                @id @default(cuid())
+  name         String
+  date         DateTime
+  frequency    ActivityFrequency     @default(ONE_TIME)
+  image        String?
+  description  String?
+  price        Int                   @default(0)
   participants ActivityParticipant[]
-  createdAt   DateTime @default(now())
+  createdAt    DateTime              @default(now())
 }
 
 model ActivityParticipant {
-  id      String @id @default(cuid())
+  id         String   @id @default(cuid())
   activityId String
-  userId  String
+  userId     String
   activity   Activity @relation(fields: [activityId], references: [id])
-  user    User  @relation(fields: [userId], references: [id])
+  user       User     @relation(fields: [userId], references: [id])
 
   @@unique([activityId, userId])
 }
 
 model SiteSetting {
-  id              Int    @id
-  logo            String?
-  favicon         String?
+  id              Int     @id
+  logo            String? @db.Text
+  favicon         String? @db.Text
   navbarColor     String?
   footerColor     String?
   backgroundColor String?


### PR DESCRIPTION
## Summary
- allow long strings for site logo and favicon
- add migration to update SiteSetting columns

## Testing
- `npx prisma migrate dev --name increase-logo-length --create-only` *(fails: Environment variable not found: DATABASE_URL)*
- `pnpm prisma:generate` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a7264698b08333a920a60b023a6052