### PR TITLE
feat: extend user and child data

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,6 +16,8 @@ model User {
   birthDate           DateTime?
   gender              Gender?
   address             String?
+  phone               String?
+  observations        String?
   nationality         String?
   maritalStatus       String?
   password            String
@@ -129,7 +131,15 @@ model Child {
   userId    String
   user      User     @relation(fields: [userId], references: [id])
   name      String
+  lastName  String?
+  documentType   String?
+  documentNumber String?
   birthDate DateTime?
+  address   String?
+  gender    Gender?
+  nationality String?
+  maritalStatus String?
+  observations String?
   createdAt DateTime @default(now())
   activityParticipants ActivityParticipant[]
 }

--- a/src/app/admin/users/[id]/child-enrollment/children.tsx
+++ b/src/app/admin/users/[id]/child-enrollment/children.tsx
@@ -3,12 +3,32 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
-type Child = { id: string; name: string; birthDate: string | null };
+type Child = {
+  id: string;
+  name: string;
+  lastName: string | null;
+  documentType: string | null;
+  documentNumber: string | null;
+  birthDate: string | null;
+  address: string | null;
+  gender: string | null;
+  nationality: string | null;
+  maritalStatus: string | null;
+  observations: string | null;
+};
 
 export default function AdminChildrenManager({ userId }: { userId: string }) {
   const [children, setChildren] = useState<Child[]>([]);
   const [name, setName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [documentType, setDocumentType] = useState('');
+  const [documentNumber, setDocumentNumber] = useState('');
   const [birthDate, setBirthDate] = useState('');
+  const [address, setAddress] = useState('');
+  const [gender, setGender] = useState('');
+  const [nationality, setNationality] = useState('');
+  const [maritalStatus, setMaritalStatus] = useState('');
+  const [observations, setObservations] = useState('');
 
   useEffect(() => {
     fetch(`/api/users/${userId}/children`)
@@ -21,13 +41,32 @@ export default function AdminChildrenManager({ userId }: { userId: string }) {
     const res = await fetch(`/api/users/${userId}/children`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, birthDate }),
+      body: JSON.stringify({
+        name,
+        lastName,
+        documentType,
+        documentNumber,
+        birthDate,
+        address,
+        gender: gender || undefined,
+        nationality,
+        maritalStatus,
+        observations,
+      }),
     });
     if (res.ok) {
       const child = await res.json();
       setChildren([...children, child]);
       setName('');
+      setLastName('');
+      setDocumentType('');
+      setDocumentNumber('');
       setBirthDate('');
+      setAddress('');
+      setGender('');
+      setNationality('');
+      setMaritalStatus('');
+      setObservations('');
     }
   }
 
@@ -47,10 +86,64 @@ export default function AdminChildrenManager({ userId }: { userId: string }) {
         />
         <input
           className="w-full border px-2 py-1"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Apellido"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={documentType}
+          onChange={(e) => setDocumentType(e.target.value)}
+          placeholder="Tipo de documento"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={documentNumber}
+          onChange={(e) => setDocumentNumber(e.target.value)}
+          placeholder="Número / Código"
+        />
+        <input
+          className="w-full border px-2 py-1"
           type="date"
           value={birthDate}
           onChange={(e) => setBirthDate(e.target.value)}
           placeholder="Fecha de nacimiento"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          placeholder="Domicilio"
+        />
+        <select
+          className="w-full border px-2 py-1"
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+        >
+          <option value="">Género</option>
+          <option value="FEMALE">Femenino</option>
+          <option value="MALE">Masculino</option>
+          <option value="NON_BINARY">No Binario</option>
+          <option value="UNDISCLOSED">Prefiero no decirlo</option>
+          <option value="OTHER">Otro</option>
+        </select>
+        <input
+          className="w-full border px-2 py-1"
+          value={nationality}
+          onChange={(e) => setNationality(e.target.value)}
+          placeholder="Nacionalidad"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={maritalStatus}
+          onChange={(e) => setMaritalStatus(e.target.value)}
+          placeholder="Estado Civil"
+        />
+        <textarea
+          className="w-full border px-2 py-1"
+          value={observations}
+          onChange={(e) => setObservations(e.target.value)}
+          placeholder="Observaciones"
         />
         <Button type="submit" className="w-full">
           Agregar hijo

--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -15,9 +15,11 @@ type User = {
   birthDate: string | null;
   gender: string | null;
   address: string | null;
+  phone: string | null;
   nationality: string | null;
   maritalStatus: string | null;
   isActive: boolean;
+  observations: string | null;
 };
 
 export default function EditUserForm({ user }: { user: User }) {
@@ -27,13 +29,13 @@ export default function EditUserForm({ user }: { user: User }) {
   const [birthDate, setBirthDate] = useState(user.birthDate ?? '');
   const [gender, setGender] = useState(user.gender ?? '');
   const [address, setAddress] = useState(user.address ?? '');
+  const [phone, setPhone] = useState(user.phone ?? '');
   const [nationality, setNationality] = useState(user.nationality ?? '');
-  const [maritalStatus, setMaritalStatus] = useState(
-    user.maritalStatus ?? ''
-  );
+  const [maritalStatus, setMaritalStatus] = useState(user.maritalStatus ?? '');
   const [email, setEmail] = useState(user.email);
   const [isActive, setIsActive] = useState(user.isActive);
   const [role, setRole] = useState(user.role);
+  const [observations, setObservations] = useState(user.observations ?? '');
   const router = useRouter();
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -52,10 +54,12 @@ export default function EditUserForm({ user }: { user: User }) {
         birthDate,
         gender: gender || undefined,
         address,
+        phone,
         nationality,
         maritalStatus,
         email,
         isActive,
+        observations,
       };
       if (canEditRole) body.role = role;
       const res = await fetch(`/api/users/${user.id}`, {
@@ -121,6 +125,12 @@ export default function EditUserForm({ user }: { user: User }) {
       />
       <input
         className="w-full border px-2 py-1"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Teléfono"
+      />
+      <input
+        className="w-full border px-2 py-1"
         value={nationality}
         onChange={(e) => setNationality(e.target.value)}
         placeholder="Nacionalidad"
@@ -130,6 +140,12 @@ export default function EditUserForm({ user }: { user: User }) {
         value={maritalStatus}
         onChange={(e) => setMaritalStatus(e.target.value)}
         placeholder="Estado Civil"
+      />
+      <textarea
+        className="w-full border px-2 py-1"
+        value={observations}
+        onChange={(e) => setObservations(e.target.value)}
+        placeholder="Observaciones"
       />
       <input
         className="w-full border px-2 py-1"

--- a/src/app/admin/users/[id]/page.tsx
+++ b/src/app/admin/users/[id]/page.tsx
@@ -28,9 +28,11 @@ export default async function EditUserPage({
       birthDate: true,
       gender: true,
       address: true,
+      phone: true,
       nationality: true,
       maritalStatus: true,
       isActive: true,
+      observations: true,
     },
   });
   if (!user) {

--- a/src/app/admin/users/[id]/view/page.tsx
+++ b/src/app/admin/users/[id]/view/page.tsx
@@ -49,6 +49,8 @@ export default async function ViewUserPage({
           {user.name} {user.lastName}
         </h1>
         <p>Email: {user.email}</p>
+        {user.phone && <p>Phone: {user.phone}</p>}
+        {user.observations && <p>Observaciones: {user.observations}</p>}
         <p>Role: {user.role}</p>
       </div>
 

--- a/src/app/api/children/route.ts
+++ b/src/app/api/children/route.ts
@@ -11,7 +11,18 @@ export async function GET() {
   }
   const children = await prisma.child.findMany({
     where: { userId: (session.user as any).id },
-    select: { id: true, name: true, birthDate: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      documentType: true,
+      documentNumber: true,
+      birthDate: true,
+      address: true,
+      gender: true,
+      nationality: true,
+      maritalStatus: true,
+    },
   });
   return NextResponse.json(children);
 }
@@ -26,9 +37,27 @@ export async function POST(req: Request) {
     data: {
       userId: (session.user as any).id,
       name: data.name,
+      lastName: data.lastName,
+      documentType: data.documentType,
+      documentNumber: data.documentNumber,
       birthDate: data.birthDate ? new Date(data.birthDate) : null,
+      address: data.address,
+      gender: data.gender,
+      nationality: data.nationality,
+      maritalStatus: data.maritalStatus,
     },
-    select: { id: true, name: true, birthDate: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      documentType: true,
+      documentNumber: true,
+      birthDate: true,
+      address: true,
+      gender: true,
+      nationality: true,
+      maritalStatus: true,
+    },
   });
   return NextResponse.json(child);
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -45,6 +45,7 @@ export async function PATCH(req: Request) {
     updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
   if (data.gender !== undefined) updateData.gender = data.gender;
   if (data.address !== undefined) updateData.address = data.address;
+  if (data.phone !== undefined) updateData.phone = data.phone;
   if (data.nationality !== undefined) updateData.nationality = data.nationality;
   if (data.maritalStatus !== undefined)
     updateData.maritalStatus = data.maritalStatus;
@@ -65,6 +66,7 @@ export async function PATCH(req: Request) {
       birthDate: true,
       gender: true,
       address: true,
+      phone: true,
       nationality: true,
       maritalStatus: true,
     },

--- a/src/app/api/users/[id]/children/route.ts
+++ b/src/app/api/users/[id]/children/route.ts
@@ -17,7 +17,19 @@ export async function GET(
   }
   const children = await prisma.child.findMany({
     where: { userId: params.id },
-    select: { id: true, name: true, birthDate: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      documentType: true,
+      documentNumber: true,
+      birthDate: true,
+      address: true,
+      gender: true,
+      nationality: true,
+      maritalStatus: true,
+      observations: true,
+    },
   });
   return NextResponse.json(children);
 }
@@ -38,9 +50,29 @@ export async function POST(
     data: {
       userId: params.id,
       name: data.name,
+      lastName: data.lastName,
+      documentType: data.documentType,
+      documentNumber: data.documentNumber,
       birthDate: data.birthDate ? new Date(data.birthDate) : null,
+      address: data.address,
+      gender: data.gender,
+      nationality: data.nationality,
+      maritalStatus: data.maritalStatus,
+      observations: data.observations,
     },
-    select: { id: true, name: true, birthDate: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      documentType: true,
+      documentNumber: true,
+      birthDate: true,
+      address: true,
+      gender: true,
+      nationality: true,
+      maritalStatus: true,
+      observations: true,
+    },
   });
   return NextResponse.json(child);
 }

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -26,7 +26,10 @@ export async function PATCH(
       where: { email: data.email },
     });
     if (existing && existing.id !== params.id) {
-      return NextResponse.json({ error: 'Email already in use' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'Email already in use' },
+        { status: 400 }
+      );
     }
   }
 
@@ -35,7 +38,10 @@ export async function PATCH(
       where: { dni: data.dni },
     });
     if (existingDni && existingDni.id !== params.id) {
-      return NextResponse.json({ error: 'DNI already in use' }, { status: 400 });
+      return NextResponse.json(
+        { error: 'DNI already in use' },
+        { status: 400 }
+      );
     }
   }
 
@@ -47,9 +53,12 @@ export async function PATCH(
     updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
   if (data.gender !== undefined) updateData.gender = data.gender;
   if (data.address !== undefined) updateData.address = data.address;
+  if (data.phone !== undefined) updateData.phone = data.phone;
   if (data.nationality !== undefined) updateData.nationality = data.nationality;
   if (data.maritalStatus !== undefined)
     updateData.maritalStatus = data.maritalStatus;
+  if (data.observations !== undefined)
+    updateData.observations = data.observations;
   if (data.email !== undefined) updateData.email = data.email;
   if (data.isActive !== undefined) updateData.isActive = data.isActive;
   if (data.role !== undefined) updateData.role = data.role;
@@ -67,8 +76,10 @@ export async function PATCH(
       birthDate: true,
       gender: true,
       address: true,
+      phone: true,
       nationality: true,
       maritalStatus: true,
+      observations: true,
       isActive: true,
     },
   });

--- a/src/app/profile/children.tsx
+++ b/src/app/profile/children.tsx
@@ -3,12 +3,35 @@
 import { useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 
-type Child = { id: string; name: string; birthDate: string | null };
+type Child = {
+  id: string;
+  name: string;
+  lastName: string | null;
+  documentType: string | null;
+  documentNumber: string | null;
+  birthDate: string | null;
+  address: string | null;
+  gender: string | null;
+  nationality: string | null;
+  maritalStatus: string | null;
+};
 
-export default function ChildrenManager() {
+export default function ChildrenManager({
+  userAddress,
+}: {
+  userAddress: string;
+}) {
   const [children, setChildren] = useState<Child[]>([]);
   const [name, setName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [documentType, setDocumentType] = useState('');
+  const [documentNumber, setDocumentNumber] = useState('');
   const [birthDate, setBirthDate] = useState('');
+  const [address, setAddress] = useState('');
+  const [sameAddress, setSameAddress] = useState(false);
+  const [gender, setGender] = useState('');
+  const [nationality, setNationality] = useState('');
+  const [maritalStatus, setMaritalStatus] = useState('');
 
   useEffect(() => {
     fetch('/api/children')
@@ -16,18 +39,42 @@ export default function ChildrenManager() {
       .then((data) => setChildren(data));
   }, []);
 
+  useEffect(() => {
+    if (sameAddress) {
+      setAddress(userAddress);
+    }
+  }, [sameAddress, userAddress]);
+
   async function addChild(e: React.FormEvent) {
     e.preventDefault();
     const res = await fetch('/api/children', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, birthDate }),
+      body: JSON.stringify({
+        name,
+        lastName,
+        documentType,
+        documentNumber,
+        birthDate,
+        address,
+        gender: gender || undefined,
+        nationality,
+        maritalStatus,
+      }),
     });
     if (res.ok) {
       const child = await res.json();
       setChildren([...children, child]);
       setName('');
+      setLastName('');
+      setDocumentType('');
+      setDocumentNumber('');
       setBirthDate('');
+      setAddress('');
+      setSameAddress(false);
+      setGender('');
+      setNationality('');
+      setMaritalStatus('');
     }
   }
 
@@ -48,10 +95,66 @@ export default function ChildrenManager() {
         />
         <input
           className="w-full border px-2 py-1"
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Apellido"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={documentType}
+          onChange={(e) => setDocumentType(e.target.value)}
+          placeholder="Tipo de documento"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={documentNumber}
+          onChange={(e) => setDocumentNumber(e.target.value)}
+          placeholder="Número / Código"
+        />
+        <input
+          className="w-full border px-2 py-1"
           type="date"
           value={birthDate}
           onChange={(e) => setBirthDate(e.target.value)}
           placeholder="Fecha de nacimiento"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          placeholder="Domicilio"
+        />
+        <label className="text-sm flex items-center space-x-1">
+          <input
+            type="checkbox"
+            checked={sameAddress}
+            onChange={(e) => setSameAddress(e.target.checked)}
+          />
+          <span>Mismo domicilio que el usuario</span>
+        </label>
+        <select
+          className="w-full border px-2 py-1"
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+        >
+          <option value="">Género</option>
+          <option value="FEMALE">Femenino</option>
+          <option value="MALE">Masculino</option>
+          <option value="NON_BINARY">No Binario</option>
+          <option value="UNDISCLOSED">Prefiero no decirlo</option>
+          <option value="OTHER">Otro</option>
+        </select>
+        <input
+          className="w-full border px-2 py-1"
+          value={nationality}
+          onChange={(e) => setNationality(e.target.value)}
+          placeholder="Nacionalidad"
+        />
+        <input
+          className="w-full border px-2 py-1"
+          value={maritalStatus}
+          onChange={(e) => setMaritalStatus(e.target.value)}
+          placeholder="Estado Civil"
         />
         <Button type="submit" className="w-full">
           Agregar hijo

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -14,6 +14,7 @@ type User = {
   nationality: string | null;
   maritalStatus: string | null;
   email: string;
+  phone: string | null;
 };
 
 export default function ProfileForm({ user }: { user: User }) {
@@ -26,6 +27,7 @@ export default function ProfileForm({ user }: { user: User }) {
   const [nationality, setNationality] = useState(user.nationality ?? '');
   const [maritalStatus, setMaritalStatus] = useState(user.maritalStatus ?? '');
   const [email, setEmail] = useState(user.email);
+  const [phone, setPhone] = useState(user.phone ?? '');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -49,6 +51,7 @@ export default function ProfileForm({ user }: { user: User }) {
           nationality,
           maritalStatus,
           email,
+          phone,
           ...(password ? { password } : {}),
         }),
       });
@@ -105,6 +108,12 @@ export default function ProfileForm({ user }: { user: User }) {
         value={address}
         onChange={(e) => setAddress(e.target.value)}
         placeholder="Domicilio"
+      />
+      <input
+        className="w-full border px-2 py-1"
+        value={phone}
+        onChange={(e) => setPhone(e.target.value)}
+        placeholder="Teléfono"
       />
       <input
         className="w-full border px-2 py-1"

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -19,6 +19,7 @@ export default async function ProfilePage() {
       birthDate: true,
       gender: true,
       address: true,
+      phone: true,
       nationality: true,
       maritalStatus: true,
       email: true,
@@ -38,7 +39,7 @@ export default async function ProfilePage() {
             : null,
         }}
       />
-      <ChildrenManager />
+      <ChildrenManager userAddress={user.address ?? ''} />
     </div>
   );
 }

--- a/src/lib/validations/child.ts
+++ b/src/lib/validations/child.ts
@@ -2,5 +2,15 @@ import { z } from 'zod';
 
 export const childCreateSchema = z.object({
   name: z.string().min(1),
+  lastName: z.string().optional(),
+  documentType: z.string().optional(),
+  documentNumber: z.string().optional(),
   birthDate: z.string().optional(),
+  address: z.string().optional(),
+  gender: z
+    .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])
+    .optional(),
+  nationality: z.string().optional(),
+  maritalStatus: z.string().optional(),
+  observations: z.string().optional(),
 });

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -9,6 +9,7 @@ export const profileUpdateSchema = z.object({
     .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])
     .optional(),
   address: z.string().optional(),
+  phone: z.string().optional(),
   nationality: z.string().optional(),
   maritalStatus: z.string().optional(),
   email: z.string().email().optional(),

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -9,9 +9,11 @@ export const userUpdateSchema = z.object({
     .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])
     .optional(),
   address: z.string().optional(),
+  phone: z.string().optional(),
   nationality: z.string().optional(),
   maritalStatus: z.string().optional(),
   email: z.string().email().optional(),
   role: z.enum(['ADMIN', 'MEMBER', 'SUPER_ADMIN']).optional(),
+  observations: z.string().optional(),
   isActive: z.boolean().optional(),
 });


### PR DESCRIPTION
## Summary
- add phone and admin-only observations fields to users
- store detailed child info including document data, address, gender, and optional admin observations
- update validations, forms, and API endpoints for new fields

## Testing
- `npx prisma generate`
- `npx next lint` *(fails: prettier warnings in unrelated files)*
- `npx next build` *(fails: Can't reach database server at `localhost:5432`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0a964cd88333a316d89000f8d064