### PR TITLE
Handle optional DNI without unique constraint failures

### DIFF
--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -50,7 +50,7 @@ export default function EditUserForm({ user }: { user: User }) {
       const body: any = {
         name,
         lastName,
-        dni,
+        dni: dni || null,
         birthDate,
         gender: gender || undefined,
         address,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -40,7 +40,7 @@ export async function PATCH(req: Request) {
   const updateData: any = {};
   if (data.name !== undefined) updateData.name = data.name;
   if (data.lastName !== undefined) updateData.lastName = data.lastName;
-  if (data.dni !== undefined) updateData.dni = data.dni;
+  if (data.dni !== undefined) updateData.dni = data.dni ?? null;
   if (data.birthDate !== undefined)
     updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
   if (data.gender !== undefined) updateData.gender = data.gender;

--- a/src/app/api/users/[id]/route.ts
+++ b/src/app/api/users/[id]/route.ts
@@ -48,7 +48,7 @@ export async function PATCH(
   const updateData: any = {};
   if (data.name !== undefined) updateData.name = data.name;
   if (data.lastName !== undefined) updateData.lastName = data.lastName;
-  if (data.dni !== undefined) updateData.dni = data.dni;
+  if (data.dni !== undefined) updateData.dni = data.dni ?? null;
   if (data.birthDate !== undefined)
     updateData.birthDate = data.birthDate ? new Date(data.birthDate) : null;
   if (data.gender !== undefined) updateData.gender = data.gender;

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -44,7 +44,7 @@ export default function ProfileForm({ user }: { user: User }) {
         body: JSON.stringify({
           name,
           lastName,
-          dni,
+          dni: dni || null,
           birthDate,
           gender: gender || undefined,
           address,

--- a/src/lib/validations/profile.ts
+++ b/src/lib/validations/profile.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const profileUpdateSchema = z.object({
   name: z.string().optional(),
   lastName: z.string().optional(),
-  dni: z.string().optional(),
+  dni: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.string().optional().nullable()
+  ),
   birthDate: z.string().optional(),
   gender: z
     .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])

--- a/src/lib/validations/user.ts
+++ b/src/lib/validations/user.ts
@@ -3,7 +3,10 @@ import { z } from 'zod';
 export const userUpdateSchema = z.object({
   name: z.string().optional(),
   lastName: z.string().optional(),
-  dni: z.string().optional(),
+  dni: z.preprocess(
+    (val) => (val === '' ? null : val),
+    z.string().optional().nullable()
+  ),
   birthDate: z.string().optional(),
   gender: z
     .enum(['FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER'])


### PR DESCRIPTION
## Summary
- treat empty `dni` values as `null` in validation schemas
- send `null` for blank `dni` from profile and admin user forms
- normalize `dni` to `null` before updating users

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ab984974848333b45bb2bd3a14ac90