### PR TITLE
Fix admin session handling for protected routes

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,7 +19,12 @@ export const authOptions: NextAuthOptions = {
         if (!user || !user.password || !user.isActive) return null;
         const valid = await compare(credentials.password, user.password);
         if (!valid) return null;
-        return { id: user.id, email: user.email, name: user.name, role: user.role };
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        };
       },
     }),
   ],
@@ -28,7 +33,10 @@ export const authOptions: NextAuthOptions = {
   },
   cookies: {
     sessionToken: {
-      name: `__Secure-next-auth.session-token`,
+      name:
+        process.env.NODE_ENV === 'production'
+          ? '__Secure-next-auth.session-token'
+          : 'next-auth.session-token',
       options: {
         httpOnly: true,
         sameSite: 'lax',

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,7 +3,7 @@ import type { NextRequest } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 
 export async function middleware(req: NextRequest) {
-  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const token = await getToken({ req });
   const { pathname } = req.nextUrl;
 
   if (pathname.startsWith('/admin/site')) {


### PR DESCRIPTION
## Summary
- Use environment-specific session cookie names so admin sessions work outside production
- Simplify middleware token lookup for admin routes

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz; Proxy response 403)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7df15aedc8333a5022e16976ad886