### PR TITLE
Normalize email case on registration and login

### DIFF
--- a/src/app/api/register/route.ts
+++ b/src/app/api/register/route.ts
@@ -5,7 +5,8 @@ import { registerSchema } from '@/lib/validations/auth';
 
 export async function POST(req: Request) {
   const data = await req.json();
-  const { email, password, name } = registerSchema.parse(data);
+  const { email: rawEmail, password, name } = registerSchema.parse(data);
+  const email = rawEmail.toLowerCase();
   const existing = await prisma.user.findUnique({ where: { email } });
   if (existing) {
     return NextResponse.json({ error: 'User already exists' }, { status: 400 });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -17,7 +17,7 @@ export default function LoginPage() {
     setError('');
     setSuccess('');
     const res = await signIn('credentials', {
-      email,
+      email: email.toLowerCase(),
       password,
       redirect: false,
     });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,8 +13,9 @@ export const authOptions: NextAuthOptions = {
       },
       async authorize(credentials) {
         if (!credentials?.email || !credentials?.password) return null;
+        const email = credentials.email.toLowerCase();
         const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
+          where: { email },
         });
         if (!user || !user.password || !user.isActive) return null;
         const valid = await compare(credentials.password, user.password);

--- a/src/lib/validations/auth.ts
+++ b/src/lib/validations/auth.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 
 export const loginSchema = z.object({
-  email: z.string().email(),
+  email: z.string().email().toLowerCase(),
   password: z.string().min(1),
 });
 
 export const registerSchema = z.object({
-  email: z.string().email(),
+  email: z.string().email().toLowerCase(),
   password: z.string().min(6),
   name: z.string().optional(),
 });


### PR DESCRIPTION
## Summary
- enforce lowercase emails in auth validation schema
- store and query emails in lowercase during registration and login
- send lowercase emails from login form

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68aa08f8bf3c833390230f0df2ab0791