### PR TITLE
feat: allow uploading activity images to IPFS

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -23,6 +23,8 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
     'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
   >(activity.frequency);
   const [image, setImage] = useState(activity.image || '');
+  const [imageType, setImageType] = useState<'url' | 'file'>(activity.image ? 'url' : 'file');
+  const [uploading, setUploading] = useState(false);
   const [description, setDescription] = useState(activity.description || '');
   const [price, setPrice] = useState(String(activity.price));
   const router = useRouter();
@@ -73,12 +75,58 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         className="w-full border px-2 py-1"
       />
       <input
-        type="url"
-        placeholder="URL de la imagen"
-        value={image}
-        onChange={(e) => setImage(e.target.value)}
-        className="w-full border px-2 py-1"
+        type="radio"
+        id="image-url"
+        value="url"
+        checked={imageType === 'url'}
+        onChange={() => setImageType('url')}
       />
+      <label htmlFor="image-url" className="ml-2 mr-4">URL</label>
+      <input
+        type="radio"
+        id="image-file"
+        value="file"
+        checked={imageType === 'file'}
+        onChange={() => setImageType('file')}
+      />
+      <label htmlFor="image-file" className="ml-2">Archivo</label>
+      {imageType === 'url' ? (
+        <input
+          type="url"
+          placeholder="URL de la imagen"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+          className="w-full border px-2 py-1 mt-2"
+        />
+      ) : (
+        <input
+          type="file"
+          accept="image/*"
+          onChange={async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            setUploading(true);
+            try {
+              const res = await fetch('/api/ipfs', {
+                method: 'POST',
+                body: formData,
+              });
+              const data = await res.json();
+              setImage(data.url);
+            } catch (err) {
+              setError('Failed to upload image');
+            } finally {
+              setUploading(false);
+            }
+          }}
+          className="w-full border px-2 py-1 mt-2"
+        />
+      )}
+      {uploading && (
+        <p className="text-sm text-gray-500">Subiendo imagen...</p>
+      )}
       <select
         value={frequency}
         onChange={(e) =>

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -8,6 +8,8 @@ export default function CreateActivityForm() {
   const [name, setName] = useState('');
   const [date, setDate] = useState('');
   const [image, setImage] = useState('');
+  const [imageType, setImageType] = useState<'url' | 'file'>('url');
+  const [uploading, setUploading] = useState(false);
   const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
   const [frequency, setFrequency] = useState<'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'>('ONE_TIME');
@@ -65,12 +67,58 @@ export default function CreateActivityForm() {
         className="w-full border px-2 py-1"
       />
       <input
-        type="url"
-        placeholder="URL de la imagen"
-        value={image}
-        onChange={(e) => setImage(e.target.value)}
-        className="w-full border px-2 py-1"
+        type="radio"
+        id="image-url"
+        value="url"
+        checked={imageType === 'url'}
+        onChange={() => setImageType('url')}
       />
+      <label htmlFor="image-url" className="ml-2 mr-4">URL</label>
+      <input
+        type="radio"
+        id="image-file"
+        value="file"
+        checked={imageType === 'file'}
+        onChange={() => setImageType('file')}
+      />
+      <label htmlFor="image-file" className="ml-2">Archivo</label>
+      {imageType === 'url' ? (
+        <input
+          type="url"
+          placeholder="URL de la imagen"
+          value={image}
+          onChange={(e) => setImage(e.target.value)}
+          className="w-full border px-2 py-1 mt-2"
+        />
+      ) : (
+        <input
+          type="file"
+          accept="image/*"
+          onChange={async (e) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            setUploading(true);
+            try {
+              const res = await fetch('/api/ipfs', {
+                method: 'POST',
+                body: formData,
+              });
+              const data = await res.json();
+              setImage(data.url);
+            } catch (err) {
+              setError('Failed to upload image');
+            } finally {
+              setUploading(false);
+            }
+          }}
+          className="w-full border px-2 py-1 mt-2"
+        />
+      )}
+      {uploading && (
+        <p className="text-sm text-gray-500">Subiendo imagen...</p>
+      )}
       <select
         value={frequency}
         onChange={(e) =>

--- a/src/app/api/ipfs/route.ts
+++ b/src/app/api/ipfs/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+
+const PINATA_JWT = process.env.PINATA_JWT;
+
+export async function POST(req: Request) {
+  if (!PINATA_JWT) {
+    return NextResponse.json(
+      { error: 'PINATA_JWT is not set' },
+      { status: 500 },
+    );
+  }
+
+  const data = await req.formData();
+  const file = data.get('file') as File | null;
+  if (!file) {
+    return NextResponse.json({ error: 'No file provided' }, { status: 400 });
+  }
+
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+
+  const res = await fetch('https://api.pinata.cloud/pinning/pinFileToIPFS', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${PINATA_JWT}`,
+    },
+    body: formData,
+  });
+
+  if (!res.ok) {
+    let message = `Failed to upload file to Pinata: ${res.status} ${res.statusText}`;
+    try {
+      const body = await res.text();
+      if (body) message += ` - ${body}`;
+    } catch {
+      // ignore
+    }
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const json = await res.json();
+  const cid = json.IpfsHash as string;
+  const url = `https://ipfs.io/ipfs/${cid}`;
+
+  return NextResponse.json({ cid, url });
+}


### PR DESCRIPTION
## Summary
- allow selecting between URL and file for activity images
- add `/api/ipfs` route to upload files to Pinata

## Testing
- `node node_modules/.bin/next lint`

------
https://chatgpt.com/codex/tasks/task_e_68a77b03162083339b4f123e85a4f0e9