### PR TITLE
fix(admin/site): remove color pickers, hardcode site colors

### DIFF
--- a/src/app/admin/site/page.tsx
+++ b/src/app/admin/site/page.tsx
@@ -1,7 +1,6 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
 import SiteSettingsForm from './site-settings-form';
 
 export default async function SiteAdminPage() {
@@ -9,14 +8,13 @@ export default async function SiteAdminPage() {
   if (!session || session.user.role !== 'SUPER_ADMIN') {
     redirect('/');
   }
-  const settings = await prisma.siteSetting.findUnique({ where: { id: 1 } });
   return (
     <div className="max-w-2xl mx-auto px-4 py-8 space-y-4">
       <h1 className="text-2xl font-bold tracking-tight">
         Configuración del sitio
       </h1>
       <div className="rounded-xl border bg-card p-6 shadow-sm">
-        <SiteSettingsForm settings={settings} />
+        <SiteSettingsForm />
       </div>
     </div>
   );

--- a/src/app/admin/site/site-settings-form.tsx
+++ b/src/app/admin/site/site-settings-form.tsx
@@ -1,25 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import type { SiteSettings } from '@/types/site';
 import { Button } from '@/components/ui/button';
 
-export default function SiteSettingsForm({
-  settings,
-}: {
-  settings: SiteSettings | null;
-}) {
+export default function SiteSettingsForm() {
   const [logo, setLogo] = useState<File | null>(null);
   const [favicon, setFavicon] = useState<File | null>(null);
-  const [navbarColor, setNavbarColor] = useState(
-    settings?.navbarColor ?? '#1e293b'
-  );
-  const [footerColor, setFooterColor] = useState(
-    settings?.footerColor ?? '#1e293b'
-  );
-  const [backgroundColor, setBackgroundColor] = useState(
-    settings?.backgroundColor ?? '#ffffff'
-  );
   const [message, setMessage] = useState('');
 
   const handleFileChange = (
@@ -35,9 +21,6 @@ export default function SiteSettingsForm({
     const formData = new FormData();
     if (logo) formData.append('logo', logo);
     if (favicon) formData.append('favicon', favicon);
-    formData.append('navbarColor', navbarColor);
-    formData.append('footerColor', footerColor);
-    formData.append('backgroundColor', backgroundColor);
     const res = await fetch('/api/site-settings', {
       method: 'POST',
       body: formData,
@@ -63,32 +46,8 @@ export default function SiteSettingsForm({
         <label className="block mb-1">Favicon (.ico)</label>
         <input
           type="file"
-          accept="image/x-icon"
+          accept="image/x-icon,image/png"
           onChange={(e) => handleFileChange(e, setFavicon)}
-        />
-      </div>
-      <div>
-        <label className="block mb-1">Navbar Color</label>
-        <input
-          type="color"
-          value={navbarColor}
-          onChange={(e) => setNavbarColor(e.target.value)}
-        />
-      </div>
-      <div>
-        <label className="block mb-1">Footer Color</label>
-        <input
-          type="color"
-          value={footerColor}
-          onChange={(e) => setFooterColor(e.target.value)}
-        />
-      </div>
-      <div>
-        <label className="block mb-1">Background Color</label>
-        <input
-          type="color"
-          value={backgroundColor}
-          onChange={(e) => setBackgroundColor(e.target.value)}
         />
       </div>
       <Button type="submit">Guardar configuración</Button>

--- a/src/app/api/site-settings/route.ts
+++ b/src/app/api/site-settings/route.ts
@@ -45,10 +45,6 @@ export async function POST(req: Request) {
   try {
     const data = await req.formData();
 
-    const navbarColor = data.get('navbarColor') as string;
-    const footerColor = data.get('footerColor') as string;
-    const backgroundColor = data.get('backgroundColor') as string;
-
     let logoHash: string | undefined;
     let faviconHash: string | undefined;
 
@@ -65,17 +61,11 @@ export async function POST(req: Request) {
     const settings = await prisma.siteSetting.upsert({
       where: { id: 1 },
       update: {
-        navbarColor,
-        footerColor,
-        backgroundColor,
         ...(logoHash && { logo: logoHash }),
         ...(faviconHash && { favicon: faviconHash }),
       },
       create: {
         id: 1,
-        navbarColor,
-        footerColor,
-        backgroundColor,
         logo: logoHash ?? null,
         favicon: faviconHash ?? null,
       },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,6 @@ import Navbar from '@/components/navbar';
 import Footer from '@/components/footer';
 import Providers from '@/components/providers';
 import { prisma } from '@/lib/prisma';
-import type { SiteSettings } from '@/types/site';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,18 +38,13 @@ export default async function RootLayout({
 }: {
   children: ReactNode;
 }) {
-  const settings: SiteSettings | null = await getSiteSettings();
-
   return (
     <html lang="es">
-      <body
-        className="min-h-screen text-foreground flex flex-col font-body"
-        style={{ backgroundColor: settings?.backgroundColor || undefined }}
-      >
+      <body className="min-h-screen text-foreground flex flex-col font-body">
         <Providers>
           <Navbar />
           <main className="flex-1">{children}</main>
-          <Footer settings={settings} />
+          <Footer />
         </Providers>
       </body>
     </html>

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import type { SiteSettings } from '@/types/site';
 import { Instagram, Youtube } from 'lucide-react';
 
-export default function Footer({
-  settings,
-}: {
-  settings: SiteSettings | null;
-}) {
+export default function Footer() {
   return (
-    <footer
-      className="px-4 py-8 text-white"
-      style={{ backgroundColor: settings?.footerColor || '#1e293b' }}
-    >
+    <footer className="px-4 py-8 text-white bg-slate-800">
       <div className="mx-auto max-w-4xl">
         <div className="flex flex-col items-center gap-4 text-center">
           <p className="text-lg font-semibold">Club Hualas Patagónico</p>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -41,8 +41,7 @@ export default function Navbar() {
 
   return (
     <nav
-      className="px-4 py-3 text-white shadow-md"
-      style={{ backgroundColor: settings?.navbarColor || '#1e293b' }}
+      className="px-4 py-3 text-white shadow-md bg-slate-800"
     >
       <div className="mx-auto flex max-w-6xl items-center justify-between">
         <Link href="/" className="flex items-center gap-2.5">

--- a/src/types/site.ts
+++ b/src/types/site.ts
@@ -1,7 +1,4 @@
 export interface SiteSettings {
   logo: string | null;
   favicon: string | null;
-  navbarColor: string | null;
-  footerColor: string | null;
-  backgroundColor: string | null;
 }


### PR DESCRIPTION
## Summary

- Removed navbar, footer, and background color pickers from `/admin/site`
- Admin page now only allows uploading the navbar logo and favicon
- Colors hardcoded to `bg-slate-800` (#1e293b) across navbar, footer, and body so the site style is protected from admin changes
- Cleaned up `SiteSettings` type, API route, and layout to remove all color-related fields

## Test plan

- [ ] Navigate to `/admin/site` as SUPER_ADMIN — verify only logo and favicon inputs are shown, no color pickers
- [ ] Upload a new logo and favicon — verify they save correctly
- [ ] Check navbar and footer render with the correct fixed dark color on all pages
- [ ] Verify build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)