### PR TITLE
Fix user role assignment for Google sign-in

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -36,7 +36,12 @@ export const authOptions: NextAuthOptions = {
         if (!user || !user.password || !user.isActive) return null;
         const valid = await compare(credentials.password, user.password);
         if (!valid) return null;
-        return { id: user.id, email: user.email, name: user.name, role: user.role };
+        return {
+          id: user.id,
+          email: user.email,
+          name: user.name,
+          role: user.role,
+        };
       },
     }),
   ],
@@ -55,6 +60,19 @@ export const authOptions: NextAuthOptions = {
     },
   },
   callbacks: {
+    async signIn({ user, account }) {
+      if (account && account.provider !== 'credentials') {
+        const email = user.email?.toLowerCase();
+        if (!email) return false;
+        const existingUser = await prisma.user.findUnique({
+          where: { email },
+        });
+        if (!existingUser || !existingUser.isActive) return false;
+        user.id = existingUser.id;
+        (user as any).role = existingUser.role;
+      }
+      return true;
+    },
     async jwt({ token, user }) {
       if (user) {
         token.role = (user as any).role;


### PR DESCRIPTION
## Summary
- fetch existing user data during OAuth sign-in and populate id/role

## Testing
- `npx next lint`

------
https://chatgpt.com/codex/tasks/task_e_68ac768bca0c83338767c0abd686c137