### PR TITLE
feat: load navbar logo from site settings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -33,7 +33,7 @@ export default async function RootLayout({
         style={{ backgroundColor: settings?.backgroundColor || undefined }}
       >
         <Providers>
-          <Navbar settings={settings} />
+          <Navbar />
           <main className="flex-1">{children}</main>
           <Footer settings={settings} />
         </Providers>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { useSession, signOut } from 'next-auth/react';
+import { useEffect, useState } from 'react';
 import type { SiteSettings } from '@/types/site';
 import {
   useTranslation,
@@ -14,14 +15,25 @@ import type { Lang } from '@/lib/i18n';
 const defaultLogo =
   'https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383';
 
-export default function Navbar({
-  settings,
-}: {
-  settings: SiteSettings | null;
-}) {
+export default function Navbar() {
   const { data: session } = useSession();
   const t = useTranslation().nav;
   const { lang, setLang } = useLang();
+  const [settings, setSettings] = useState<SiteSettings | null>(null);
+
+  useEffect(() => {
+    async function fetchSettings() {
+      try {
+        const res = await fetch('/api/site-settings');
+        if (res.ok) {
+          setSettings((await res.json()) as SiteSettings);
+        }
+      } catch (error) {
+        console.error('Failed to load site settings', error);
+      }
+    }
+    fetchSettings();
+  }, []);
 
   const logoUrl = settings?.logo
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`


### PR DESCRIPTION
## Summary
- fetch site settings on the client and show the configured logo in the navbar
- remove unused site settings prop from navbar

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a74a2143c08333a5c532dffdc936e3