### PR TITLE
feat: expand user profiles and child enrollment

### DIFF
--- a/prisma/migrations/20241116000000_add_profile_and_children/migration.sql
+++ b/prisma/migrations/20241116000000_add_profile_and_children/migration.sql
@@ -1,0 +1,40 @@
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('FEMALE','MALE','NON_BINARY','UNDISCLOSED','OTHER');
+
+-- AlterTable
+ALTER TABLE "User"
+  ADD COLUMN "lastName" TEXT,
+  ADD COLUMN "dni" TEXT,
+  ADD COLUMN "birthDate" TIMESTAMP(3),
+  ADD COLUMN "gender" "Gender",
+  ADD COLUMN "address" TEXT,
+  ADD COLUMN "nationality" TEXT,
+  ADD COLUMN "maritalStatus" TEXT;
+
+CREATE UNIQUE INDEX "User_dni_key" ON "User"("dni");
+
+-- CreateTable
+CREATE TABLE "Child" (
+  "id" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "name" TEXT NOT NULL,
+  "birthDate" TIMESTAMP(3),
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT "Child_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Child" ADD CONSTRAINT "Child_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AlterTable
+ALTER TABLE "ActivityParticipant"
+  ADD COLUMN "childId" TEXT;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_childId_fkey" FOREIGN KEY ("childId") REFERENCES "Child"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- DropIndex
+DROP INDEX "ActivityParticipant_activityId_userId_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityParticipant_activityId_userId_childId_key" ON "ActivityParticipant"("activityId", "userId", "childId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,13 @@ model User {
   id                  String                    @id @default(cuid())
   email               String                    @unique
   name                String?
+  lastName            String?
+  dni                 String?                   @unique
+  birthDate           DateTime?
+  gender              Gender?
+  address             String?
+  nationality         String?
+  maritalStatus       String?
   password            String
   role                Role                      @default(MEMBER)
   isActive            Boolean                   @default(true)
@@ -21,6 +28,7 @@ model User {
   passwordResetTokens PasswordResetToken[]
   formResponses       FormResponse[]
   activityParticipants ActivityParticipant[]
+  children            Child[]
 }
 
 model PasswordResetToken {
@@ -106,12 +114,24 @@ model ActivityParticipant {
   id      String @id @default(cuid())
   activityId String
   userId  String
+  childId String?
   receipt String?
   receiptDate DateTime?
   activity   Activity @relation(fields: [activityId], references: [id])
   user    User  @relation(fields: [userId], references: [id])
+  child   Child? @relation(fields: [childId], references: [id])
 
-  @@unique([activityId, userId])
+  @@unique([activityId, userId, childId])
+}
+
+model Child {
+  id        String   @id @default(cuid())
+  userId    String
+  user      User     @relation(fields: [userId], references: [id])
+  name      String
+  birthDate DateTime?
+  createdAt DateTime @default(now())
+  activityParticipants ActivityParticipant[]
 }
 
 model SiteSetting {
@@ -134,4 +154,12 @@ enum ActivityFrequency {
   WEEKLY
   MONTHLY
   ONE_TIME
+}
+
+enum Gender {
+  FEMALE
+  MALE
+  NON_BINARY
+  UNDISCLOSED
+  OTHER
 }

--- a/src/app/activities/[id]/payment-handler.tsx
+++ b/src/app/activities/[id]/payment-handler.tsx
@@ -9,12 +9,13 @@ export default function PaymentHandler({ activityId }: { activityId: string }) {
   useEffect(() => {
     const status = searchParams.get('status');
     const paymentId = searchParams.get('payment_id');
+    const childId = searchParams.get('childId');
 
     if (status === 'approved' && paymentId) {
       fetch(`/api/activities/${activityId}/payment`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ paymentId }),
+        body: JSON.stringify({ paymentId, childId }),
       });
     }
   }, [searchParams, activityId]);

--- a/src/app/activities/[id]/register-button.tsx
+++ b/src/app/activities/[id]/register-button.tsx
@@ -3,6 +3,7 @@
 import RegisterButton from '@/components/register-button';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
 
 export default function ActivityRegisterButton({
   activityId,
@@ -11,12 +12,45 @@ export default function ActivityRegisterButton({
 }) {
   const { data: session } = useSession();
   const router = useRouter();
+  const [children, setChildren] = useState<Array<{ id: string; name: string }>>(
+    []
+  );
+  const [target, setTarget] = useState('self');
+
+  useEffect(() => {
+    if (session) {
+      fetch('/api/children')
+        .then((res) => res.json())
+        .then((data) => setChildren(data));
+    }
+  }, [session]);
+
   const handleClick = () => {
     if (!session) {
       router.push('/login');
       return;
     }
-    window.location.href = `/api/activities/${activityId}/checkout`;
+    const qs = target !== 'self' ? `?childId=${target}` : '';
+    window.location.href = `/api/activities/${activityId}/checkout${qs}`;
   };
-  return <RegisterButton onClick={handleClick} />;
+
+  return (
+    <div className="space-y-2">
+      {session && (
+        <select
+          className="border px-2 py-1"
+          value={target}
+          onChange={(e) => setTarget(e.target.value)}
+        >
+          <option value="self">Para mí</option>
+          {children.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      )}
+      <RegisterButton onClick={handleClick} />
+    </div>
+  );
 }

--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -5,10 +5,17 @@ import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 
-type User = { id: string; name: string | null; email: string; role: string };
+type User = {
+  id: string;
+  name: string | null;
+  lastName: string | null;
+  email: string;
+  role: string;
+};
 
 export default function EditUserForm({ user }: { user: User }) {
   const [name, setName] = useState(user.name ?? '');
+  const [lastName, setLastName] = useState(user.lastName ?? '');
   const [role, setRole] = useState(user.role);
   const router = useRouter();
   const [error, setError] = useState('');
@@ -21,7 +28,7 @@ export default function EditUserForm({ user }: { user: User }) {
     setError('');
     setSuccess('');
     try {
-      const body: any = { name };
+      const body: any = { name, lastName };
       if (canEditRole) body.role = role;
       const res = await fetch(`/api/users/${user.id}`, {
         method: 'PATCH',
@@ -45,7 +52,13 @@ export default function EditUserForm({ user }: { user: User }) {
         className="w-full border px-2 py-1"
         value={name}
         onChange={(e) => setName(e.target.value)}
-        placeholder="Name"
+        placeholder="Nombre"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={lastName}
+        onChange={(e) => setLastName(e.target.value)}
+        placeholder="Apellido"
       />
       {canEditRole && (
         <select

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -10,12 +10,15 @@ export default async function EditUserPage({
   params: { id: string };
 }) {
   const session = await getServerSession(authOptions);
-  if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')) {
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
     redirect('/');
   }
   const user = await prisma.user.findUnique({
     where: { id: params.id },
-    select: { id: true, name: true, email: true, role: true },
+    select: { id: true, name: true, lastName: true, email: true, role: true },
   });
   if (!user) {
     redirect('/admin/users');

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -7,12 +7,15 @@ import DeleteUserButton from './delete-button';
 
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
-  if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')) {
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
     redirect('/');
   }
 
   const users = await prisma.user.findMany({
-    select: { id: true, name: true, email: true, role: true },
+    select: { id: true, name: true, lastName: true, email: true, role: true },
   });
 
   return (
@@ -22,7 +25,7 @@ export default async function UsersPage() {
         {users.map((u) => (
           <li key={u.id} className="flex items-center gap-2">
             <span className="flex-1">
-              {u.name ?? 'Unnamed'} ({u.email}) - {u.role}
+              {u.name} {u.lastName} ({u.email}) - {u.role}
             </span>
             <Link
               href={`/admin/users/${u.id}/view`}

--- a/src/app/api/activities/[id]/checkout/route.ts
+++ b/src/app/api/activities/[id]/checkout/route.ts
@@ -12,6 +12,8 @@ export async function GET(
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+  const searchParams = new URL(req.url).searchParams;
+  const childId = searchParams.get('childId');
   const activity: any = await prisma.activity.findUnique({
     where: { id: params.id },
   });
@@ -33,11 +35,11 @@ export async function GET(
           unit_price: Number(activity.price),
         },
       ],
-      back_urls: {
-        success: `${process.env.NEXTAUTH_URL}/activities/${activity.id}`,
-        failure: `${process.env.NEXTAUTH_URL}/activities/${activity.id}`,
-        pending: `${process.env.NEXTAUTH_URL}/activities/${activity.id}`,
-      },
+      back_urls: (() => {
+        const base = `${process.env.NEXTAUTH_URL}/activities/${activity.id}`;
+        const url = childId ? `${base}?childId=${childId}` : base;
+        return { success: url, failure: url, pending: url };
+      })(),
       auto_return: 'approved',
     },
   });

--- a/src/app/api/activities/[id]/payment/route.ts
+++ b/src/app/api/activities/[id]/payment/route.ts
@@ -13,7 +13,7 @@ export async function POST(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { paymentId } = await req.json();
+  const { paymentId, childId } = await req.json();
   if (!paymentId) {
     return NextResponse.json({ error: 'Missing paymentId' }, { status: 400 });
   }
@@ -28,14 +28,16 @@ export async function POST(
 
   await prisma.activityParticipant.upsert({
     where: {
-      activityId_userId: {
+      activityId_userId_childId: {
         activityId: params.id,
         userId: (session.user as any).id,
+        childId: childId ?? null,
       },
     },
     create: {
       activityId: params.id,
       userId: (session.user as any).id,
+      childId: childId ?? null,
       receipt,
       receiptDate: new Date(date),
     },

--- a/src/app/api/children/route.ts
+++ b/src/app/api/children/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { childCreateSchema } from '@/lib/validations/child';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const children = await prisma.child.findMany({
+    where: { userId: (session.user as any).id },
+    select: { id: true, name: true, birthDate: true },
+  });
+  return NextResponse.json(children);
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = childCreateSchema.parse(await req.json());
+  const child = await prisma.child.create({
+    data: {
+      userId: (session.user as any).id,
+      name: data.name,
+      birthDate: data.birthDate ? new Date(data.birthDate) : null,
+    },
+    select: { id: true, name: true, birthDate: true },
+  });
+  return NextResponse.json(child);
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -25,8 +25,29 @@ export async function PATCH(req: Request) {
     }
   }
 
+  if (data.dni) {
+    const existingDni = await prisma.user.findUnique({
+      where: { dni: data.dni },
+    });
+    if (existingDni && existingDni.id !== session.user.id) {
+      return NextResponse.json(
+        { error: 'DNI already in use' },
+        { status: 400 }
+      );
+    }
+  }
+
   const updateData: any = {};
   if (data.name !== undefined) updateData.name = data.name;
+  if (data.lastName !== undefined) updateData.lastName = data.lastName;
+  if (data.dni !== undefined) updateData.dni = data.dni;
+  if (data.birthDate !== undefined)
+    updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
+  if (data.gender !== undefined) updateData.gender = data.gender;
+  if (data.address !== undefined) updateData.address = data.address;
+  if (data.nationality !== undefined) updateData.nationality = data.nationality;
+  if (data.maritalStatus !== undefined)
+    updateData.maritalStatus = data.maritalStatus;
   if (data.email !== undefined) updateData.email = data.email;
   if (data.password !== undefined) {
     updateData.password = await hash(data.password, 12);
@@ -35,7 +56,18 @@ export async function PATCH(req: Request) {
   const user = await prisma.user.update({
     where: { id: (session.user as any).id },
     data: updateData,
-    select: { id: true, email: true, name: true },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      lastName: true,
+      dni: true,
+      birthDate: true,
+      gender: true,
+      address: true,
+      nationality: true,
+      maritalStatus: true,
+    },
   });
 
   return NextResponse.json(user);

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -9,7 +9,10 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')) {
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
@@ -19,11 +22,12 @@ export async function PATCH(
   }
   const updateData: any = {};
   if (data.name !== undefined) updateData.name = data.name;
+  if (data.lastName !== undefined) updateData.lastName = data.lastName;
   if (data.role !== undefined) updateData.role = data.role;
   const user = await prisma.user.update({
     where: { id: params.id },
     data: updateData,
-    select: { id: true, email: true, name: true, role: true },
+    select: { id: true, email: true, name: true, lastName: true, role: true },
   });
 
   return NextResponse.json(user);
@@ -34,7 +38,10 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   const session = await getServerSession(authOptions);
-  if (!session || (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')) {
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -10,7 +10,7 @@ export async function GET() {
   }
 
   const users = await prisma.user.findMany({
-    select: { id: true, name: true, role: true },
+    select: { id: true, name: true, lastName: true, role: true },
   });
 
   return NextResponse.json(users);

--- a/src/app/profile/children.tsx
+++ b/src/app/profile/children.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+type Child = { id: string; name: string; birthDate: string | null };
+
+export default function ChildrenManager() {
+  const [children, setChildren] = useState<Child[]>([]);
+  const [name, setName] = useState('');
+  const [birthDate, setBirthDate] = useState('');
+
+  useEffect(() => {
+    fetch('/api/children')
+      .then((res) => res.json())
+      .then((data) => setChildren(data));
+  }, []);
+
+  async function addChild(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch('/api/children', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, birthDate }),
+    });
+    if (res.ok) {
+      const child = await res.json();
+      setChildren([...children, child]);
+      setName('');
+      setBirthDate('');
+    }
+  }
+
+  return (
+    <div className="mt-6 space-y-2 max-w-sm">
+      <h2 className="text-xl font-semibold">Hijos</h2>
+      <ul className="list-disc pl-4">
+        {children.map((c) => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+      <form onSubmit={addChild} className="space-y-2">
+        <input
+          className="w-full border px-2 py-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nombre"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          placeholder="Fecha de nacimiento"
+        />
+        <Button type="submit" className="w-full">
+          Agregar hijo
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -4,10 +4,27 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
-type User = { name: string | null; email: string };
+type User = {
+  name: string | null;
+  lastName: string | null;
+  dni: string | null;
+  birthDate: string | null;
+  gender: string | null;
+  address: string | null;
+  nationality: string | null;
+  maritalStatus: string | null;
+  email: string;
+};
 
 export default function ProfileForm({ user }: { user: User }) {
   const [name, setName] = useState(user.name ?? '');
+  const [lastName, setLastName] = useState(user.lastName ?? '');
+  const [dni, setDni] = useState(user.dni ?? '');
+  const [birthDate, setBirthDate] = useState(user.birthDate ?? '');
+  const [gender, setGender] = useState(user.gender ?? '');
+  const [address, setAddress] = useState(user.address ?? '');
+  const [nationality, setNationality] = useState(user.nationality ?? '');
+  const [maritalStatus, setMaritalStatus] = useState(user.maritalStatus ?? '');
   const [email, setEmail] = useState(user.email);
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -24,6 +41,13 @@ export default function ProfileForm({ user }: { user: User }) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           name,
+          lastName,
+          dni,
+          birthDate,
+          gender: gender || undefined,
+          address,
+          nationality,
+          maritalStatus,
           email,
           ...(password ? { password } : {}),
         }),
@@ -43,7 +67,56 @@ export default function ProfileForm({ user }: { user: User }) {
         className="w-full border px-2 py-1"
         value={name}
         onChange={(e) => setName(e.target.value)}
-        placeholder="Name"
+        placeholder="Nombre"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={lastName}
+        onChange={(e) => setLastName(e.target.value)}
+        placeholder="Apellido"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={dni}
+        onChange={(e) => setDni(e.target.value)}
+        placeholder="DNI"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        type="date"
+        value={birthDate}
+        onChange={(e) => setBirthDate(e.target.value)}
+        placeholder="Fecha de nacimiento"
+      />
+      <select
+        className="w-full border px-2 py-1"
+        value={gender}
+        onChange={(e) => setGender(e.target.value)}
+      >
+        <option value="">Género</option>
+        <option value="FEMALE">Femenino</option>
+        <option value="MALE">Masculino</option>
+        <option value="NON_BINARY">No Binario</option>
+        <option value="UNDISCLOSED">Prefiero no decirlo</option>
+        <option value="OTHER">Otro</option>
+      </select>
+      <input
+        className="w-full border px-2 py-1"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        placeholder="Domicilio"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={nationality}
+        onChange={(e) => setNationality(e.target.value)}
+        placeholder="Nacionalidad"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={maritalStatus}
+        onChange={(e) => setMaritalStatus(e.target.value)}
+        placeholder="Estado Civil"
       />
       <input
         className="w-full border px-2 py-1"

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import ProfileForm from './form';
+import ChildrenManager from './children';
 
 export default async function ProfilePage() {
   const session = await getServerSession(authOptions);
@@ -11,7 +12,17 @@ export default async function ProfilePage() {
   }
   const user = await prisma.user.findUnique({
     where: { id: (session.user as any).id },
-    select: { name: true, email: true },
+    select: {
+      name: true,
+      lastName: true,
+      dni: true,
+      birthDate: true,
+      gender: true,
+      address: true,
+      nationality: true,
+      maritalStatus: true,
+      email: true,
+    },
   });
   if (!user) {
     redirect('/');
@@ -19,7 +30,15 @@ export default async function ProfilePage() {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Profile</h1>
-      <ProfileForm user={user} />
+      <ProfileForm
+        user={{
+          ...user,
+          birthDate: user.birthDate
+            ? user.birthDate.toISOString().split('T')[0]
+            : null,
+        }}
+      />
+      <ChildrenManager />
     </div>
   );
 }

--- a/src/lib/validations/child.ts
+++ b/src/lib/validations/child.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod';
+
+export const childCreateSchema = z.object({
+  name: z.string().min(1),
+  birthDate: z.string().optional(),
+});

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -2,6 +2,15 @@ import { z } from 'zod';
 
 export const profileUpdateSchema = z.object({
   name: z.string().optional(),
+  lastName: z.string().optional(),
+  dni: z.string().optional(),
+  birthDate: z.string().optional(),
+  gender: z
+    .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])
+    .optional(),
+  address: z.string().optional(),
+  nationality: z.string().optional(),
+  maritalStatus: z.string().optional(),
   email: z.string().email().optional(),
   password: z.string().min(6).optional(),
 });

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -2,5 +2,6 @@ import { z } from 'zod';
 
 export const userUpdateSchema = z.object({
   name: z.string().optional(),
+  lastName: z.string().optional(),
   role: z.enum(['ADMIN', 'MEMBER', 'SUPER_ADMIN']).optional(),
 });


### PR DESCRIPTION
## Summary
- extend user profiles with personal data fields and gender enum
- allow parents to manage children and register them for activities
- track child-specific activity payments

## Testing
- `npm run lint` *(fails: prettier warnings for existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68a77c4920ec8333a280718292e85a0d