### PR TITLE
feat: add child enrollment management for users

### DIFF
--- a/src/app/admin/users/[id]/child-enrollment/children.tsx
+++ b/src/app/admin/users/[id]/child-enrollment/children.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+type Child = { id: string; name: string; birthDate: string | null };
+
+export default function AdminChildrenManager({ userId }: { userId: string }) {
+  const [children, setChildren] = useState<Child[]>([]);
+  const [name, setName] = useState('');
+  const [birthDate, setBirthDate] = useState('');
+
+  useEffect(() => {
+    fetch(`/api/users/${userId}/children`)
+      .then((res) => res.json())
+      .then((data) => setChildren(data));
+  }, [userId]);
+
+  async function addChild(e: React.FormEvent) {
+    e.preventDefault();
+    const res = await fetch(`/api/users/${userId}/children`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, birthDate }),
+    });
+    if (res.ok) {
+      const child = await res.json();
+      setChildren([...children, child]);
+      setName('');
+      setBirthDate('');
+    }
+  }
+
+  return (
+    <div className="space-y-2 max-w-sm">
+      <ul className="list-disc pl-4">
+        {children.map((c) => (
+          <li key={c.id}>{c.name}</li>
+        ))}
+      </ul>
+      <form onSubmit={addChild} className="space-y-2">
+        <input
+          className="w-full border px-2 py-1"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nombre"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          placeholder="Fecha de nacimiento"
+        />
+        <Button type="submit" className="w-full">
+          Agregar hijo
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/src/app/admin/users/[id]/child-enrollment/page.tsx
+++ b/src/app/admin/users/[id]/child-enrollment/page.tsx
@@ -1,0 +1,24 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import AdminChildrenManager from './children';
+
+export default async function ChildEnrollmentPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
+    redirect('/');
+  }
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Child Enrollment</h1>
+      <AdminChildrenManager userId={params.id} />
+    </div>
+  );
+}

--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -11,11 +11,28 @@ type User = {
   lastName: string | null;
   email: string;
   role: string;
+  dni: string | null;
+  birthDate: string | null;
+  gender: string | null;
+  address: string | null;
+  nationality: string | null;
+  maritalStatus: string | null;
+  isActive: boolean;
 };
 
 export default function EditUserForm({ user }: { user: User }) {
   const [name, setName] = useState(user.name ?? '');
   const [lastName, setLastName] = useState(user.lastName ?? '');
+  const [dni, setDni] = useState(user.dni ?? '');
+  const [birthDate, setBirthDate] = useState(user.birthDate ?? '');
+  const [gender, setGender] = useState(user.gender ?? '');
+  const [address, setAddress] = useState(user.address ?? '');
+  const [nationality, setNationality] = useState(user.nationality ?? '');
+  const [maritalStatus, setMaritalStatus] = useState(
+    user.maritalStatus ?? ''
+  );
+  const [email, setEmail] = useState(user.email);
+  const [isActive, setIsActive] = useState(user.isActive);
   const [role, setRole] = useState(user.role);
   const router = useRouter();
   const [error, setError] = useState('');
@@ -28,7 +45,18 @@ export default function EditUserForm({ user }: { user: User }) {
     setError('');
     setSuccess('');
     try {
-      const body: any = { name, lastName };
+      const body: any = {
+        name,
+        lastName,
+        dni,
+        birthDate,
+        gender: gender || undefined,
+        address,
+        nationality,
+        maritalStatus,
+        email,
+        isActive,
+      };
       if (canEditRole) body.role = role;
       const res = await fetch(`/api/users/${user.id}`, {
         method: 'PATCH',
@@ -60,6 +88,63 @@ export default function EditUserForm({ user }: { user: User }) {
         onChange={(e) => setLastName(e.target.value)}
         placeholder="Apellido"
       />
+      <input
+        className="w-full border px-2 py-1"
+        value={dni}
+        onChange={(e) => setDni(e.target.value)}
+        placeholder="DNI"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        type="date"
+        value={birthDate}
+        onChange={(e) => setBirthDate(e.target.value)}
+        placeholder="Fecha de nacimiento"
+      />
+      <select
+        className="w-full border px-2 py-1"
+        value={gender}
+        onChange={(e) => setGender(e.target.value)}
+      >
+        <option value="">Género</option>
+        <option value="FEMALE">Femenino</option>
+        <option value="MALE">Masculino</option>
+        <option value="NON_BINARY">No Binario</option>
+        <option value="UNDISCLOSED">Prefiero no decirlo</option>
+        <option value="OTHER">Otro</option>
+      </select>
+      <input
+        className="w-full border px-2 py-1"
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        placeholder="Domicilio"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={nationality}
+        onChange={(e) => setNationality(e.target.value)}
+        placeholder="Nacionalidad"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={maritalStatus}
+        onChange={(e) => setMaritalStatus(e.target.value)}
+        placeholder="Estado Civil"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        placeholder="Email"
+      />
+      <label className="text-sm flex items-center space-x-1">
+        <input
+          type="checkbox"
+          checked={isActive}
+          onChange={(e) => setIsActive(e.target.checked)}
+        />
+        <span>Active</span>
+      </label>
       {canEditRole && (
         <select
           className="w-full border px-2 py-1"

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -18,7 +18,20 @@ export default async function EditUserPage({
   }
   const user = await prisma.user.findUnique({
     where: { id: params.id },
-    select: { id: true, name: true, lastName: true, email: true, role: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      email: true,
+      role: true,
+      dni: true,
+      birthDate: true,
+      gender: true,
+      address: true,
+      nationality: true,
+      maritalStatus: true,
+      isActive: true,
+    },
   });
   if (!user) {
     redirect('/admin/users');
@@ -27,7 +40,14 @@ export default async function EditUserPage({
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Edit User</h1>
-      <EditUserForm user={user} />
+      <EditUserForm
+        user={{
+          ...user,
+          birthDate: user.birthDate
+            ? user.birthDate.toISOString().split('T')[0]
+            : null,
+        }}
+      />
     </div>
   );
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -39,6 +39,12 @@ export default async function UsersPage() {
             >
               Edit
             </Link>
+            <Link
+              href={`/admin/users/${u.id}/child-enrollment`}
+              className="text-blue-600 hover:underline"
+            >
+              Child enrollment
+            </Link>
             <DeleteUserButton id={u.id} />
           </li>
         ))}

--- a/src/app/api/users/[id]/children/route.ts
+++ b/src/app/api/users/[id]/children/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { childCreateSchema } from '@/lib/validations/child';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const children = await prisma.child.findMany({
+    where: { userId: params.id },
+    select: { id: true, name: true, birthDate: true },
+  });
+  return NextResponse.json(children);
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const data = childCreateSchema.parse(await req.json());
+  const child = await prisma.child.create({
+    data: {
+      userId: params.id,
+      name: data.name,
+      birthDate: data.birthDate ? new Date(data.birthDate) : null,
+    },
+    select: { id: true, name: true, birthDate: true },
+  });
+  return NextResponse.json(child);
+}

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -20,14 +20,57 @@ export async function PATCH(
   if (data.role && session.user.role !== 'SUPER_ADMIN') {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  if (data.email) {
+    const existing = await prisma.user.findUnique({
+      where: { email: data.email },
+    });
+    if (existing && existing.id !== params.id) {
+      return NextResponse.json({ error: 'Email already in use' }, { status: 400 });
+    }
+  }
+
+  if (data.dni) {
+    const existingDni = await prisma.user.findUnique({
+      where: { dni: data.dni },
+    });
+    if (existingDni && existingDni.id !== params.id) {
+      return NextResponse.json({ error: 'DNI already in use' }, { status: 400 });
+    }
+  }
+
   const updateData: any = {};
   if (data.name !== undefined) updateData.name = data.name;
   if (data.lastName !== undefined) updateData.lastName = data.lastName;
+  if (data.dni !== undefined) updateData.dni = data.dni;
+  if (data.birthDate !== undefined)
+    updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
+  if (data.gender !== undefined) updateData.gender = data.gender;
+  if (data.address !== undefined) updateData.address = data.address;
+  if (data.nationality !== undefined) updateData.nationality = data.nationality;
+  if (data.maritalStatus !== undefined)
+    updateData.maritalStatus = data.maritalStatus;
+  if (data.email !== undefined) updateData.email = data.email;
+  if (data.isActive !== undefined) updateData.isActive = data.isActive;
   if (data.role !== undefined) updateData.role = data.role;
+
   const user = await prisma.user.update({
     where: { id: params.id },
     data: updateData,
-    select: { id: true, email: true, name: true, lastName: true, role: true },
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      lastName: true,
+      role: true,
+      dni: true,
+      birthDate: true,
+      gender: true,
+      address: true,
+      nationality: true,
+      maritalStatus: true,
+      isActive: true,
+    },
   });
 
   return NextResponse.json(user);

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -3,5 +3,15 @@ import { z } from 'zod';
 export const userUpdateSchema = z.object({
   name: z.string().optional(),
   lastName: z.string().optional(),
+  dni: z.string().optional(),
+  birthDate: z.string().optional(),
+  gender: z
+    .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])
+    .optional(),
+  address: z.string().optional(),
+  nationality: z.string().optional(),
+  maritalStatus: z.string().optional(),
+  email: z.string().email().optional(),
   role: z.enum(['ADMIN', 'MEMBER', 'SUPER_ADMIN']).optional(),
+  isActive: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- add child enrollment link in admin user list
- allow admin to manage children for users
- extend admin user editing with full profile fields

## Testing
- ⚠️ `pnpm lint` *(failed: Error when performing request to pnpm registry, Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68a9ee5c423483338ca409c12cfbc0da