### PR TITLE
feat: add Google registration

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { signIn } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import { registerSchema } from '@/lib/validations/auth';
 
@@ -71,6 +72,12 @@ export default function RegisterPage() {
       {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button className="w-full" onClick={submit}>
         Register
+      </Button>
+      <Button
+        className="w-full"
+        onClick={() => signIn('google', { callbackUrl: '/' })}
+      >
+        Register with Google
       </Button>
     </div>
   );

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
-import { compare } from 'bcrypt';
+import { compare, hash } from 'bcrypt';
+import { randomUUID } from 'crypto';
 import type { NextAuthOptions } from 'next-auth';
 import GoogleProvider from 'next-auth/providers/google';
 import Credentials from 'next-auth/providers/credentials';
@@ -53,10 +54,20 @@ export const authOptions: NextAuthOptions = {
       if (account && account.provider !== 'credentials') {
         const email = user.email?.toLowerCase();
         if (!email) return false;
-        const existingUser = await prisma.user.findUnique({
+        let existingUser = await prisma.user.findUnique({
           where: { email },
         });
-        if (!existingUser || !existingUser.isActive) return false;
+        if (!existingUser) {
+          const randomPassword = await hash(randomUUID(), 12);
+          existingUser = await prisma.user.create({
+            data: {
+              email,
+              name: user.name,
+              password: randomPassword,
+            },
+          });
+        }
+        if (!existingUser.isActive) return false;
         user.id = existingUser.id;
         (user as any).role = existingUser.role;
       }


### PR DESCRIPTION
## Summary
- allow Google sign-in to auto-create users
- add "Register with Google" button to registration page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npx eslint src/app/register/page.tsx src/lib/auth.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ac8f58f7ec8333836c6e702dcbc121