### PR TITLE
feat: add google registration

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { registerSchema } from '@/lib/validations/auth';
 
@@ -71,6 +72,9 @@ export default function RegisterPage() {
       {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button className="w-full" onClick={submit}>
         Register
+      </Button>
+      <Button className="w-full" onClick={() => signIn('google')}>
+        Register with Google
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- create users on first Google sign in and persist role/id in session
- allow sign up with Google from registration page

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac771581c483339c053f73feef4800