### PR TITLE
feat: allow admins to reset user passwords

### DIFF
--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import DeleteUserButton from './delete-button';
+import ResetPasswordButton from './reset-password-button';
 
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
@@ -45,6 +46,7 @@ export default async function UsersPage() {
             >
               Child enrollment
             </Link>
+            <ResetPasswordButton id={u.id} />
             <DeleteUserButton id={u.id} />
           </li>
         ))}

--- a/src/app/admin/users/reset-password-button.tsx
+++ b/src/app/admin/users/reset-password-button.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+
+export default function ResetPasswordButton({ id }: { id: string }) {
+  const router = useRouter();
+
+  async function reset() {
+    const res = await fetch(`/api/users/${id}/reset-password`, { method: 'POST' });
+    if (res.ok) {
+      const data = await res.json();
+      alert(`New password: ${data.password}`);
+      router.refresh();
+    }
+  }
+
+  return (
+    <Button onClick={reset} className="bg-yellow-600 hover:bg-yellow-700">
+      Reset password
+    </Button>
+  );
+}

--- a/src/app/api/users/[id]/reset-password/route.ts
+++ b/src/app/api/users/[id]/reset-password/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { randomBytes } from 'crypto';
+import { hash } from 'bcrypt';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const newPassword = randomBytes(6).toString('base64url');
+  const hashed = await hash(newPassword, 12);
+
+  await prisma.user.update({
+    where: { id: params.id },
+    data: { password: hashed },
+  });
+
+  return NextResponse.json({ password: newPassword });
+}


### PR DESCRIPTION
## Summary
- enable admins to reset user passwords from the user list
- display new password to admin immediately after reset

## Testing
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68a9fef8e5c48333a1c3dbfab4c851a6