### PR TITLE
Handle root POST requests for Mercadopago IPN

### DIFF
--- a/src/app/api/mercadopago/notifications/route.ts
+++ b/src/app/api/mercadopago/notifications/route.ts
@@ -29,32 +29,43 @@ export async function POST(req: NextRequest) {
     const client = new MercadoPagoConfig({
       accessToken: process.env.MP_ACCESS_TOKEN!,
     });
-    const payment = await new Payment(client).get({ id });
-    if (payment.status === 'approved' && payment.external_reference) {
-      const [activityId, userId, childId] = payment.external_reference.split(':');
-      const receipt = payment.id?.toString();
-      const date = payment.date_approved || payment.date_created || new Date();
 
-      await prisma.activityParticipant.upsert({
-        where: {
-          activityId_userId_childId: {
+    try {
+      const payment = await new Payment(client).get({ id });
+
+      if (payment.status === 'approved' && payment.external_reference) {
+        const [activityId, userId, childId] =
+          payment.external_reference.split(':');
+        const receipt = payment.id?.toString();
+        const date =
+          payment.date_approved || payment.date_created || new Date();
+
+        await prisma.activityParticipant.upsert({
+          where: {
+            activityId_userId_childId: {
+              activityId,
+              userId,
+              childId: childId || null,
+            },
+          },
+          create: {
             activityId,
             userId,
             childId: childId || null,
+            receipt,
+            receiptDate: new Date(date),
           },
-        },
-        create: {
-          activityId,
-          userId,
-          childId: childId || null,
-          receipt,
-          receiptDate: new Date(date),
-        },
-        update: {
-          receipt,
-          receiptDate: new Date(date),
-        },
-      });
+          update: {
+            receipt,
+            receiptDate: new Date(date),
+          },
+        });
+      }
+    } catch (error: any) {
+      // ignore missing payments, rethrow other errors
+      if (error?.status !== 404) {
+        throw error;
+      }
     }
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  if (
+    request.nextUrl.pathname === '/' &&
+    (request.method === 'POST' || request.method === 'OPTIONS')
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/api/mercadopago/notifications';
+    return NextResponse.rewrite(url);
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: '/',
+};


### PR DESCRIPTION
## Summary
- Redirect root POST and OPTIONS requests to Mercado Pago notifications using middleware
- Ignore missing payments during Mercado Pago IPN handling to prevent server errors

## Testing
- `npm run lint`
- `npm run build` *(fails: Environment variable not found: DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_68aa353a6ff08333b32173828c3c9c89