### PR TITLE
Redirect to home after Google login

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -60,7 +60,10 @@ export default function LoginPage() {
       <Button className="w-full" onClick={submit}>
         Sign in
       </Button>
-      <Button className="w-full" onClick={() => signIn('google')}>
+      <Button
+        className="w-full"
+        onClick={() => signIn('google', { callbackUrl: '/' })}
+      >
         Sign in with Google
       </Button>
     </div>


### PR DESCRIPTION
## Summary
- Redirect Google sign-ins to the home page so users aren't left on the `/login` screen after authenticating.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac792d8ca48333984e943aab9fbbfc