### PR TITLE
Add Mercado Pago data and webhook processing

### DIFF
--- a/src/app/api/mercadopago/notifications/route.ts
+++ b/src/app/api/mercadopago/notifications/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { MercadoPagoConfig, Payment } from 'mercadopago';
 
 export async function POST(req: NextRequest) {
   let body: any = null;
@@ -11,12 +12,50 @@ export async function POST(req: NextRequest) {
   const topic =
     req.nextUrl.searchParams.get('type') ||
     req.nextUrl.searchParams.get('topic');
+  const id =
+    req.nextUrl.searchParams.get('data.id') ||
+    req.nextUrl.searchParams.get('id');
+
   await prisma.mercadoPagoNotification.create({
     data: {
       topic: topic ?? undefined,
       data: body,
     },
   });
+
+  if (topic === 'payment' && id) {
+    const client = new MercadoPagoConfig({
+      accessToken: process.env.MP_ACCESS_TOKEN!,
+    });
+    const payment = await new Payment(client).get({ id });
+    if (payment.status === 'approved' && payment.external_reference) {
+      const [activityId, userId, childId] = payment.external_reference.split(':');
+      const receipt = payment.id?.toString();
+      const date = payment.date_approved || payment.date_created || new Date();
+
+      await prisma.activityParticipant.upsert({
+        where: {
+          activityId_userId_childId: {
+            activityId,
+            userId,
+            childId: childId || null,
+          },
+        },
+        create: {
+          activityId,
+          userId,
+          childId: childId || null,
+          receipt,
+          receiptDate: new Date(date),
+        },
+        update: {
+          receipt,
+          receiptDate: new Date(date),
+        },
+      });
+    }
+  }
+
   return NextResponse.json({ received: true });
 }
 


### PR DESCRIPTION
## Summary
- send detailed payer and item data plus notification, statement and reference metadata to Mercado Pago
- process Mercado Pago webhooks to register approved participants

## Testing
- ⚠️ `pnpm lint` *(failed: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68aa10d9868483339ee93c363d22b861