### PR TITLE
Improve password form accessibility

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import Image from 'next/image';
@@ -17,7 +17,8 @@ export default function LoginPage() {
   const router = useRouter();
   const t = useTranslation().auth;
 
-  const submit = async () => {
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
     setError('');
     setSuccess('');
     const res = await signIn('credentials', {
@@ -35,44 +36,55 @@ export default function LoginPage() {
 
   return (
     <div className="p-4 max-w-sm mx-auto space-y-2">
-      <input
-        className="w-full border px-2 py-1"
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <div className="relative">
+      <form onSubmit={submit} className="space-y-2">
         <input
-          className="w-full border px-2 py-1 pr-8"
-          type={showPassword ? 'text' : 'password'}
-          placeholder="Password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border px-2 py-1"
+          id="login-email"
+          name="email"
+          type="email"
+          autoComplete="username"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
         />
-        <button
-          type="button"
-          onClick={() => setShowPassword(!showPassword)}
-          aria-label={t.showPassword}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+        <div className="relative">
+          <input
+            className="w-full border px-2 py-1 pr-8"
+            id="login-password"
+            name="password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="current-password"
+            placeholder="Password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={t.showPassword}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+        {error && (
+          <p className="text-red-500 text-sm">{t[error as keyof typeof t]}</p>
+        )}
+        {success && <p className="text-green-600 text-sm">{success}</p>}
+        <Button
+          type="submit"
+          className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         >
-          {showPassword ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-        </button>
-      </div>
-      {error && (
-        <p className="text-red-500 text-sm">{t[error as keyof typeof t]}</p>
-      )}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button
-        className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={submit}
-      >
-        {t.signIn}
-      </Button>
+          {t.signIn}
+        </Button>
+        <input type="hidden" name="auth-type" value="login" />
+      </form>
       <Button
         className="w-full flex items-center justify-center bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         onClick={() => signIn('google', { callbackUrl: '/' })}

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -65,7 +65,7 @@ export default function ProfileForm({ user }: { user: User }) {
   }
 
   return (
-    <form onSubmit={submit} className="space-y-2 max-w-sm">
+    <form onSubmit={submit} className="space-y-2 max-w-sm" autoComplete="on">
       <input
         className="w-full border px-2 py-1"
         value={name}
@@ -129,17 +129,25 @@ export default function ProfileForm({ user }: { user: User }) {
       />
       <input
         className="w-full border px-2 py-1"
+        id="profile-email"
+        name="email"
+        type="email"
+        autoComplete="email"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Email"
       />
       <input
         className="w-full border px-2 py-1"
+        id="profile-new-password"
+        name="new-password"
         type="password"
+        autoComplete="new-password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
         placeholder="New password"
       />
+      <input type="hidden" name="username" value={user.email} />
       {error && <p className="text-red-500 text-sm">{error}</p>}
       {success && <p className="text-green-600 text-sm">{success}</p>}
       <Button type="submit" className="w-full">

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { FormEvent, useState } from 'react';
 import { signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
@@ -17,7 +17,8 @@ export default function RegisterPage() {
   const [success, setSuccess] = useState('');
   const t = useTranslation().auth;
 
-  async function submit() {
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
     setError('');
     setSuccess('');
     const parsed = registerSchema.safeParse({ email, password, name });
@@ -43,47 +44,63 @@ export default function RegisterPage() {
 
   return (
     <div className="p-4 max-w-sm mx-auto space-y-2">
-      <input
-        className="w-full border px-2 py-1"
-        placeholder="Name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-      />
-      <input
-        className="w-full border px-2 py-1"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-      />
-      <div className="relative">
+      <form onSubmit={submit} className="space-y-2" autoComplete="on">
         <input
-          className="w-full border px-2 py-1 pr-8"
-          placeholder="Password"
-          type={showPassword ? 'text' : 'password'}
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border px-2 py-1"
+          id="register-name"
+          name="name"
+          placeholder="Name"
+          autoComplete="name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
         />
-        <button
-          type="button"
-          onClick={() => setShowPassword(!showPassword)}
-          aria-label={t.showPassword}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+        <input
+          className="w-full border px-2 py-1"
+          id="register-email"
+          name="email"
+          type="email"
+          placeholder="Email"
+          autoComplete="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <div className="relative">
+          <input
+            className="w-full border px-2 py-1 pr-8"
+            id="register-password"
+            name="password"
+            placeholder="Password"
+            type={showPassword ? 'text' : 'password'}
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+          <button
+            type="button"
+            onClick={() => setShowPassword(!showPassword)}
+            aria-label={t.showPassword}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500"
+          >
+            {showPassword ? (
+              <EyeOff className="h-4 w-4" />
+            ) : (
+              <Eye className="h-4 w-4" />
+            )}
+          </button>
+        </div>
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        {success && <p className="text-green-600 text-sm">{success}</p>}
+        <Button
+          type="submit"
+          className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         >
-          {showPassword ? (
-            <EyeOff className="h-4 w-4" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-        </button>
-      </div>
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      {success && <p className="text-green-600 text-sm">{success}</p>}
-      <Button
-        className="w-full bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
-        onClick={submit}
-      >
-        Register
-      </Button>
+          Register
+        </Button>
+        <input type="hidden" name="auth-type" value="register" />
+      </form>
       <Button
         className="w-full flex items-center justify-center bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         onClick={() => signIn('google', { callbackUrl: '/' })}


### PR DESCRIPTION
## Summary
- wrap login and registration inputs in semantic forms and mark fields with proper autocomplete hints
- enhance profile form email and password inputs with identifiers, autocomplete, and hidden username metadata
- ensure password toggles keep buttons accessible while preserving password manager compatibility

## Testing
- pnpm lint *(fails: network proxy prevented downloading pnpm 8.15.4)*

------
https://chatgpt.com/codex/tasks/task_e_68dffaa9bd5c83339fc5eec7fc544acf