### PR TITLE
Improve mobile layout for mobile-first experience

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -19,7 +19,10 @@ export default async function ActivitiesPage() {
     activities = [];
   }
 
-  const frequencyLabels: Record<'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME', string> = {
+  const frequencyLabels: Record<
+    'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME',
+    string
+  > = {
     DAILY: 'Diaria',
     WEEKLY: 'Semanal',
     MONTHLY: 'Mensual',
@@ -28,7 +31,7 @@ export default async function ActivitiesPage() {
 
   return (
     <main className="p-4">
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
         <ActivitiesHeading />
         {session?.user.role === 'ADMIN' && (
           <Link href="/activities/new">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,16 @@
 import './globals.css';
 import type { ReactNode } from 'react';
+import type { Viewport } from 'next';
 import Navbar from '@/components/navbar';
 import Footer from '@/components/footer';
 import Providers from '@/components/providers';
 import { prisma } from '@/lib/prisma';
 import type { SiteSettings } from '@/types/site';
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
 
 export async function generateMetadata() {
   const settings = await prisma.siteSetting.findUnique({ where: { id: 1 } });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,7 +39,7 @@ export default async function Home() {
                 alt={activity.name}
                 width={800}
                 height={600}
-                className="mb-2 max-w-full"
+                className="mb-2 h-auto w-full"
               />
             )}
             <span className="mb-1 font-semibold">{activity.name}</span>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -2,6 +2,8 @@
 
 import Link from 'next/link';
 import Image from 'next/image';
+import { Menu } from 'lucide-react';
+import { useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import type { SiteSettings } from '@/types/site';
 import {
@@ -22,6 +24,7 @@ export default function Navbar({
   const { data: session } = useSession();
   const t = useTranslation().nav;
   const { lang, setLang } = useLang();
+  const [menuOpen, setMenuOpen] = useState(false);
 
   const logoUrl = settings?.logo
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`
@@ -29,20 +32,31 @@ export default function Navbar({
 
   return (
     <nav
-      className="flex items-center justify-between px-4 py-2 text-white"
+      className="flex flex-col px-4 py-2 text-white"
       style={{ backgroundColor: settings?.navbarColor || '#1e293b' }}
     >
-      <Link href="/" className="flex items-center gap-2">
-        <Image
-          src={logoUrl}
-          alt="Hualas Club logo"
-          width={40}
-          height={40}
-          unoptimized
-        />
-        <span className="font-semibold">Hualas Patagónico</span>
-      </Link>
-      <div className="flex items-center gap-[5ch]">
+      <div className="flex items-center justify-between">
+        <Link href="/" className="flex items-center gap-2">
+          <Image
+            src={logoUrl}
+            alt="Hualas Club logo"
+            width={40}
+            height={40}
+            unoptimized
+          />
+          <span className="font-semibold">Hualas Patagónico</span>
+        </Link>
+        <button
+          className="md:hidden"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label="Toggle menu"
+        >
+          <Menu />
+        </button>
+      </div>
+      <div
+        className={`${menuOpen ? 'flex' : 'hidden'} flex-col gap-2 mt-2 md:mt-0 md:flex md:flex-row md:items-center md:gap-[5ch]`}
+      >
         <Link href="/">{t.home}</Link>
         <Link href="/activities">{t.activities}</Link>
         <Link href="/contact">{t.contact}</Link>


### PR DESCRIPTION
## Summary
- add viewport configuration for proper mobile scaling
- implement collapsible mobile navigation menu
- adjust activities page and images for better small-screen layout

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a74552d3b08333ac89da3128e9e9dd