### PR TITLE
feat(chat): show conversation history

### DIFF
--- a/src/app/api/messages/[userId]/route.ts
+++ b/src/app/api/messages/[userId]/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const otherUserId = params.userId;
+
+  const conversation = await prisma.conversation.findFirst({
+    where: {
+      participants: {
+        some: { userId: session.user.id },
+      },
+      AND: {
+        participants: {
+          some: { userId: otherUserId },
+        },
+      },
+    },
+    include: {
+      messages: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  });
+
+  const messages = conversation
+    ? conversation.messages.map((m) => ({
+        from: m.senderId,
+        content: m.body,
+      }))
+    : [];
+
+  return NextResponse.json(messages);
+}


### PR DESCRIPTION
## Summary
- store messages in the database and expose an endpoint to retrieve them
- load conversation history for selected user on the chat page

## Testing
- ⚠️ `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a74c83ba408333959e2966945724cb