### PR TITLE
feat: load navbar logo from site settings

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -39,7 +39,7 @@ export default async function RootLayout({
         style={{ backgroundColor: settings?.backgroundColor || undefined }}
       >
         <Providers>
-          <Navbar settings={settings} />
+          <Navbar />
           <main className="flex-1">{children}</main>
           <Footer settings={settings} />
         </Providers>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Menu } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import type { SiteSettings } from '@/types/site';
 import {
@@ -16,15 +16,18 @@ import type { Lang } from '@/lib/i18n';
 const defaultLogo =
   'https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383';
 
-export default function Navbar({
-  settings,
-}: {
-  settings: SiteSettings | null;
-}) {
+export default function Navbar() {
   const { data: session } = useSession();
   const t = useTranslation().nav;
   const { lang, setLang } = useLang();
   const [menuOpen, setMenuOpen] = useState(false);
+  const [settings, setSettings] = useState<SiteSettings | null>(null);
+
+  useEffect(() => {
+    fetch('/api/site-settings')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => setSettings(data));
+  }, []);
 
   const logoUrl = settings?.logo
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`


### PR DESCRIPTION
## Summary
- fetch site settings on the client and use them to build navbar logo url
- simplify RootLayout usage of Navbar

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a74bcaa7848333a7ee645c28bbe254