### PR TITLE
Simplificar texto del banner de Mercado Pago en modo TESTING

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default async function RootLayout({
         <Providers>
           {isMercadoPagoTestingEnvironment() ? (
             <div className="w-full bg-yellow-300 text-yellow-950 text-sm font-semibold text-center py-2 px-4">
-              Mercado Pago en modo TESTING (MP_*). Las credenciales de producción (MERCADOPAGO_*) están desactivadas.
+              Mercado Pago en modo TESTING
             </div>
           ) : null}
           <Navbar />


### PR DESCRIPTION
### Motivation
- Reducir y simplificar el texto del banner de advertencia cuando la app está en entorno de pruebas de Mercado Pago para evitar información redundante.

### Description
- Reemplacé la línea en `src/app/layout.tsx` para mostrar únicamente `Mercado Pago en modo TESTING` dentro del banner condicionado por `isMercadoPagoTestingEnvironment()`.

### Testing
- Verifiqué la actualización mediante `rg -n "Mercado Pago en modo TESTING"` y comprobé el archivo con `nl` para confirmar la modificación; ambas comprobaciones tuvieron éxito.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed17b463e4833385b3e8848b8eac61)