### PR TITLE
Store MercadoPago receipts for activity payments

### DIFF
--- a/prisma/migrations/20241010000000_add_receipt_to_activity_participant/migration.sql
+++ b/prisma/migrations/20241010000000_add_receipt_to_activity_participant/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ActivityParticipant" ADD COLUMN "receipt" TEXT;
+ALTER TABLE "ActivityParticipant" ADD COLUMN "receiptDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -106,6 +106,8 @@ model ActivityParticipant {
   id      String @id @default(cuid())
   activityId String
   userId  String
+  receipt String?
+  receiptDate DateTime?
   activity   Activity @relation(fields: [activityId], references: [id])
   user    User  @relation(fields: [userId], references: [id])
 

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import RegisterButton from './register-button';
+import PaymentHandler from './payment-handler';
 import Image from 'next/image';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
@@ -38,6 +39,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   return (
     <main className="p-4">
+      <PaymentHandler activityId={activity.id} />
       <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
       {session?.user.role === 'ADMIN' && (
         <Link
@@ -58,9 +60,8 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
       )}
       <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
       <p className="mb-2">
-        Frecuencia: {
-          frequencyLabels[activity.frequency as keyof typeof frequencyLabels]
-        }
+        Frecuencia:{' '}
+        {frequencyLabels[activity.frequency as keyof typeof frequencyLabels]}
       </p>
       <p className="mb-4">{activity.description}</p>
       <p className="mb-4 font-semibold">Precio: ${activity.price}</p>

--- a/src/app/activities/[id]/payment-handler.tsx
+++ b/src/app/activities/[id]/payment-handler.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useSearchParams } from 'next/navigation';
+
+export default function PaymentHandler({ activityId }: { activityId: string }) {
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const status = searchParams.get('status');
+    const paymentId = searchParams.get('payment_id');
+
+    if (status === 'approved' && paymentId) {
+      fetch(`/api/activities/${activityId}/payment`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ paymentId }),
+      });
+    }
+  }, [searchParams, activityId]);
+
+  return null;
+}

--- a/src/app/api/activities/[id]/payment/route.ts
+++ b/src/app/api/activities/[id]/payment/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { MercadoPagoConfig, Payment } from 'mercadopago';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { paymentId } = await req.json();
+  if (!paymentId) {
+    return NextResponse.json({ error: 'Missing paymentId' }, { status: 400 });
+  }
+
+  const client = new MercadoPagoConfig({
+    accessToken: process.env.MP_ACCESS_TOKEN!,
+  });
+  const payment = await new Payment(client).get({ id: paymentId });
+
+  const receipt = payment.id?.toString();
+  const date = payment.date_approved || payment.date_created || new Date();
+
+  await prisma.activityParticipant.upsert({
+    where: {
+      activityId_userId: {
+        activityId: params.id,
+        userId: (session.user as any).id,
+      },
+    },
+    create: {
+      activityId: params.id,
+      userId: (session.user as any).id,
+      receipt,
+      receiptDate: new Date(date),
+    },
+    update: {
+      receipt,
+      receiptDate: new Date(date),
+    },
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/src/types/mercadopago.d.ts
+++ b/src/types/mercadopago.d.ts
@@ -6,4 +6,8 @@ declare module 'mercadopago' {
     constructor(config: any);
     create(options: any): Promise<any>;
   }
+  export class Payment {
+    constructor(config: any);
+    get(options: any): Promise<any>;
+  }
 }


### PR DESCRIPTION
## Summary
- save MercadoPago receipt and date in activity participant records
- add API endpoint and client handler to persist receipts after successful payments
- extend MercadoPago types to support payment retrieval

## Testing
- `npm run lint`
- `npm run build` *(fails: can't reach database server at localhost:5432)*

------
https://chatgpt.com/codex/tasks/task_e_68a7395066708333b0be467eef134b2a