### PR TITLE
feat: translate key UI texts

### DIFF
--- a/src/app/activities/[id]/register-button.tsx
+++ b/src/app/activities/[id]/register-button.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
+import RegisterButton from '@/components/register-button';
 
-export default function RegisterButton({ activityId }: { activityId: string }) {
+export default function ActivityRegisterButton({
+  activityId,
+}: {
+  activityId: string;
+}) {
   const handleClick = () => {
     window.location.href = `/api/activities/${activityId}/checkout`;
   };
-  return <Button onClick={handleClick}>Inscribirse</Button>;
+  return <RegisterButton onClick={handleClick} />;
 }

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { Button } from '@/components/ui/button';
+import ActivitiesHeading from '@/components/activities-heading';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
@@ -28,7 +29,7 @@ export default async function ActivitiesPage() {
   return (
     <main className="p-4">
       <div className="mb-4 flex items-center justify-between">
-        <h1 className="text-2xl font-bold">Activities</h1>
+        <ActivitiesHeading />
         {session?.user.role === 'ADMIN' && (
           <Link href="/activities/new">
             <Button>Crear actividad</Button>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
-import Link from 'next/link';
 import Image from 'next/image';
-import { Button } from '@/components/ui/button';
+import HomeHeading from '@/components/home-heading';
+import RegisterButton from '@/components/register-button';
 import { prisma } from '@/lib/prisma';
 import { Prisma } from '@prisma/client';
 
@@ -29,7 +29,7 @@ export default async function Home() {
 
   return (
     <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">Welcome to Club Hualas</h1>
+      <HomeHeading />
       <ul className="space-y-4">
         {activities.map((activity) => (
           <li key={activity.id} className="flex flex-col border p-4">
@@ -48,9 +48,7 @@ export default async function Home() {
                 {activity.description}
               </p>
             )}
-            <Link href={`/activities/${activity.id}`}>
-              <Button>Inscribirse</Button>
-            </Link>
+            <RegisterButton href={`/activities/${activity.id}`} />
           </li>
         ))}
       </ul>

--- a/src/components/activities-heading.tsx
+++ b/src/components/activities-heading.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useTranslation } from './language-provider';
+
+export default function ActivitiesHeading() {
+  const t = useTranslation();
+  return <h1 className="text-2xl font-bold">{t.nav.activities}</h1>;
+}

--- a/src/components/home-heading.tsx
+++ b/src/components/home-heading.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { useTranslation } from './language-provider';
+
+export default function HomeHeading() {
+  const t = useTranslation();
+  return <h1 className="mb-4 text-2xl font-bold">{t.home.welcome}</h1>;
+}

--- a/src/components/register-button.tsx
+++ b/src/components/register-button.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+import Link from 'next/link';
+import { Button } from './ui/button';
+import { useTranslation } from './language-provider';
+
+interface Props {
+  href?: string;
+  onClick?: () => void;
+}
+
+export default function RegisterButton({ href, onClick }: Props) {
+  const t = useTranslation();
+  const btn = <Button onClick={onClick}>{t.nav.register}</Button>;
+  if (href) {
+    return <Link href={href}>{btn}</Link>;
+  }
+  return btn;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -10,8 +10,11 @@ export const translations = {
       forms: 'Formularios',
       admin: 'Administrador del sitio',
       login: 'Ingresar',
-      register: 'Registrarse',
+      register: 'Inscribirse',
       logout: 'Salir',
+    },
+    home: {
+      welcome: 'Bienvenido a Club Hualas',
     },
   },
   pt: {
@@ -25,8 +28,11 @@ export const translations = {
       forms: 'Formulários',
       admin: 'Administrador do Site',
       login: 'Entrar',
-      register: 'Registrar',
+      register: 'Inscrever-se',
       logout: 'Sair',
+    },
+    home: {
+      welcome: 'Bem-vindo ao Club Hualas',
     },
   },
   en: {
@@ -43,6 +49,9 @@ export const translations = {
       register: 'Register',
       logout: 'Logout',
     },
+    home: {
+      welcome: 'Welcome to Club Hualas',
+    },
   },
   fr: {
     nav: {
@@ -55,8 +64,11 @@ export const translations = {
       forms: 'Formulaires',
       admin: 'Administrateur du Site',
       login: 'Connexion',
-      register: 'Inscription',
+      register: "S'inscrire",
       logout: 'Déconnexion',
+    },
+    home: {
+      welcome: 'Bienvenue au Club Hualas',
     },
   },
 };


### PR DESCRIPTION
## Summary
- extend i18n with welcome message and updated register labels
- show translated headings and register buttons on home and activities pages

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a73304ac888333939ccc8c5459a528