### PR TITLE
Remove non-Google social login providers

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -63,12 +63,6 @@ export default function LoginPage() {
       <Button className="w-full" onClick={() => signIn('google')}>
         Sign in with Google
       </Button>
-      <Button className="w-full" onClick={() => signIn('instagram')}>
-        Sign in with Instagram
-      </Button>
-      <Button className="w-full" onClick={() => signIn('twitter')}>
-        Sign in with Twitter
-      </Button>
     </div>
   );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,8 +1,6 @@
 import { compare } from 'bcrypt';
 import type { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
-import InstagramProvider from 'next-auth/providers/instagram';
-import TwitterProvider from 'next-auth/providers/twitter';
 import Credentials from 'next-auth/providers/credentials';
 import { prisma } from './prisma';
 
@@ -11,15 +9,6 @@ export const authOptions: NextAuthOptions = {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-    }),
-    InstagramProvider({
-      clientId: process.env.INSTAGRAM_CLIENT_ID!,
-      clientSecret: process.env.INSTAGRAM_CLIENT_SECRET!,
-    }),
-    TwitterProvider({
-      clientId: process.env.TWITTER_CLIENT_ID!,
-      clientSecret: process.env.TWITTER_CLIENT_SECRET!,
-      version: '2.0',
     }),
     Credentials({
       name: 'Credentials',
@@ -36,7 +25,12 @@ export const authOptions: NextAuthOptions = {
         if (!user || !user.password || !user.isActive) return null;
         const valid = await compare(credentials.password, user.password);
         if (!valid) return null;
-        return { id: user.id, email: user.email, name: user.name, role: user.role };
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        };
       },
     }),
   ],


### PR DESCRIPTION
## Summary
- Remove Instagram and Twitter providers from NextAuth, leaving Google and email-based login
- Drop Instagram and Twitter login buttons from the login page

## Testing
- `npm run lint`
- `npm run build` *(fails: Export encountered errors on several paths)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75eb27d8833395717e4b432cdda9