### PR TITLE
Enable Google registration

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { registerSchema } from '@/lib/validations/auth';
 
@@ -71,6 +72,9 @@ export default function RegisterPage() {
       {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button className="w-full" onClick={submit}>
         Register
+      </Button>
+      <Button className="w-full" onClick={() => signIn('google')}>
+        Register with Google
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow users to register via Google OAuth
- show "Register with Google" option on signup page

## Testing
- `./node_modules/.bin/next lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac78d29ba883338c2adf63e9b7b0a3