### PR TITLE
Restrict normal admins from system settings

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,7 +6,11 @@ export async function middleware(req: NextRequest) {
   const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
   const { pathname } = req.nextUrl;
 
-  if (pathname.startsWith('/admin')) {
+  if (pathname.startsWith('/admin/site')) {
+    if (!token || token.role !== 'SUPER_ADMIN') {
+      return NextResponse.redirect(new URL('/', req.url));
+    }
+  } else if (pathname.startsWith('/admin')) {
     if (!token || (token.role !== 'ADMIN' && token.role !== 'SUPER_ADMIN')) {
       return NextResponse.redirect(new URL('/', req.url));
     }


### PR DESCRIPTION
## Summary
- block non-super admins from `/admin/site` in middleware

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79c90e2e083339c2d6c7a4b53c8ed