### PR TITLE
feat: add eye toggle for password fields

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { useTranslation } from '@/components/language-provider';
+import { Eye, EyeOff } from 'lucide-react';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -41,22 +42,26 @@ export default function LoginPage() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
-      <div className="space-y-1">
+      <div className="relative">
         <input
-          className="w-full border px-2 py-1"
+          className="w-full border px-2 py-1 pr-8"
           type={showPassword ? 'text' : 'password'}
           placeholder="Password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <label className="text-sm flex items-center space-x-1">
-          <input
-            type="checkbox"
-            checked={showPassword}
-            onChange={() => setShowPassword(!showPassword)}
-          />
-          <span>{t.showPassword}</span>
-        </label>
+        <button
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          aria-label={t.showPassword}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </button>
       </div>
       {error && (
         <p className="text-red-500 text-sm">{t[error as keyof typeof t]}</p>

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 import { registerSchema } from '@/lib/validations/auth';
 import { useTranslation } from '@/components/language-provider';
+import { Eye, EyeOff } from 'lucide-react';
 
 export default function RegisterPage() {
   const [email, setEmail] = useState('');
@@ -54,22 +55,26 @@ export default function RegisterPage() {
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
-      <div className="space-y-1">
+      <div className="relative">
         <input
-          className="w-full border px-2 py-1"
+          className="w-full border px-2 py-1 pr-8"
           placeholder="Password"
           type={showPassword ? 'text' : 'password'}
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <label className="text-sm flex items-center space-x-1">
-          <input
-            type="checkbox"
-            checked={showPassword}
-            onChange={() => setShowPassword(!showPassword)}
-          />
-          <span>{t.showPassword}</span>
-        </label>
+        <button
+          type="button"
+          onClick={() => setShowPassword(!showPassword)}
+          aria-label={t.showPassword}
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+        >
+          {showPassword ? (
+            <EyeOff className="h-4 w-4" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+        </button>
       </div>
       {error && <p className="text-red-500 text-sm">{error}</p>}
       {success && <p className="text-green-600 text-sm">{success}</p>}


### PR DESCRIPTION
## Summary
- replace checkbox password visibility toggle with eye icon
- allow toggling between hidden and visible password in login and register forms

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68add76160fc8333bd8b193376f81a3b