### PR TITLE
feat(navbar): move menu left of logo

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -38,10 +38,17 @@ export default function Navbar() {
 
   return (
     <nav
-      className="flex flex-col px-4 py-2 text-white"
+      className="flex flex-col px-4 py-2 text-white md:flex-row md:items-center md:justify-between"
       style={{ backgroundColor: settings?.navbarColor || '#1e293b' }}
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2 md:order-2">
+        <button
+          className="md:hidden"
+          onClick={() => setMenuOpen((prev) => !prev)}
+          aria-label="Toggle menu"
+        >
+          <Menu />
+        </button>
         <Link href="/" className="flex items-center gap-2">
           <Image
             src={logoUrl}
@@ -52,16 +59,9 @@ export default function Navbar() {
           />
           <span className="font-semibold">Hualas Patagónico</span>
         </Link>
-        <button
-          className="md:hidden"
-          onClick={() => setMenuOpen((prev) => !prev)}
-          aria-label="Toggle menu"
-        >
-          <Menu />
-        </button>
       </div>
       <div
-        className={`${menuOpen ? 'flex' : 'hidden'} flex-col gap-2 mt-2 md:mt-0 md:flex md:flex-row md:items-center md:gap-[5ch]`}
+        className={`${menuOpen ? 'flex' : 'hidden'} flex-col gap-2 mt-2 md:mt-0 md:flex md:flex-row md:items-center md:gap-[5ch] md:order-1`}
       >
         <Link href="/activities">{t.activities}</Link>
         {session && <Link href="/chat">{t.chat}</Link>}


### PR DESCRIPTION
## Summary
- reorder navbar elements so menu toggle and links appear to the left of the logo

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad2d971cc08333ac27d0f0c073daf8