### PR TITLE
Require login before activity registration

### DIFF
--- a/src/app/activities/[id]/register-button.tsx
+++ b/src/app/activities/[id]/register-button.tsx
@@ -1,13 +1,21 @@
 'use client';
 
 import RegisterButton from '@/components/register-button';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
 
 export default function ActivityRegisterButton({
   activityId,
 }: {
   activityId: string;
 }) {
+  const { data: session } = useSession();
+  const router = useRouter();
   const handleClick = () => {
+    if (!session) {
+      router.push('/login');
+      return;
+    }
     window.location.href = `/api/activities/${activityId}/checkout`;
   };
   return <RegisterButton onClick={handleClick} />;


### PR DESCRIPTION
## Summary
- redirect to login when unauthenticated users try to register for an activity

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a73f423ba48333ac57e8772032a254