### PR TITLE
Ensure chat messages create conversations even if recipient offline

### DIFF
--- a/src/app/api/socket/route.ts
+++ b/src/app/api/socket/route.ts
@@ -27,10 +27,17 @@ export async function GET(req: NextRequest) {
         'message',
         async ({ to, content }: { to: string; content: string }) => {
           const target = users.get(to);
-          if (!target) return;
           const isSenderAdmin = role === 'ADMIN' || role === 'SUPER_ADMIN';
+          let targetRole = target?.role;
+          if (!targetRole) {
+            const targetUser = await prisma.user.findUnique({
+              where: { id: to },
+              select: { role: true },
+            });
+            targetRole = targetUser?.role;
+          }
           const isTargetAdmin =
-            target.role === 'ADMIN' || target.role === 'SUPER_ADMIN';
+            targetRole === 'ADMIN' || targetRole === 'SUPER_ADMIN';
           if (!isSenderAdmin && !isTargetAdmin) return;
 
           let conversation = await prisma.conversation.findFirst({
@@ -58,7 +65,9 @@ export async function GET(req: NextRequest) {
             },
           });
 
-          io?.to(target.socketId).emit('message', { from: userId, content });
+          if (target) {
+            io?.to(target.socketId).emit('message', { from: userId, content });
+          }
         }
       );
 


### PR DESCRIPTION
## Summary
- Fetch target user's role from the database when they are offline
- Persist new conversations and messages even if the recipient isn't connected
- Only emit socket message when recipient is online

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npm run lint`
- `npx prettier src/app/api/socket/route.ts --check`


------
https://chatgpt.com/codex/tasks/task_e_68acfe2e97bc8333be0339f7f971a60b