### PR TITLE
feat: translate admin action buttons

### DIFF
--- a/src/app/admin/forms/form-list.tsx
+++ b/src/app/admin/forms/form-list.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/components/language-provider';
 
 interface Form {
   id: string;
@@ -11,6 +12,7 @@ interface Form {
 
 export default function FormList({ forms }: { forms: Form[] }) {
   const router = useRouter();
+  const t = useTranslation().actions;
 
   const handleDelete = async (id: string) => {
     await fetch(`/api/forms/${id}`, { method: 'DELETE' });
@@ -33,13 +35,13 @@ export default function FormList({ forms }: { forms: Form[] }) {
             <td className="p-2 border-b">{f.responseCount}</td>
             <td className="p-2 border-b space-x-2">
               <Link href={`/admin/forms/${f.id}`} className="text-blue-600">
-                View
+                {t.view}
               </Link>
               <Link
                 href={`/admin/forms/${f.id}/edit`}
                 className="text-blue-600"
               >
-                Edit
+                {t.edit}
               </Link>
               <Link
                 href={`/forms/${f.id}`}
@@ -52,7 +54,7 @@ export default function FormList({ forms }: { forms: Form[] }) {
                 onClick={() => handleDelete(f.id)}
                 className="text-red-600"
               >
-                Delete
+                {t.delete}
               </button>
             </td>
           </tr>

--- a/src/app/admin/users/delete-button.tsx
+++ b/src/app/admin/users/delete-button.tsx
@@ -2,9 +2,11 @@
 
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/components/language-provider';
 
 export default function DeleteUserButton({ id }: { id: string }) {
   const router = useRouter();
+  const t = useTranslation().actions;
 
   async function remove() {
     await fetch(`/api/users/${id}`, { method: 'DELETE' });
@@ -13,7 +15,7 @@ export default function DeleteUserButton({ id }: { id: string }) {
 
   return (
     <Button onClick={remove} className="bg-red-600 hover:bg-red-700">
-      Delete
+      {t.delete}
     </Button>
   );
 }

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -1,10 +1,8 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import DeleteUserButton from './delete-button';
-import ResetPasswordButton from './reset-password-button';
+import UsersList from './users-list';
 
 export default async function UsersPage() {
   const session = await getServerSession(authOptions);
@@ -22,35 +20,7 @@ export default async function UsersPage() {
   return (
     <div className="p-4">
       <h1 className="text-2xl font-bold mb-4">Users</h1>
-      <ul className="space-y-2">
-        {users.map((u) => (
-          <li key={u.id} className="flex items-center gap-2">
-            <span className="flex-1">
-              {u.name} {u.lastName} ({u.email}) - {u.role}
-            </span>
-            <Link
-              href={`/admin/users/${u.id}/view`}
-              className="text-blue-600 hover:underline"
-            >
-              View
-            </Link>
-            <Link
-              href={`/admin/users/${u.id}`}
-              className="text-blue-600 hover:underline"
-            >
-              Edit
-            </Link>
-            <Link
-              href={`/admin/users/${u.id}/child-enrollment`}
-              className="text-blue-600 hover:underline"
-            >
-              Child enrollment
-            </Link>
-            <ResetPasswordButton id={u.id} />
-            <DeleteUserButton id={u.id} />
-          </li>
-        ))}
-      </ul>
+      <UsersList users={users} />
     </div>
   );
 }

--- a/src/app/admin/users/reset-password-button.tsx
+++ b/src/app/admin/users/reset-password-button.tsx
@@ -2,12 +2,16 @@
 
 import { Button } from '@/components/ui/button';
 import { useRouter } from 'next/navigation';
+import { useTranslation } from '@/components/language-provider';
 
 export default function ResetPasswordButton({ id }: { id: string }) {
   const router = useRouter();
+  const t = useTranslation().actions;
 
   async function reset() {
-    const res = await fetch(`/api/users/${id}/reset-password`, { method: 'POST' });
+    const res = await fetch(`/api/users/${id}/reset-password`, {
+      method: 'POST',
+    });
     if (res.ok) {
       const data = await res.json();
       alert(`New password: ${data.password}`);
@@ -17,7 +21,7 @@ export default function ResetPasswordButton({ id }: { id: string }) {
 
   return (
     <Button onClick={reset} className="bg-yellow-600 hover:bg-yellow-700">
-      Reset password
+      {t.resetPassword}
     </Button>
   );
 }

--- a/src/app/admin/users/users-list.tsx
+++ b/src/app/admin/users/users-list.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import ResetPasswordButton from './reset-password-button';
+import DeleteUserButton from './delete-button';
+import { useTranslation } from '@/components/language-provider';
+
+interface User {
+  id: string;
+  name: string | null;
+  lastName: string | null;
+  email: string;
+  role: string;
+}
+
+export default function UsersList({ users }: { users: User[] }) {
+  const t = useTranslation().actions;
+  return (
+    <ul className="space-y-2">
+      {users.map((u) => (
+        <li key={u.id} className="flex items-center gap-2">
+          <span className="flex-1">
+            {u.name} {u.lastName} ({u.email}) - {u.role}
+          </span>
+          <Link
+            href={`/admin/users/${u.id}/view`}
+            className="text-blue-600 hover:underline"
+          >
+            {t.view}
+          </Link>
+          <Link
+            href={`/admin/users/${u.id}`}
+            className="text-blue-600 hover:underline"
+          >
+            {t.edit}
+          </Link>
+          <Link
+            href={`/admin/users/${u.id}/child-enrollment`}
+            className="text-blue-600 hover:underline"
+          >
+            {t.childEnrollment}
+          </Link>
+          <ResetPasswordButton id={u.id} />
+          <DeleteUserButton id={u.id} />
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -17,6 +17,13 @@ export const translations = {
     home: {
       welcome: 'Bienvenido a Club Hualas',
     },
+    actions: {
+      view: 'Ver',
+      edit: 'Editar',
+      childEnrollment: 'Inscripción de menores',
+      resetPassword: 'Restablecer contraseña',
+      delete: 'Eliminar',
+    },
   },
   pt: {
     nav: {
@@ -35,6 +42,13 @@ export const translations = {
     },
     home: {
       welcome: 'Bem-vindo ao Club Hualas',
+    },
+    actions: {
+      view: 'Ver',
+      edit: 'Editar',
+      childEnrollment: 'Inscrição de crianças',
+      resetPassword: 'Redefinir senha',
+      delete: 'Excluir',
     },
   },
   en: {
@@ -55,6 +69,13 @@ export const translations = {
     home: {
       welcome: 'Welcome to Club Hualas',
     },
+    actions: {
+      view: 'View',
+      edit: 'Edit',
+      childEnrollment: 'Child enrollment',
+      resetPassword: 'Reset password',
+      delete: 'Delete',
+    },
   },
   fr: {
     nav: {
@@ -73,6 +94,13 @@ export const translations = {
     },
     home: {
       welcome: 'Bienvenue au Club Hualas',
+    },
+    actions: {
+      view: 'Voir',
+      edit: 'Modifier',
+      childEnrollment: 'Inscription des enfants',
+      resetPassword: 'Réinitialiser le mot de passe',
+      delete: 'Supprimer',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add shared translations for view, edit, child enrollment, reset password and delete
- use translation hook for admin user and form action buttons

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npx eslint src/lib/i18n.ts src/app/admin/users/reset-password-button.tsx src/app/admin/users/delete-button.tsx src/app/admin/users/users-list.tsx src/app/admin/users/page.tsx src/app/admin/forms/form-list.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68aa088d7b7083339eb3f0d241e04347