### PR TITLE
Ensure admins can access forms section

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,7 +10,7 @@ export async function middleware(req: NextRequest) {
     if (!token || token.role !== 'SUPER_ADMIN') {
       return NextResponse.redirect(new URL('/', req.url));
     }
-  } else if (pathname.startsWith('/admin')) {
+  } else if (pathname.startsWith('/admin') || pathname.startsWith('/forms')) {
     if (!token || (token.role !== 'ADMIN' && token.role !== 'SUPER_ADMIN')) {
       return NextResponse.redirect(new URL('/', req.url));
     }
@@ -26,5 +26,5 @@ export async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/admin/:path*', '/members/:path*'],
+  matcher: ['/admin/:path*', '/members/:path*', '/forms/:path*'],
 };


### PR DESCRIPTION
## Summary
- Allow ADMIN and SUPER_ADMIN roles to reach `/forms` by expanding middleware checks

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68a7e04946b08333b0726b099bfede5f