### PR TITLE
feat: refresh ui with glassmorphism layout

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -57,27 +57,33 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
     }
   };
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+    >
       <input
         type="text"
         placeholder="Nombre de la actividad"
         value={name}
         onChange={(e) => setName(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <input
         type="date"
         value={date}
         onChange={(e) => setDate(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <input
         type="url"
         placeholder="URL de la imagen"
         value={image}
         onChange={(e) => setImage(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <select
         value={frequency}
@@ -86,7 +92,7 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
             e.target.value as 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
           )
         }
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       >
         <option value="ONE_TIME">Un solo pago</option>
         <option value="DAILY">Diaria</option>
@@ -97,18 +103,28 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         placeholder="Descripción"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={`${fieldClass} min-h-[120px]`}
       />
       <input
         type="number"
         placeholder="Precio"
         value={price}
         onChange={(e) => setPrice(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button type="submit">Guardar</Button>
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <Button type="submit" className="w-full shadow-lg shadow-emerald-500/30">
+        Guardar
+      </Button>
     </form>
   );
 }

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -22,8 +22,15 @@ export default async function EditActivityPage({
     redirect('/activities');
   }
   return (
-    <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">Editar actividad</h1>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">
+          Editar actividad
+        </h1>
+        <p className="text-sm text-slate-500">
+          Actualizá la información para mantener a la comunidad al tanto.
+        </p>
+      </div>
       <EditActivityForm
         activity={{
           id: activity.id,
@@ -35,6 +42,6 @@ export default async function EditActivityPage({
           price: activity.price,
         }}
       />
-    </main>
+    </div>
   );
 }

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -22,7 +22,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   }
 
   if (!activity) {
-    return <main className="p-4">Activity not found</main>;
+    return (
+      <div className="rounded-3xl border border-dashed border-slate-300/70 bg-white/60 p-10 text-center text-slate-500 backdrop-blur">
+        Actividad no encontrada
+      </div>
+    );
   }
 
   const session = await getServerSession(authOptions);
@@ -38,38 +42,61 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   };
 
   return (
-    <main className="p-4">
+    <div className="space-y-8">
       <PaymentHandler activityId={activity.id} />
-      <h1 className="mb-4 text-2xl font-bold">{activity.name}</h1>
-      {(session?.user.role === 'ADMIN' ||
-        session?.user.role === 'SUPER_ADMIN') && (
-        <Link
-          href={`/activities/${activity.id}/edit`}
-          className="mb-4 inline-block text-blue-600"
-        >
-          Editar
-        </Link>
-      )}
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">
+          {activity.name}
+        </h1>
+        {(session?.user.role === 'ADMIN' ||
+          session?.user.role === 'SUPER_ADMIN') && (
+          <Link
+            href={`/activities/${activity.id}/edit`}
+            className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-700"
+          >
+            Editar actividad
+          </Link>
+        )}
+      </div>
       {activity.image && (
-        <Image
-          src={activity.image}
-          alt={activity.name}
-          width={800}
-          height={600}
-          className="mb-4 max-w-full"
-        />
+        <div className="overflow-hidden rounded-3xl border border-white/60 bg-white/60 shadow-lg shadow-slate-900/5">
+          <Image
+            src={activity.image}
+            alt={activity.name}
+            width={1200}
+            height={700}
+            className="h-auto w-full object-cover"
+          />
+        </div>
       )}
-      <p className="mb-2">Date: {activity.date.toISOString().split('T')[0]}</p>
-      <p className="mb-2">
-        Frecuencia:{' '}
-        {frequencyLabels[activity.frequency as keyof typeof frequencyLabels]}
-      </p>
-      <p className="mb-4">{activity.description}</p>
-      <p className="mb-4 font-semibold">Precio: ${activity.price}</p>
-      <p className="mb-4 font-semibold">
-        {activity.participants.length} suscriptos
-      </p>
-      <RegisterButton activityId={activity.id} />
-    </main>
+      <div className="grid gap-6 md:grid-cols-[2fr,1fr]">
+        <div className="space-y-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <dl className="grid gap-3 text-sm text-slate-600 sm:grid-cols-2">
+            <div>
+              <dt className="font-semibold text-slate-800">Fecha</dt>
+              <dd>{activity.date.toISOString().split('T')[0]}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-800">Frecuencia</dt>
+              <dd>{frequencyLabels[activity.frequency as keyof typeof frequencyLabels]}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-800">Precio</dt>
+              <dd>${activity.price}</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-slate-800">Suscriptos</dt>
+              <dd>{activity.participants.length}</dd>
+            </div>
+          </dl>
+          {activity.description && (
+            <p className="rounded-2xl bg-white/80 p-4 text-sm text-slate-600 shadow-inner shadow-white/40">
+              {activity.description}
+            </p>
+          )}
+        </div>
+        <RegisterButton activityId={activity.id} />
+      </div>
+    </div>
   );
 }

--- a/src/app/activities/[id]/register-button.tsx
+++ b/src/app/activities/[id]/register-button.tsx
@@ -35,22 +35,37 @@ export default function ActivityRegisterButton({
   };
 
   return (
-    <div className="space-y-2">
-      {session && (
-        <select
-          className="border px-2 py-1"
-          value={target}
-          onChange={(e) => setTarget(e.target.value)}
-        >
-          <option value="self">Para mí</option>
-          {children.map((c) => (
-            <option key={c.id} value={c.id}>
-              {c.name}
-            </option>
-          ))}
-        </select>
+    <div className="space-y-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+      {!session ? (
+        <div className="space-y-3">
+          <p className="text-sm text-slate-600">
+            Iniciá sesión para finalizar tu inscripción y elegir el participante.
+          </p>
+          <RegisterButton href="/login" label="Iniciar sesión" />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <label htmlFor="participant" className="text-sm font-semibold text-slate-700">
+              ¿Quién va a participar?
+            </label>
+            <select
+              id="participant"
+              className="w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-2.5 text-sm text-slate-700 shadow-sm focus:outline-none focus:ring-2 focus:ring-slate-200"
+              value={target}
+              onChange={(e) => setTarget(e.target.value)}
+            >
+              <option value="self">Para mí</option>
+              {children.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <RegisterButton onClick={handleClick} label="Continuar con el pago" />
+        </>
       )}
-      <RegisterButton onClick={handleClick} />
     </div>
   );
 }

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -49,27 +49,33 @@ export default function CreateActivityForm() {
     }
   };
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+    >
       <input
         type="text"
         placeholder="Nombre de la actividad"
         value={name}
         onChange={(e) => setName(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <input
         type="date"
         value={date}
         onChange={(e) => setDate(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <input
         type="url"
         placeholder="URL de la imagen"
         value={image}
         onChange={(e) => setImage(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
       <select
         value={frequency}
@@ -78,7 +84,7 @@ export default function CreateActivityForm() {
             e.target.value as 'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
           )
         }
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       >
         <option value="ONE_TIME">Un solo pago</option>
         <option value="DAILY">Diaria</option>
@@ -89,18 +95,28 @@ export default function CreateActivityForm() {
         placeholder="Descripción"
         value={description}
         onChange={(e) => setDescription(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={`${fieldClass} min-h-[120px]`}
       />
       <input
         type="number"
         placeholder="Precio"
         value={price}
         onChange={(e) => setPrice(e.target.value)}
-        className="w-full border px-2 py-1"
+        className={fieldClass}
       />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button type="submit">Guardar</Button>
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <Button type="submit" className="w-full shadow-lg shadow-emerald-500/30">
+        Guardar
+      </Button>
     </form>
   );
 }

--- a/src/app/activities/new/page.tsx
+++ b/src/app/activities/new/page.tsx
@@ -10,9 +10,14 @@ export default async function CreateActivityPage() {
   }
 
   return (
-    <main className="p-4">
-      <h1 className="mb-4 text-2xl font-bold">Crear actividad</h1>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">Crear actividad</h1>
+        <p className="text-sm text-slate-500">
+          Diseñá una nueva propuesta y compartila con la comunidad.
+        </p>
+      </div>
       <CreateActivityForm />
-    </main>
+    </div>
   );
 }

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -37,48 +37,57 @@ export default async function ActivitiesPage() {
   };
 
   return (
-    <main className="p-4">
-      <div className="mb-4 flex flex-col items-start gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur sm:flex-row sm:items-center sm:justify-between">
         <ActivitiesHeading />
         {(session?.user.role === 'ADMIN' ||
           session?.user.role === 'SUPER_ADMIN') && (
           <Link href="/activities/new">
-            <Button>Crear actividad</Button>
+            <Button variant="secondary">Crear actividad</Button>
           </Link>
         )}
       </div>
-      <ul className="space-y-4">
+      <ul className="grid gap-6 md:grid-cols-2">
         {activities.map((activity) => (
-          <li key={activity.id} className="border p-4">
-            <Link
-              href={`/activities/${activity.id}`}
-              className="text-xl font-semibold"
-            >
-              {activity.name}
-            </Link>
-            <p className="text-sm text-slate-600">
-              {activity.participants.length} suscriptos
-            </p>
-            <p className="text-sm text-slate-600">
-              {
-                frequencyLabels[
-                  activity.frequency as keyof typeof frequencyLabels
-                ]
-              }
-            </p>
-            <p className="text-sm text-slate-600">Precio: ${activity.price}</p>
+          <li
+            key={activity.id}
+            className="flex flex-col justify-between gap-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+          >
+            <div className="space-y-3">
+              <Link
+                href={`/activities/${activity.id}`}
+                className="text-lg font-semibold text-slate-900 transition hover:text-emerald-600"
+              >
+                {activity.name}
+              </Link>
+              <p className="text-sm text-slate-500">
+                {frequencyLabels[activity.frequency as keyof typeof frequencyLabels]}
+              </p>
+              <p className="text-sm font-semibold text-slate-700">
+                {activity.participants.length} suscriptos
+              </p>
+              <p className="text-sm text-slate-500">Precio: ${activity.price}</p>
+            </div>
             {(session?.user.role === 'ADMIN' ||
               session?.user.role === 'SUPER_ADMIN') && (
-              <Link
-                href={`/activities/${activity.id}/edit`}
-                className="text-sm text-blue-600"
-              >
-                Editar
-              </Link>
+              <div className="flex items-center justify-between">
+                <Link
+                  href={`/activities/${activity.id}/edit`}
+                  className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-700"
+                >
+                  Editar
+                </Link>
+                <Link
+                  href={`/activities/${activity.id}`}
+                  className="text-sm text-slate-500 transition hover:text-slate-700"
+                >
+                  Ver detalles →
+                </Link>
+              </div>
             )}
           </li>
         ))}
       </ul>
-    </main>
+    </div>
   );
 }

--- a/src/app/admin/users/[id]/view/page.tsx
+++ b/src/app/admin/users/[id]/view/page.tsx
@@ -43,34 +43,75 @@ export default async function ViewUserPage({
   }
 
   return (
-    <div className="p-4 space-y-4">
-      <div>
-        <h1 className="text-2xl font-bold">
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">
           {user.name} {user.lastName}
         </h1>
-        <p>Email: {user.email}</p>
-        {user.phone && <p>Phone: {user.phone}</p>}
-        {user.observations && <p>Observaciones: {user.observations}</p>}
-        <p>Role: {user.role}</p>
+        <p className="text-sm text-slate-500">
+          Detalles del socio y sus participaciones.
+        </p>
       </div>
 
-      <div>
-        <h2 className="text-xl font-semibold mb-2">Activities</h2>
+      <div className="grid gap-6 md:grid-cols-2">
+        <div className="space-y-3 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <h2 className="text-lg font-semibold text-slate-900">Datos personales</h2>
+          <dl className="space-y-2 text-sm text-slate-600">
+            <div>
+              <dt className="font-semibold text-slate-800">Email</dt>
+              <dd>{user.email}</dd>
+            </div>
+            {user.phone && (
+              <div>
+                <dt className="font-semibold text-slate-800">Teléfono</dt>
+                <dd>{user.phone}</dd>
+              </div>
+            )}
+            {user.observations && (
+              <div>
+                <dt className="font-semibold text-slate-800">Observaciones</dt>
+                <dd>{user.observations}</dd>
+              </div>
+            )}
+            <div>
+              <dt className="font-semibold text-slate-800">Rol</dt>
+              <dd>{user.role}</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="space-y-3 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <h2 className="text-lg font-semibold text-slate-900">Resumen</h2>
+          <p className="text-sm text-slate-600">
+            {user.activityParticipants.length} actividades registradas y{' '}
+            {user.conversations.length} conversaciones activas.
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-3 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <h2 className="text-lg font-semibold text-slate-900">Actividades</h2>
         {user.activityParticipants.length === 0 ? (
-          <p>No activities</p>
+          <p className="text-sm text-slate-500">No hay actividades registradas.</p>
         ) : (
-          <ul className="list-disc pl-4 space-y-1">
+          <ul className="space-y-2 text-sm text-slate-600">
             {user.activityParticipants.map((ap) => (
-              <li key={ap.id}>
-                {ap.activity.name} - {ap.activity.date.toLocaleDateString()} - $
-                {ap.activity.price}
-                {ap.child && ` - ${ap.child.name}`}
+              <li
+                key={ap.id}
+                className="flex flex-col gap-1 rounded-2xl bg-white/80 p-4 shadow-inner shadow-white/40"
+              >
+                <span className="font-semibold text-slate-900">
+                  {ap.activity.name}
+                </span>
+                <span>
+                  {ap.activity.date.toLocaleDateString()} • ${ap.activity.price}
+                </span>
+                {ap.child && <span>Participante: {ap.child.name}</span>}
                 {ap.receipt && (
                   <a
                     href={ap.receipt}
-                    className="text-blue-600 hover:underline ml-2"
+                    className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-700"
                   >
-                    Receipt
+                    Ver comprobante
                   </a>
                 )}
               </li>
@@ -79,38 +120,44 @@ export default async function ViewUserPage({
         )}
       </div>
 
-      <div>
-        <h2 className="text-xl font-semibold mb-2">Chats</h2>
+      <div className="space-y-3 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+        <h2 className="text-lg font-semibold text-slate-900">Chats</h2>
         {user.conversations.length === 0 ? (
-          <p>No chats</p>
+          <p className="text-sm text-slate-500">Sin conversaciones recientes.</p>
         ) : (
-          <ul className="list-disc pl-4 space-y-1">
+          <ul className="space-y-2 text-sm text-slate-600">
             {user.conversations.map((cp) => {
               const conv = cp.conversation;
               const others = conv.participants
                 .filter((p) => p.userId !== user.id)
                 .map(
                   (p) =>
-                    `${p.user.name ?? 'Unnamed'}${
+                    `${p.user.name ?? 'Sin nombre'}${
                       p.user.lastName ? ' ' + p.user.lastName : ''
                     }`
                 )
                 .join(', ');
               const last = conv.messages[0];
               return (
-                <li key={conv.id}>
-                  With: {others || 'Unknown'}
+                <li
+                  key={conv.id}
+                  className="rounded-2xl bg-white/80 p-4 shadow-inner shadow-white/40"
+                >
+                  <p className="font-semibold text-slate-900">
+                    Con: {others || 'Participante desconocido'}
+                  </p>
                   {last && (
-                    <span className="block text-sm text-gray-600">
+                    <p className="text-xs text-slate-500">
+                      Último mensaje:{' '}
                       {last.senderId === user.id
-                        ? 'You'
-                        : `${last.sender?.name ?? 'Unknown'}${
+                        ? 'Enviado por vos'
+                        : `${last.sender?.name ?? 'Sin nombre'}${
                             last.sender?.lastName
                               ? ' ' + last.sender.lastName
                               : ''
                           }`}
                       : {last.body}
-                    </span>
+                    </p>
                   )}
                 </li>
               );
@@ -120,8 +167,11 @@ export default async function ViewUserPage({
       </div>
 
       <div>
-        <Link href="/admin/users" className="text-blue-600 hover:underline">
-          Back to users
+        <Link
+          href="/admin/users"
+          className="inline-flex items-center rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-semibold text-emerald-600 shadow-sm transition hover:border-emerald-400 hover:text-emerald-700"
+        >
+          ← Volver al listado
         </Link>
       </div>
     </div>

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,41 +1,50 @@
 export default function ContactPage() {
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center p-4 space-y-4 text-center">
-      <h1 className="text-2xl font-bold">¡Estamos en contacto!</h1>
-      <div>
-        <h2 className="font-semibold">Instagram</h2>
-        <p>
+    <div className="mx-auto flex max-w-3xl flex-col gap-8 text-center">
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-slate-900">
+          ¡Estamos en contacto!
+        </h1>
+        <p className="text-sm text-slate-500">
+          Elegí el canal que prefieras y conversemos sobre próximas actividades,
+          inscripciones o consultas administrativas.
+        </p>
+      </div>
+      <div className="grid gap-6 sm:grid-cols-3">
+        <div className="flex flex-col items-center gap-2 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <span className="text-2xl">📸</span>
+          <h2 className="text-sm font-semibold text-slate-800">Instagram</h2>
           <a
             href="https://www.instagram.com/hualas_patagonico"
             target="_blank"
             rel="noopener noreferrer"
-            className="text-blue-500 underline"
+            className="text-sm font-medium text-emerald-600 transition hover:text-emerald-700"
           >
             @hualas_patagonico
           </a>
-        </p>
-      </div>
-      <div>
-        <h2 className="font-semibold">Información general</h2>
-        <p>
+        </div>
+        <div className="flex flex-col items-center gap-2 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <span className="text-2xl">✉️</span>
+          <h2 className="text-sm font-semibold text-slate-800">
+            Información general
+          </h2>
           <a
             href="mailto:Info@clubhualas.com.ar"
-            className="text-blue-500 underline"
+            className="text-sm font-medium text-emerald-600 transition hover:text-emerald-700"
           >
             Info@clubhualas.com.ar
           </a>
-        </p>
-      </div>
-      <div>
-        <h2 className="font-semibold">Tesorería</h2>
-        <p>
+        </div>
+        <div className="flex flex-col items-center gap-2 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur">
+          <span className="text-2xl">💳</span>
+          <h2 className="text-sm font-semibold text-slate-800">Tesorería</h2>
           <a
             href="mailto:tesoreria@clubhualas.com.ar"
-            className="text-blue-500 underline"
+            className="text-sm font-medium text-emerald-600 transition hover:text-emerald-700"
           >
             tesoreria@clubhualas.com.ar
           </a>
-        </p>
+        </div>
       </div>
     </div>
   );

--- a/src/app/forms/[id]/form.tsx
+++ b/src/app/forms/[id]/form.tsx
@@ -29,17 +29,23 @@ export default function FormDisplay({ form }: { form: any }) {
     }
   };
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-4">
+    <form
+      onSubmit={handleSubmit}
+      className="space-y-6 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+    >
       {form.fields.map((f: any) => (
-        <div key={f.id}>
-          <label className="block mb-1">
+        <div key={f.id} className="space-y-2">
+          <label className="block text-sm font-semibold text-slate-800">
             {f.label}
-            {f.required && <span className="text-red-600 ml-1">*</span>}
+            {f.required && <span className="ml-1 text-red-500">*</span>}
           </label>
           {f.type === 'text' && (
             <input
-              className="border p-2 w-full"
+              className={fieldClass}
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
               required={f.required}
@@ -48,7 +54,7 @@ export default function FormDisplay({ form }: { form: any }) {
           {f.type === 'number' && (
             <input
               type="number"
-              className="border p-2 w-full"
+              className={fieldClass}
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
               required={f.required}
@@ -56,7 +62,7 @@ export default function FormDisplay({ form }: { form: any }) {
           )}
           {f.type === 'select' && (
             <select
-              className="border p-2 w-full"
+              className={fieldClass}
               value={data[f.id] || ''}
               onChange={(e) => handleChange(f.id, e.target.value)}
               required={f.required}
@@ -72,10 +78,21 @@ export default function FormDisplay({ form }: { form: any }) {
           )}
         </div>
       ))}
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <button type="submit" className="px-4 py-2 bg-blue-600 text-white">
-        Submit
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <button
+        type="submit"
+        className="inline-flex w-full items-center justify-center rounded-full bg-slate-900 px-5 py-3 text-sm font-semibold text-white shadow-lg shadow-slate-900/30 transition hover:bg-slate-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+      >
+        Enviar
       </button>
     </form>
   );

--- a/src/app/forms/[id]/page.tsx
+++ b/src/app/forms/[id]/page.tsx
@@ -18,11 +18,22 @@ export default async function FormPage({ params }: { params: { id: string } }) {
     include: { fields: { orderBy: { order: 'asc' } } },
   });
   if (!form) {
-    return <div className="p-4">Form not found</div>;
+    return (
+      <div className="rounded-3xl border border-dashed border-slate-300/70 bg-white/60 p-10 text-center text-slate-500 backdrop-blur">
+        Formulario no disponible
+      </div>
+    );
   }
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">{form.title}</h1>
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">
+          {form.title}
+        </h1>
+        {form.description && (
+          <p className="text-sm text-slate-500">{form.description}</p>
+        )}
+      </div>
       <FormDisplay form={form} />
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,14 +34,30 @@ export default async function RootLayout({
   });
   return (
     <html lang="en">
-      <body
-        className="min-h-screen text-foreground flex flex-col"
-        style={{ backgroundColor: settings?.backgroundColor || undefined }}
-      >
+      <body className="min-h-screen bg-slate-100 text-slate-900 antialiased">
         <Providers>
-          <Navbar />
-          <main className="flex-1">{children}</main>
-          <Footer settings={settings} />
+          <div className="relative flex min-h-screen flex-col overflow-hidden">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(15,118,110,0.08),_transparent_55%)]" />
+            <div className="pointer-events-none absolute -top-48 -right-32 h-72 w-72 rounded-full bg-emerald-200/40 blur-3xl" />
+            <div className="pointer-events-none absolute -bottom-32 -left-24 h-80 w-80 rounded-full bg-sky-200/40 blur-3xl" />
+            <div className="relative flex min-h-screen flex-col">
+              <Navbar />
+              <main className="flex-1">
+                <div className="mx-auto w-full max-w-5xl px-4 py-10 sm:px-6 lg:px-8">{children}</div>
+              </main>
+              <Footer settings={settings} />
+            </div>
+            <a
+              href="https://wa.me/5491151298250"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group fixed bottom-6 right-6 inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-3 text-sm font-semibold text-white shadow-xl shadow-emerald-500/30 transition-all hover:translate-y-[-2px] hover:bg-emerald-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-300 focus-visible:ring-offset-2"
+              aria-label="Contactar por WhatsApp"
+            >
+              <span className="text-base">💬</span>
+              <span className="hidden sm:inline">WhatsApp</span>
+            </a>
+          </div>
         </Providers>
       </body>
     </html>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -33,59 +33,76 @@ export default function LoginPage() {
     }
   };
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <div className="p-4 max-w-sm mx-auto space-y-2">
-      <input
-        className="w-full border px-2 py-1"
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <div className="relative">
+    <div className="mx-auto max-w-md space-y-6 rounded-3xl border border-white/60 bg-white/70 p-8 shadow-lg shadow-slate-900/5 backdrop-blur">
+      <div className="space-y-1 text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">{t.signIn}</h1>
+        <p className="text-sm text-slate-500">
+          Accedé a tu cuenta para gestionar tus actividades y notificaciones.
+        </p>
+      </div>
+      <div className="space-y-3">
         <input
-          className="w-full border px-2 py-1 pr-8"
-          type={showPassword ? 'text' : 'password'}
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          className={fieldClass}
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
         />
-        <button
-          type="button"
-          onClick={() => setShowPassword(!showPassword)}
-          aria-label={t.showPassword}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
-        >
-          {showPassword ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-        </button>
+        <div className="relative">
+          <input
+            className={`${fieldClass} pr-10`}
+            type={showPassword ? 'text' : 'password'}
+            placeholder="Contraseña"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={t.showPassword}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 transition hover:text-slate-600"
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
       </div>
       {error && (
-        <p className="text-red-500 text-sm">{t[error as keyof typeof t]}</p>
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {t[error as keyof typeof t]}
+        </p>
       )}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button
-        className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={submit}
-      >
-        {t.signIn}
-      </Button>
-      <Button
-        className="w-full flex items-center justify-center bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={() => signIn('google', { callbackUrl: '/' })}
-      >
-        <Image
-          src="/google.svg"
-          alt="Google logo"
-          width={20}
-          height={20}
-          className="mr-2"
-        />
-        {t.signInWithGoogle}
-      </Button>
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <div className="space-y-3">
+        <Button onClick={submit} className="w-full shadow-lg shadow-emerald-500/30">
+          {t.signIn}
+        </Button>
+        <Button
+          onClick={() => signIn('google', { callbackUrl: '/' })}
+          variant="secondary"
+          className="w-full justify-center gap-3"
+        >
+          <Image
+            src="/google.svg"
+            alt="Google logo"
+            width={20}
+            height={20}
+            className="h-5 w-5"
+          />
+          {t.signInWithGoogle}
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,52 +27,81 @@ export default async function Home() {
   }
 
   return (
-    <main className="p-4">
+    <div className="space-y-12">
       <HomeHeading />
-      <ul className="space-y-4">
-        {activities.map((activity) => (
-          <li key={activity.id}>
-            <Link
-              href={`/activities/${activity.id}`}
-              className="block max-w-sm w-full lg:max-w-full lg:flex"
-            >
-              <div
-                className="h-48 lg:h-auto lg:w-48 flex-none bg-cover rounded-t lg:rounded-t-none lg:rounded-l text-center overflow-hidden bg-gray-200"
-                style={
-                  activity.image
-                    ? { backgroundImage: `url(${activity.image})` }
-                    : undefined
-                }
-                title={activity.name}
-              />
-              <div className="border-r border-b border-l border-gray-400 lg:border-l-0 lg:border-t lg:border-gray-400 bg-white rounded-b lg:rounded-b-none lg:rounded-r p-4 flex flex-col justify-between leading-normal">
-                <div className="mb-8">
-                  {activity.date && (
-                    <p className="text-sm text-gray-600">
-                      {activity.date.toLocaleDateString()}
-                    </p>
+      <section className="space-y-6">
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-slate-900">
+              Próximas actividades
+            </h2>
+            <p className="text-sm text-slate-500">
+              Sumate a las propuestas vigentes o descubrí qué se viene.
+            </p>
+          </div>
+          <Link
+            href="/activities"
+            className="text-sm font-semibold text-emerald-600 transition hover:text-emerald-700"
+          >
+            Ver todas las actividades →
+          </Link>
+        </div>
+        {activities.length === 0 ? (
+          <div className="rounded-3xl border border-dashed border-slate-300/70 bg-white/60 p-10 text-center text-slate-500 backdrop-blur">
+            Aún no hay actividades publicadas. ¡Pronto habrá novedades!
+          </div>
+        ) : (
+          <ul className="grid gap-6 md:grid-cols-2">
+            {activities.map((activity) => (
+              <li key={activity.id}>
+                <Link
+                  href={`/activities/${activity.id}`}
+                  className="group relative flex h-full flex-col overflow-hidden rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur transition duration-300 hover:-translate-y-1 hover:shadow-emerald-200/40"
+                >
+                  {activity.image ? (
+                    <div
+                      className="relative h-40 overflow-hidden rounded-2xl bg-slate-200"
+                    >
+                      <div
+                        className="absolute inset-0 bg-cover bg-center transition duration-300 group-hover:scale-105"
+                        style={{ backgroundImage: `url(${activity.image})` }}
+                      />
+                      <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-slate-900/70 to-transparent" />
+                    </div>
+                  ) : (
+                    <div className="flex h-40 items-center justify-center rounded-2xl bg-slate-100 text-slate-400">
+                      Sin imagen disponible
+                    </div>
                   )}
-                  <div className="text-gray-900 font-bold text-xl mb-2">
-                    {activity.name}
+                  <div className="mt-5 flex flex-1 flex-col gap-3">
+                    {activity.date && (
+                      <span className="inline-flex w-fit items-center rounded-full bg-emerald-50/90 px-3 py-1 text-xs font-semibold text-emerald-700">
+                        {activity.date.toLocaleDateString()}
+                      </span>
+                    )}
+                    <h3 className="text-lg font-semibold text-slate-900">
+                      {activity.name}
+                    </h3>
+                    {activity.description && (
+                      <p className="text-sm text-slate-500">
+                        {activity.description}
+                      </p>
+                    )}
+                    <div className="mt-auto flex items-center justify-between text-sm">
+                      <span className="font-semibold text-slate-700">
+                        Participantes: {activity.participants.length}
+                      </span>
+                      <span className="text-emerald-600 transition group-hover:text-emerald-700">
+                        Ver detalle
+                      </span>
+                    </div>
                   </div>
-                  {activity.description && (
-                    <p className="text-gray-700 text-base">
-                      {activity.description}
-                    </p>
-                  )}
-                </div>
-                <div className="flex items-center">
-                  <div className="text-sm">
-                    <p className="text-gray-600">
-                      {activity.participants.length} participantes
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </main>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </div>
   );
 }

--- a/src/app/profile/children.tsx
+++ b/src/app/profile/children.tsx
@@ -32,6 +32,11 @@ export default function ChildrenManager({
   const [gender, setGender] = useState('');
   const [nationality, setNationality] = useState('');
   const [maritalStatus, setMaritalStatus] = useState('');
+  const [contact, setContact] = useState('');
+  const [formError, setFormError] = useState('');
+  const [formSuccess, setFormSuccess] = useState('');
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
 
   useEffect(() => {
     fetch('/api/children')
@@ -47,21 +52,28 @@ export default function ChildrenManager({
 
   async function addChild(e: React.FormEvent) {
     e.preventDefault();
+    setFormError('');
+    setFormSuccess('');
+    if (!name || !lastName || !documentType || !documentNumber || !birthDate) {
+      setFormError('Completá todos los campos obligatorios.');
+      return;
+    }
     const res = await fetch('/api/children', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        name,
-        lastName,
-        documentType,
-        documentNumber,
-        birthDate,
-        address,
-        gender: gender || undefined,
-        nationality,
-        maritalStatus,
-      }),
-    });
+        body: JSON.stringify({
+          name,
+          lastName,
+          documentType,
+          documentNumber,
+          birthDate,
+          address,
+          gender: gender || undefined,
+          nationality,
+          maritalStatus,
+          observations: contact || undefined,
+        }),
+      });
     if (res.ok) {
       const child = await res.json();
       setChildren([...children, child]);
@@ -75,93 +87,151 @@ export default function ChildrenManager({
       setGender('');
       setNationality('');
       setMaritalStatus('');
+      setContact('');
+      setFormSuccess('Participante agregado correctamente.');
+    } else {
+      setFormError('No se pudo guardar el participante.');
     }
   }
 
   return (
-    <div className="mt-6 space-y-2 max-w-sm">
-      <h2 className="text-xl font-semibold">Hijos</h2>
-      <ul className="list-disc pl-4">
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h2 className="text-2xl font-semibold text-slate-900">
+          Información de participantes
+        </h2>
+        <p className="text-sm text-slate-500">
+          Registrá a tus hijas e hijos para inscribirlos rápidamente en las
+          actividades.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-2">
         {children.map((c) => (
-          <li key={c.id}>{c.name}</li>
+          <div
+            key={c.id}
+            className="rounded-3xl border border-white/60 bg-white/70 p-4 shadow-lg shadow-slate-900/5 backdrop-blur"
+          >
+            <p className="text-sm font-semibold text-slate-900">
+              {c.name} {c.lastName ?? ''}
+            </p>
+            {c.documentNumber && (
+              <p className="text-xs text-slate-500">
+                {c.documentType}: {c.documentNumber}
+              </p>
+            )}
+            {c.birthDate && (
+              <p className="text-xs text-slate-500">
+                Nacimiento: {c.birthDate}
+              </p>
+            )}
+          </div>
         ))}
-      </ul>
-      <form onSubmit={addChild} className="space-y-2">
-        <input
-          className="w-full border px-2 py-1"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="Nombre"
-        />
-        <input
-          className="w-full border px-2 py-1"
-          value={lastName}
-          onChange={(e) => setLastName(e.target.value)}
-          placeholder="Apellido"
-        />
-        <select
-          className="w-full border px-2 py-1"
-          value={documentType}
-          onChange={(e) => setDocumentType(e.target.value)}
-        >
-          <option value="">Tipo de documento</option>
-          <option value="DNI">DNI</option>
-          <option value="PASAPORTE">Pasaporte</option>
-          <option value="OTRO">Otro</option>
-        </select>
-        <input
-          className="w-full border px-2 py-1"
-          value={documentNumber}
-          onChange={(e) => setDocumentNumber(e.target.value)}
-          placeholder="Número / Código"
-        />
-        <input
-          className="w-full border px-2 py-1"
-          type="date"
-          value={birthDate}
-          onChange={(e) => setBirthDate(e.target.value)}
-          placeholder="Fecha de nacimiento"
-        />
-        <input
-          className="w-full border px-2 py-1"
-          value={address}
-          onChange={(e) => setAddress(e.target.value)}
-          placeholder="Domicilio"
-        />
-        <label className="text-sm flex items-center space-x-1">
+        {children.length === 0 && (
+          <div className="rounded-3xl border border-dashed border-slate-300/70 bg-white/60 p-6 text-sm text-slate-500 backdrop-blur">
+            Todavía no registraste participantes.
+          </div>
+        )}
+      </div>
+      <form
+        onSubmit={addChild}
+        className="space-y-4 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+      >
+        <div className="grid gap-4 sm:grid-cols-2">
+          <input
+            className={fieldClass}
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Nombre"
+          />
+          <input
+            className={fieldClass}
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            placeholder="Apellido"
+          />
+          <select
+            className={fieldClass}
+            value={documentType}
+            onChange={(e) => setDocumentType(e.target.value)}
+          >
+            <option value="">Tipo de documento</option>
+            <option value="DNI">DNI</option>
+            <option value="PASAPORTE">Pasaporte</option>
+            <option value="OTRO">Otro</option>
+          </select>
+          <input
+            className={fieldClass}
+            value={documentNumber}
+            onChange={(e) => setDocumentNumber(e.target.value)}
+            placeholder="Número / Código"
+          />
+          <input
+            className={fieldClass}
+            type="date"
+            value={birthDate}
+            onChange={(e) => setBirthDate(e.target.value)}
+            placeholder="Fecha de nacimiento"
+          />
+          <input
+            className={fieldClass}
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            placeholder="Domicilio"
+          />
+        </div>
+        <label className="flex items-center gap-2 text-sm text-slate-600">
           <input
             type="checkbox"
             checked={sameAddress}
             onChange={(e) => setSameAddress(e.target.checked)}
+            className="h-4 w-4 rounded border-slate-300 text-emerald-600 focus:ring-emerald-500"
           />
           <span>Mismo domicilio que el usuario</span>
         </label>
-        <select
-          className="w-full border px-2 py-1"
-          value={gender}
-          onChange={(e) => setGender(e.target.value)}
-        >
-          <option value="">Género</option>
-          <option value="FEMALE">Femenino</option>
-          <option value="MALE">Masculino</option>
-          <option value="NON_BINARY">No Binario</option>
-          <option value="UNDISCLOSED">Prefiero no decirlo</option>
-          <option value="OTHER">Otro</option>
-        </select>
-        <input
-          className="w-full border px-2 py-1"
-          value={nationality}
-          onChange={(e) => setNationality(e.target.value)}
-          placeholder="Nacionalidad"
-        />
-        <input
-          className="w-full border px-2 py-1"
-          value={maritalStatus}
-          onChange={(e) => setMaritalStatus(e.target.value)}
-          placeholder="Estado Civil"
-        />
-        <Button type="submit" className="w-full">
-          Agregar hijo
+        <div className="grid gap-4 sm:grid-cols-2">
+          <select
+            className={fieldClass}
+            value={gender}
+            onChange={(e) => setGender(e.target.value)}
+          >
+            <option value="">Género</option>
+            <option value="FEMALE">Femenino</option>
+            <option value="MALE">Masculino</option>
+            <option value="NON_BINARY">No binario</option>
+            <option value="UNDISCLOSED">Prefiero no decirlo</option>
+            <option value="OTHER">Otro</option>
+          </select>
+          <input
+            className={fieldClass}
+            value={nationality}
+            onChange={(e) => setNationality(e.target.value)}
+            placeholder="Nacionalidad"
+          />
+          <input
+            className={fieldClass}
+            value={maritalStatus}
+            onChange={(e) => setMaritalStatus(e.target.value)}
+            placeholder="Estado civil"
+          />
+          <input
+            className={fieldClass}
+            value={contact}
+            onChange={(e) => setContact(e.target.value)}
+            placeholder="Contacto de emergencia"
+          />
+        </div>
+        {formError && (
+          <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+            {formError}
+          </p>
+        )}
+        {formSuccess && (
+          <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+            {formSuccess}
+          </p>
+        )}
+        <Button type="submit" className="w-full shadow-lg shadow-emerald-500/30">
+          Agregar participante
         </Button>
       </form>
     </div>

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -64,86 +64,103 @@ export default function ProfileForm({ user }: { user: User }) {
     }
   }
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <form onSubmit={submit} className="space-y-2 max-w-sm">
-      <input
-        className="w-full border px-2 py-1"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        placeholder="Nombre"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={lastName}
-        onChange={(e) => setLastName(e.target.value)}
-        placeholder="Apellido"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={dni}
-        onChange={(e) => setDni(e.target.value)}
-        placeholder="DNI"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        type="date"
-        value={birthDate}
-        onChange={(e) => setBirthDate(e.target.value)}
-        placeholder="Fecha de nacimiento"
-      />
-      <select
-        className="w-full border px-2 py-1"
-        value={gender}
-        onChange={(e) => setGender(e.target.value)}
-      >
-        <option value="">Género</option>
-        <option value="FEMALE">Femenino</option>
-        <option value="MALE">Masculino</option>
-        <option value="NON_BINARY">No Binario</option>
-        <option value="UNDISCLOSED">Prefiero no decirlo</option>
-        <option value="OTHER">Otro</option>
-      </select>
-      <input
-        className="w-full border px-2 py-1"
-        value={address}
-        onChange={(e) => setAddress(e.target.value)}
-        placeholder="Domicilio"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={phone}
-        onChange={(e) => setPhone(e.target.value)}
-        placeholder="Teléfono"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={nationality}
-        onChange={(e) => setNationality(e.target.value)}
-        placeholder="Nacionalidad"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={maritalStatus}
-        onChange={(e) => setMaritalStatus(e.target.value)}
-        placeholder="Estado Civil"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="Email"
-      />
-      <input
-        className="w-full border px-2 py-1"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="New password"
-      />
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button type="submit" className="w-full">
-        Save
+    <form
+      onSubmit={submit}
+      className="space-y-6 rounded-3xl border border-white/60 bg-white/70 p-6 shadow-lg shadow-slate-900/5 backdrop-blur"
+    >
+      <div className="grid gap-4 sm:grid-cols-2">
+        <input
+          className={fieldClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nombre"
+        />
+        <input
+          className={fieldClass}
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Apellido"
+        />
+        <input
+          className={fieldClass}
+          value={dni}
+          onChange={(e) => setDni(e.target.value)}
+          placeholder="DNI"
+        />
+        <input
+          className={fieldClass}
+          type="date"
+          value={birthDate}
+          onChange={(e) => setBirthDate(e.target.value)}
+          placeholder="Fecha de nacimiento"
+        />
+        <select
+          className={fieldClass}
+          value={gender}
+          onChange={(e) => setGender(e.target.value)}
+        >
+          <option value="">Género</option>
+          <option value="FEMALE">Femenino</option>
+          <option value="MALE">Masculino</option>
+          <option value="NON_BINARY">No binario</option>
+          <option value="UNDISCLOSED">Prefiero no decirlo</option>
+          <option value="OTHER">Otro</option>
+        </select>
+        <input
+          className={fieldClass}
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          placeholder="Domicilio"
+        />
+        <input
+          className={fieldClass}
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          placeholder="Teléfono"
+        />
+        <input
+          className={fieldClass}
+          value={nationality}
+          onChange={(e) => setNationality(e.target.value)}
+          placeholder="Nacionalidad"
+        />
+        <input
+          className={fieldClass}
+          value={maritalStatus}
+          onChange={(e) => setMaritalStatus(e.target.value)}
+          placeholder="Estado civil"
+        />
+        <input
+          className={`${fieldClass} sm:col-span-2`}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          type="email"
+        />
+        <input
+          className={`${fieldClass} sm:col-span-2`}
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Nueva contraseña"
+        />
+      </div>
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <Button type="submit" className="w-full shadow-lg shadow-emerald-500/30">
+        Guardar cambios
       </Button>
     </form>
   );

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -29,8 +29,14 @@ export default async function ProfilePage() {
     redirect('/');
   }
   return (
-    <div className="p-4">
-      <h1 className="text-2xl font-bold mb-4">Profile</h1>
+    <div className="space-y-8">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold text-slate-900">Mi perfil</h1>
+        <p className="text-sm text-slate-500">
+          Actualizá tus datos personales y gestioná la información de tu grupo
+          familiar.
+        </p>
+      </div>
       <ProfileForm
         user={{
           ...user,

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -41,62 +41,83 @@ export default function RegisterPage() {
     }
   }
 
+  const fieldClass =
+    'w-full rounded-xl border border-slate-200 bg-white/80 px-4 py-3 text-sm text-slate-700 shadow-sm transition focus:outline-none focus:ring-2 focus:ring-slate-200';
+
   return (
-    <div className="p-4 max-w-sm mx-auto space-y-2">
-      <input
-        className="w-full border px-2 py-1"
-        placeholder="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <input
-        className="w-full border px-2 py-1"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <div className="relative">
-        <input
-          className="w-full border px-2 py-1 pr-8"
-          placeholder="Password"
-          type={showPassword ? 'text' : 'password'}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        <button
-          type="button"
-          onClick={() => setShowPassword(!showPassword)}
-          aria-label={t.showPassword}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
-        >
-          {showPassword ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-        </button>
+    <div className="mx-auto max-w-md space-y-6 rounded-3xl border border-white/60 bg-white/70 p-8 shadow-lg shadow-slate-900/5 backdrop-blur">
+      <div className="space-y-1 text-center">
+        <h1 className="text-2xl font-semibold text-slate-900">Crear cuenta</h1>
+        <p className="text-sm text-slate-500">
+          Unite a la comunidad Hualas para descubrir actividades y gestionar tu
+          participación.
+        </p>
       </div>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button
-        className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={submit}
-      >
-        Register
-      </Button>
-      <Button
-        className="w-full flex items-center justify-center bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={() => signIn('google', { callbackUrl: '/' })}
-      >
-        <Image
-          src="/google.svg"
-          alt="Google logo"
-          width={20}
-          height={20}
-          className="mr-2"
+      <div className="space-y-3">
+        <input
+          className={fieldClass}
+          placeholder="Nombre completo"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
         />
-        Register with Google
-      </Button>
+        <input
+          className={fieldClass}
+          placeholder="Email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <div className="relative">
+          <input
+            className={`${fieldClass} pr-10`}
+            placeholder="Contraseña"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={t.showPassword}
+            className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-400 transition hover:text-slate-600"
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+      </div>
+      {error && (
+        <p className="rounded-xl border border-red-200 bg-red-50/80 p-3 text-sm text-red-600">
+          {error}
+        </p>
+      )}
+      {success && (
+        <p className="rounded-xl border border-emerald-200 bg-emerald-50/80 p-3 text-sm text-emerald-600">
+          {success}
+        </p>
+      )}
+      <div className="space-y-3">
+        <Button onClick={submit} className="w-full shadow-lg shadow-emerald-500/30">
+          Registrarme
+        </Button>
+        <Button
+          onClick={() => signIn('google', { callbackUrl: '/' })}
+          variant="secondary"
+          className="w-full justify-center gap-3"
+        >
+          <Image
+            src="/google.svg"
+            alt="Google logo"
+            width={20}
+            height={20}
+            className="h-5 w-5"
+          />
+          Registrarme con Google
+        </Button>
+      </div>
     </div>
   );
 }

--- a/src/components/activities-heading.tsx
+++ b/src/components/activities-heading.tsx
@@ -4,5 +4,14 @@ import { useTranslation } from './language-provider';
 
 export default function ActivitiesHeading() {
   const t = useTranslation();
-  return <h1 className="text-2xl font-bold">{t.nav.activities}</h1>;
+  return (
+    <div className="space-y-1">
+      <h1 className="text-2xl font-semibold text-slate-900 sm:text-3xl">
+        {t.nav.activities}
+      </h1>
+      <p className="text-sm text-slate-500">
+        Gestioná las propuestas disponibles y mantené informada a la comunidad.
+      </p>
+    </div>
+  );
 }

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -8,40 +8,46 @@ export default function Footer({
 }: {
   settings: SiteSettings | null;
 }) {
+  const footerStyle = settings?.footerColor
+    ? { backgroundColor: `${settings.footerColor}e6` }
+    : undefined;
   return (
     <footer
-      className="flex flex-col items-center justify-center px-4 py-6 text-white text-center"
-      style={{ backgroundColor: settings?.footerColor || '#1e293b' }}
+      className="border-t border-white/60 bg-white/80 text-slate-600 backdrop-blur"
+      style={footerStyle}
     >
-      <p className="text-2xl">💚</p>
-      <p className="mt-2">¡Seguinos en nuestras redes!</p>
-      <div className="mt-2 flex flex-col items-center gap-2">
-        <a
-          href="https://www.instagram.com/hualas_patagonico/"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2"
-          aria-label="Instagram"
-        >
-          <Instagram />
-          <span>@hualas_patagonico</span>
-        </a>
-        <a
-          href="https://youtube.com/@escuelademontanahualas?si=j8VEKHbe9IRhXsw4"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex items-center gap-2"
-          aria-label="YouTube"
-        >
-          <Youtube />
-          <span>@escuelademontanahualas</span>
-        </a>
+      <div className="mx-auto flex w-full max-w-5xl flex-col items-center gap-6 px-4 py-10 text-center sm:px-6">
+        <div className="inline-flex items-center gap-3 rounded-full bg-white/70 px-4 py-2 text-sm font-semibold text-emerald-600 shadow-sm">
+          <span className="text-lg">💚</span>
+          <span>Seguinos en nuestras redes</span>
+        </div>
+        <div className="flex flex-col items-center gap-3 text-slate-500 sm:flex-row sm:gap-6">
+          <a
+            href="https://www.instagram.com/hualas_patagonico/"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-4 py-2 text-sm font-medium transition hover:border-emerald-400 hover:text-emerald-600"
+            aria-label="Instagram"
+          >
+            <Instagram className="h-4 w-4" />
+            <span>@hualas_patagonico</span>
+          </a>
+          <a
+            href="https://youtube.com/@escuelademontanahualas?si=j8VEKHbe9IRhXsw4"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-full border border-white/60 bg-white/70 px-4 py-2 text-sm font-medium transition hover:border-emerald-400 hover:text-emerald-600"
+            aria-label="YouTube"
+          >
+            <Youtube className="h-4 w-4" />
+            <span>@escuelademontanahualas</span>
+          </a>
+        </div>
+        <p className="max-w-xl text-sm text-slate-500">
+          Club Social y Deportivo Hualas Patagónico.<br />
+          ⛰️ San Martín de los Andes, Neuquén, Patagonia Argentina. 🇦🇷
+        </p>
       </div>
-      <p className="mt-2">
-        Club Social y Deportivo Hualas Patagónico.
-        <br />
-        ⛰️San Martín de los Andes, Neuquén, Patagonia Argentina. 🇦🇷
-      </p>
     </footer>
   );
 }

--- a/src/components/home-heading.tsx
+++ b/src/components/home-heading.tsx
@@ -1,8 +1,48 @@
 'use client';
 
+import Link from 'next/link';
 import { useTranslation } from './language-provider';
+import { buttonVariants } from './ui/button';
+import { cn } from '@/lib/utils';
 
 export default function HomeHeading() {
   const t = useTranslation();
-  return <h1 className="mb-4 text-2xl font-bold">{t.home.welcome}</h1>;
+  return (
+    <section className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-slate-900 via-slate-800 to-slate-600 px-8 py-12 text-white shadow-2xl shadow-slate-900/30">
+      <div className="pointer-events-none absolute -top-24 -right-24 h-56 w-56 rounded-full bg-emerald-400/40 blur-3xl" />
+      <div className="pointer-events-none absolute -bottom-12 left-12 h-40 w-40 rounded-full bg-sky-400/40 blur-3xl" />
+      <div className="relative max-w-2xl space-y-4">
+        <span className="inline-flex items-center rounded-full bg-white/10 px-4 py-1 text-sm font-medium text-emerald-200">
+          Club de montaña y aventura
+        </span>
+        <h1 className="text-3xl font-semibold tracking-tight sm:text-4xl">
+          {t.home.welcome}
+        </h1>
+        <p className="text-base text-slate-200 sm:text-lg">
+          Disfrutá de experiencias inolvidables en la Patagonia argentina con una
+          comunidad apasionada por la naturaleza y el deporte al aire libre.
+        </p>
+        <div className="flex flex-wrap gap-3 pt-4">
+          <Link
+            href="/register"
+            className={cn(
+              buttonVariants({ variant: 'secondary', size: 'lg' }),
+              'shadow-xl shadow-slate-900/20'
+            )}
+          >
+            Explorar actividades
+          </Link>
+          <Link
+            href="/contact"
+            className={cn(
+              buttonVariants({ variant: 'ghost', size: 'lg' }),
+              'border border-white/20 text-white hover:bg-white/10 hover:text-white focus-visible:ring-white/40'
+            )}
+          >
+            Conversemos
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { Menu } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type ReactNode } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import type { SiteSettings } from '@/types/site';
 import {
@@ -36,76 +36,109 @@ export default function Navbar() {
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`
     : defaultLogo;
 
-  return (
-    <nav
-      className="flex flex-col px-4 py-2 text-white md:flex-row md:items-center md:justify-between"
-      style={{ backgroundColor: settings?.navbarColor || '#1e293b' }}
+  const navbarStyle = settings?.navbarColor
+    ? {
+        backgroundColor: `${settings.navbarColor}e6`,
+      }
+    : undefined;
+
+  const NavLink = ({ href, children }: { href: string; children: ReactNode }) => (
+    <Link
+      href={href}
+      className="rounded-full px-4 py-2 text-sm font-medium text-slate-600 transition hover:bg-slate-100/70 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
     >
-      <div className="flex items-center justify-between w-full md:w-auto">
-        <Link href="/" className="flex items-center gap-2">
-          <Image
-            src={logoUrl}
-            alt="Hualas Club logo"
-            width={40}
-            height={40}
-            unoptimized
-          />
-          <span className="font-semibold">Hualas Patagónico</span>
-        </Link>
-        <button
-          className="md:hidden"
-          onClick={() => setMenuOpen((prev) => !prev)}
-          aria-label="Toggle menu"
-        >
-          <Menu />
-        </button>
-      </div>
-      <div
-        className={`${menuOpen ? 'flex' : 'hidden'} flex-col gap-2 mt-2 md:mt-0 md:flex md:flex-row md:items-center md:gap-[5ch]`}
+      {children}
+    </Link>
+  );
+
+  return (
+    <header className="sticky top-0 z-50 w-full">
+      <nav
+        className="border-b border-white/40 bg-white/90 backdrop-blur"
+        style={navbarStyle}
       >
-        <Link href="/activities">{t.activities}</Link>
-        {session && <Link href="/chat">{t.chat}</Link>}
-        {isAdmin && (
-          <>
-            <Link href="/admin/users">{t.users}</Link>
-            <Link href="/admin/forms">{t.forms}</Link>
-            <Link href="/admin/notifications">{t.notifications}</Link>
-            {isSuperAdmin && <Link href="/admin/site">{t.admin}</Link>}
-          </>
-        )}
-        <Link href="/contact">{t.contact}</Link>
-        {session ? (
-          <>
-            <Link href="/profile">{t.profile}</Link>
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4 px-4 py-4 text-slate-700 md:flex-row md:items-center md:justify-between md:py-3">
+          <div className="flex w-full items-center justify-between gap-4 md:w-auto">
+            <Link href="/" className="flex items-center gap-3">
+              <span className="relative flex h-12 w-12 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-slate-900 via-slate-700 to-slate-500 shadow-lg shadow-slate-900/20">
+                <Image
+                  src={logoUrl}
+                  alt="Hualas Club logo"
+                  width={48}
+                  height={48}
+                  className="h-10 w-10 object-contain"
+                  unoptimized
+                />
+              </span>
+              <div className="flex flex-col">
+                <span className="text-lg font-semibold text-slate-900">
+                  Hualas Patagónico
+                </span>
+                <span className="text-sm text-slate-500">
+                  Club Social &amp; Deportivo
+                </span>
+              </div>
+            </Link>
             <button
-              onClick={() => signOut({ callbackUrl: '/login' })}
-              className="hover:underline"
+              className="inline-flex items-center justify-center rounded-full bg-white/80 p-2 text-slate-600 shadow-sm ring-1 ring-white/60 transition hover:bg-white/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 md:hidden"
+              onClick={() => setMenuOpen((prev) => !prev)}
+              aria-label="Abrir menú de navegación"
             >
-              {t.logout}
+              <Menu className="h-5 w-5" />
             </button>
-          </>
-        ) : (
-          <>
-            <Link href="/login" className="hover:underline">
-              {t.login}
-            </Link>
-            <Link href="/register" className="hover:underline">
-              {t.register}
-            </Link>
-          </>
-        )}
-        <select
-          value={lang}
-          onChange={(e) => setLang(e.target.value as Lang)}
-          className="bg-transparent text-black dark:text-white"
-        >
-          {availableLanguages.map(({ code, flag }) => (
-            <option key={code} value={code}>
-              {flag}
-            </option>
-          ))}
-        </select>
-      </div>
-    </nav>
+          </div>
+
+          <div
+            className={`${
+              menuOpen ? 'flex' : 'hidden'
+            } flex-col gap-2 rounded-3xl border border-white/40 bg-white/70 p-4 shadow-lg shadow-slate-900/5 backdrop-blur md:flex md:flex-row md:items-center md:gap-4 md:border-0 md:bg-transparent md:p-0 md:shadow-none`}
+          >
+            <div className="flex flex-col gap-1 md:flex-row md:items-center">
+              <NavLink href="/activities">{t.activities}</NavLink>
+              {session && <NavLink href="/chat">{t.chat}</NavLink>}
+              {isAdmin && (
+                <>
+                  <NavLink href="/admin/users">{t.users}</NavLink>
+                  <NavLink href="/admin/forms">{t.forms}</NavLink>
+                  <NavLink href="/admin/notifications">{t.notifications}</NavLink>
+                  {isSuperAdmin && <NavLink href="/admin/site">{t.admin}</NavLink>}
+                </>
+              )}
+              <NavLink href="/contact">{t.contact}</NavLink>
+            </div>
+
+            <div className="flex flex-col gap-2 md:flex-row md:items-center">
+              {session ? (
+                <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                  <NavLink href="/profile">{t.profile}</NavLink>
+                  <button
+                    onClick={() => signOut({ callbackUrl: '/login' })}
+                    className="rounded-full px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100/70 hover:text-slate-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200"
+                  >
+                    {t.logout}
+                  </button>
+                </div>
+              ) : (
+                <div className="flex flex-col gap-2 md:flex-row md:items-center">
+                  <NavLink href="/login">{t.login}</NavLink>
+                  <NavLink href="/register">{t.register}</NavLink>
+                </div>
+              )}
+              <select
+                value={lang}
+                onChange={(e) => setLang(e.target.value as Lang)}
+                className="w-full rounded-full border border-white/60 bg-white/80 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-200 md:w-auto"
+              >
+                {availableLanguages.map(({ code, flag }) => (
+                  <option key={code} value={code}>
+                    {flag}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </div>
+      </nav>
+    </header>
   );
 }

--- a/src/components/register-button.tsx
+++ b/src/components/register-button.tsx
@@ -1,19 +1,42 @@
 'use client';
 
 import Link from 'next/link';
-import { Button } from './ui/button';
+import { Button, buttonVariants } from './ui/button';
 import { useTranslation } from './language-provider';
+import { cn } from '@/lib/utils';
 
 interface Props {
   href?: string;
   onClick?: () => void;
+  label?: string;
 }
 
-export default function RegisterButton({ href, onClick }: Props) {
+export default function RegisterButton({ href, onClick, label }: Props) {
   const t = useTranslation();
-  const btn = <Button onClick={onClick}>{t.nav.register}</Button>;
+  const text = label ?? t.nav.register;
   if (href) {
-    return <Link href={href}>{btn}</Link>;
+    return (
+      <Link
+        href={href}
+        className={cn(
+          buttonVariants({ variant: 'primary', size: 'md' }),
+          'shadow-lg shadow-emerald-500/30'
+        )}
+      >
+        {text}
+      </Link>
+    );
   }
-  return btn;
+  const handleClick = () => {
+    if (onClick) onClick();
+  };
+  return (
+    <Button
+      type="button"
+      onClick={handleClick}
+      className="shadow-lg shadow-emerald-500/30"
+    >
+      {text}
+    </Button>
+  );
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,16 +1,42 @@
 import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '@/lib/utils';
 
-export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-full font-semibold transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 shadow-sm focus-visible:ring-slate-300 focus-visible:ring-offset-slate-100',
+  {
+    variants: {
+      variant: {
+        primary: 'bg-slate-900 text-white hover:bg-slate-800',
+        secondary:
+          'bg-white text-slate-900 shadow-lg shadow-slate-900/5 hover:bg-slate-100/80',
+        outline:
+          'border border-slate-200 bg-white/70 text-slate-700 hover:border-slate-900 hover:text-slate-900',
+        ghost:
+          'bg-transparent text-slate-600 hover:bg-slate-100/70 hover:text-slate-900',
+      },
+      size: {
+        sm: 'px-3 py-1.5 text-xs',
+        md: 'px-5 py-2.5 text-sm',
+        lg: 'px-6 py-3 text-base',
+      },
+    },
+    defaultVariants: {
+      variant: 'primary',
+      size: 'md',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {}
 
 export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, ...props }, ref) => (
+  ({ className, variant, size, ...props }, ref) => (
     <button
       ref={ref}
-      className={cn(
-        'inline-flex items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus:outline-none disabled:opacity-50',
-        className,
-      )}
+      className={cn(buttonVariants({ variant, size }), className)}
       {...props}
     />
   ),


### PR DESCRIPTION
## Summary
- redesign the global layout with a glassmorphism backdrop, gradient hero, and updated navigation/footer shells
- add reusable button variants and restyle activities, authentication, profile, contact, and admin views for the new look
- enhance participant management with validation feedback and richer form capture

## Testing
- pnpm lint *(fails: corepack cannot download pnpm in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dff92dea088333979e9b0ec526b12b