### PR TITLE
Update document type inputs to select options

### DIFF
--- a/src/app/admin/users/[id]/child-enrollment/children.tsx
+++ b/src/app/admin/users/[id]/child-enrollment/children.tsx
@@ -90,12 +90,16 @@ export default function AdminChildrenManager({ userId }: { userId: string }) {
           onChange={(e) => setLastName(e.target.value)}
           placeholder="Apellido"
         />
-        <input
+        <select
           className="w-full border px-2 py-1"
           value={documentType}
           onChange={(e) => setDocumentType(e.target.value)}
-          placeholder="Tipo de documento"
-        />
+        >
+          <option value="">Tipo de documento</option>
+          <option value="DNI">DNI</option>
+          <option value="PASAPORTE">Pasaporte</option>
+          <option value="OTRO">Otro</option>
+        </select>
         <input
           className="w-full border px-2 py-1"
           value={documentNumber}

--- a/src/app/profile/children.tsx
+++ b/src/app/profile/children.tsx
@@ -99,12 +99,16 @@ export default function ChildrenManager({
           onChange={(e) => setLastName(e.target.value)}
           placeholder="Apellido"
         />
-        <input
+        <select
           className="w-full border px-2 py-1"
           value={documentType}
           onChange={(e) => setDocumentType(e.target.value)}
-          placeholder="Tipo de documento"
-        />
+        >
+          <option value="">Tipo de documento</option>
+          <option value="DNI">DNI</option>
+          <option value="PASAPORTE">Pasaporte</option>
+          <option value="OTRO">Otro</option>
+        </select>
         <input
           className="w-full border px-2 py-1"
           value={documentNumber}


### PR DESCRIPTION
## Summary
- replace the free text document type fields in child forms with select menus
- provide consistent options for document type: DNI, Pasaporte, or Otro

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd3adb3bc8333812eed80d9a7d5f7