### PR TITLE
feat: translate auth strings

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
+import { useTranslation } from '@/components/language-provider';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -13,6 +14,7 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const router = useRouter();
+  const t = useTranslation().auth;
 
   const submit = async () => {
     setError('');
@@ -23,7 +25,7 @@ export default function LoginPage() {
       redirect: false,
     });
     if (res?.error) {
-      setError('Invalid credentials');
+      setError('invalidCredentials');
     } else {
       setSuccess('Login successful');
       setTimeout(() => router.push('/'), 1000);
@@ -53,16 +55,18 @@ export default function LoginPage() {
             checked={showPassword}
             onChange={() => setShowPassword(!showPassword)}
           />
-          <span>Show password</span>
+          <span>{t.showPassword}</span>
         </label>
       </div>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
+      {error && (
+        <p className="text-red-500 text-sm">{t[error as keyof typeof t]}</p>
+      )}
       {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button
         className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         onClick={submit}
       >
-        Sign in
+        {t.signIn}
       </Button>
       <Button
         className="w-full flex items-center justify-center bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
@@ -75,7 +79,7 @@ export default function LoginPage() {
           height={20}
           className="mr-2"
         />
-        Sign in with Google
+        {t.signInWithGoogle}
       </Button>
     </div>
   );

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -5,6 +5,7 @@ import { signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { registerSchema } from '@/lib/validations/auth';
+import { useTranslation } from '@/components/language-provider';
 
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
@@ -13,6 +14,7 @@ export default function RegisterPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const t = useTranslation().auth;
 
   async function submit() {
     setError('');
@@ -66,7 +68,7 @@ export default function RegisterPage() {
             checked={showPassword}
             onChange={() => setShowPassword(!showPassword)}
           />
-          <span>Show password</span>
+          <span>{t.showPassword}</span>
         </label>
       </div>
       {error && <p className="text-red-500 text-sm">{error}</p>}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -24,6 +24,12 @@ export const translations = {
       resetPassword: 'Restablecer contraseña',
       delete: 'Eliminar',
     },
+    auth: {
+      showPassword: 'Mostrar contraseña',
+      invalidCredentials: 'Credenciales inválidas',
+      signIn: 'Iniciar sesión',
+      signInWithGoogle: 'Iniciar sesión con Google',
+    },
   },
   pt: {
     nav: {
@@ -49,6 +55,12 @@ export const translations = {
       childEnrollment: 'Inscrição de crianças',
       resetPassword: 'Redefinir senha',
       delete: 'Excluir',
+    },
+    auth: {
+      showPassword: 'Mostrar senha',
+      invalidCredentials: 'Credenciais inválidas',
+      signIn: 'Entrar',
+      signInWithGoogle: 'Entrar com Google',
     },
   },
   en: {
@@ -76,6 +88,12 @@ export const translations = {
       resetPassword: 'Reset password',
       delete: 'Delete',
     },
+    auth: {
+      showPassword: 'Show password',
+      invalidCredentials: 'Invalid credentials',
+      signIn: 'Sign in',
+      signInWithGoogle: 'Sign in with Google',
+    },
   },
   fr: {
     nav: {
@@ -101,6 +119,12 @@ export const translations = {
       childEnrollment: 'Inscription des enfants',
       resetPassword: 'Réinitialiser le mot de passe',
       delete: 'Supprimer',
+    },
+    auth: {
+      showPassword: 'Afficher le mot de passe',
+      invalidCredentials: 'Identifiants invalides',
+      signIn: 'Se connecter',
+      signInWithGoogle: 'Se connecter avec Google',
     },
   },
 };


### PR DESCRIPTION
## Summary
- add auth translations for sign-in flow
- use translations for login page and register password toggle

## Testing
- `pnpm lint` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.4.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_68add61036308333bb2703d505d80454