### PR TITLE
Center contact page and update contact links

### DIFF
--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,18 +1,41 @@
 export default function ContactPage() {
   return (
-    <div className="p-4 space-y-4">
+    <div className="min-h-screen flex flex-col items-center justify-center p-4 space-y-4 text-center">
       <h1 className="text-2xl font-bold">¡Estamos en contacto!</h1>
       <div>
         <h2 className="font-semibold">Instagram</h2>
-        <p>@hualas_patagonico</p>
+        <p>
+          <a
+            href="https://www.instagram.com/hualas_patagonico"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-500 underline"
+          >
+            @hualas_patagonico
+          </a>
+        </p>
       </div>
       <div>
         <h2 className="font-semibold">Información general</h2>
-        <p>Info@clubhualas.com.ar</p>
+        <p>
+          <a
+            href="mailto:Info@clubhualas.com.ar"
+            className="text-blue-500 underline"
+          >
+            Info@clubhualas.com.ar
+          </a>
+        </p>
       </div>
       <div>
         <h2 className="font-semibold">Tesorería</h2>
-        <p>tesoreria@clubhualas.com.ar</p>
+        <p>
+          <a
+            href="mailto:tesoreria@clubhualas.com.ar"
+            className="text-blue-500 underline"
+          >
+            tesoreria@clubhualas.com.ar
+          </a>
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- center contact page content
- link emails with `mailto` and Instagram handle to profile

## Testing
- `npm run lint` *(fails: Prettier warnings in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68add6efe0e8833380aaea27c3f6e097