### PR TITLE
[codex] add activity capacity

### DIFF
--- a/prisma/migrations/0_init/migration.sql
+++ b/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,234 @@
+-- CreateEnum
+CREATE TYPE "ActivityFrequency" AS ENUM ('DAILY', 'WEEKLY', 'MONTHLY', 'ONE_TIME');
+
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('FEMALE', 'MALE', 'NON_BINARY', 'UNDISCLOSED', 'OTHER');
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('ADMIN', 'MEMBER', 'SUPER_ADMIN');
+
+-- CreateTable
+CREATE TABLE "Activity" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "date" TIMESTAMP(3) NOT NULL,
+    "image" TEXT,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "frequency" "ActivityFrequency" NOT NULL DEFAULT 'ONE_TIME',
+    "price" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "Activity_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ActivityParticipant" (
+    "id" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "receiptDate" TIMESTAMP(3),
+    "receipt" TEXT,
+    "childId" TEXT,
+
+    CONSTRAINT "ActivityParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Child" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "birthDate" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastName" TEXT,
+    "documentType" TEXT,
+    "documentNumber" TEXT,
+    "address" TEXT,
+    "gender" "Gender",
+    "nationality" TEXT,
+    "maritalStatus" TEXT,
+    "observations" TEXT,
+
+    CONSTRAINT "Child_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Conversation" (
+    "id" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Conversation_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ConversationParticipant" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ConversationParticipant_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Form" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Form_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FormField" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "options" JSONB,
+    "order" INTEGER NOT NULL,
+    "required" BOOLEAN NOT NULL DEFAULT false,
+
+    CONSTRAINT "FormField_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FormResponse" (
+    "id" TEXT NOT NULL,
+    "formId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "FormResponse_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "MercadoPagoNotification" (
+    "id" TEXT NOT NULL,
+    "topic" TEXT NOT NULL,
+    "data" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "MercadoPagoNotification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Message" (
+    "id" TEXT NOT NULL,
+    "conversationId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Message_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PasswordResetToken" (
+    "id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PasswordResetToken_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "SiteSetting" (
+    "id" SERIAL NOT NULL,
+    "logo" TEXT,
+    "favicon" TEXT,
+    "navbarColor" VARCHAR(50),
+    "footerColor" VARCHAR(50),
+    "backgroundColor" VARCHAR(50),
+
+    CONSTRAINT "SiteSetting_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "password" TEXT NOT NULL,
+    "role" "Role" NOT NULL DEFAULT 'MEMBER',
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastName" TEXT,
+    "dni" TEXT,
+    "birthDate" TIMESTAMP(3),
+    "gender" "Gender",
+    "address" TEXT,
+    "nationality" TEXT,
+    "maritalStatus" TEXT,
+    "phone" TEXT,
+    "observations" TEXT,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityParticipant_activityId_userId_childId_key" ON "ActivityParticipant"("activityId" ASC, "userId" ASC, "childId" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityParticipant_activityId_userId_key" ON "ActivityParticipant"("activityId" ASC, "userId" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ConversationParticipant_user_convo_unique" ON "ConversationParticipant"("userId" ASC, "conversationId" ASC);
+
+-- CreateIndex
+CREATE INDEX "idx_participant_conversation" ON "ConversationParticipant"("conversationId" ASC);
+
+-- CreateIndex
+CREATE INDEX "idx_message_conversation" ON "Message"("conversationId" ASC);
+
+-- CreateIndex
+CREATE INDEX "idx_message_sender" ON "Message"("senderId" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "PasswordResetToken_token_key" ON "PasswordResetToken"("token" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_dni_key" ON "User"("dni" ASC);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email" ASC);
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_childId_fkey" FOREIGN KEY ("childId") REFERENCES "Child"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipant" ADD CONSTRAINT "ActivityParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Child" ADD CONSTRAINT "Child_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ConversationParticipant" ADD CONSTRAINT "ConversationParticipant_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormField" ADD CONSTRAINT "FormField_formId_fkey" FOREIGN KEY ("formId") REFERENCES "Form"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormResponse" ADD CONSTRAINT "FormResponse_formId_fkey" FOREIGN KEY ("formId") REFERENCES "Form"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "FormResponse" ADD CONSTRAINT "FormResponse_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_conversationId_fkey" FOREIGN KEY ("conversationId") REFERENCES "Conversation"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PasswordResetToken" ADD CONSTRAINT "PasswordResetToken_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/20260425000000_sync_schema_safe/migration.sql
+++ b/prisma/migrations/20260425000000_sync_schema_safe/migration.sql
@@ -1,0 +1,55 @@
+-- DropConstraint
+ALTER TABLE "ActivityParticipant" DROP CONSTRAINT IF EXISTS "ActivityParticipant_activityId_userId_key";
+
+-- DropIndex
+DROP INDEX IF EXISTS "idx_participant_conversation";
+
+-- DropIndex
+DROP INDEX IF EXISTS "idx_message_conversation";
+
+-- DropIndex
+DROP INDEX IF EXISTS "idx_message_sender";
+
+-- AlterTable
+ALTER TABLE "Conversation" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- AlterTable
+ALTER TABLE "FormResponse" ALTER COLUMN "userId" DROP NOT NULL;
+
+-- AlterTable
+ALTER TABLE "MercadoPagoNotification" ALTER COLUMN "topic" DROP NOT NULL,
+ALTER COLUMN "data" DROP NOT NULL;
+
+-- Preserve existing message timestamps by renaming the column instead of dropping it.
+-- The application schema expects `readAt`, and this keeps the stored values intact.
+ALTER TABLE "Message" RENAME COLUMN "updatedAt" TO "readAt";
+
+-- AlterTable
+ALTER TABLE "SiteSetting" ALTER COLUMN "id" DROP DEFAULT,
+ALTER COLUMN "navbarColor" SET DATA TYPE TEXT,
+ALTER COLUMN "footerColor" SET DATA TYPE TEXT,
+ALTER COLUMN "backgroundColor" SET DATA TYPE TEXT;
+DROP SEQUENCE IF EXISTS "SiteSetting_id_seq";
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "updatedAt" DROP DEFAULT;
+
+-- Rename the legacy unique object if it still exists under the old name.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE c.conname = 'ConversationParticipant_user_convo_unique'
+      AND t.relname = 'ConversationParticipant'
+  ) THEN
+    EXECUTE 'ALTER TABLE "ConversationParticipant" RENAME CONSTRAINT "ConversationParticipant_user_convo_unique" TO "ConversationParticipant_userId_conversationId_key"';
+  ELSIF EXISTS (
+    SELECT 1
+    FROM pg_class
+    WHERE relname = 'ConversationParticipant_user_convo_unique'
+  ) THEN
+    EXECUTE 'ALTER INDEX "ConversationParticipant_user_convo_unique" RENAME TO "ConversationParticipant_userId_conversationId_key"';
+  END IF;
+END $$;

--- a/prisma/migrations/20260425000001_add_activity_capacity/migration.sql
+++ b/prisma/migrations/20260425000001_add_activity_capacity/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "Activity" ADD COLUMN "capacity" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,29 +8,29 @@ datasource db {
 }
 
 model User {
-  id                  String                    @id @default(cuid())
-  email               String                    @unique
-  name                String?
-  lastName            String?
-  dni                 String?                   @unique
-  birthDate           DateTime?
-  gender              Gender?
-  address             String?
-  phone               String?
-  observations        String?
-  nationality         String?
-  maritalStatus       String?
-  password            String
-  role                Role                      @default(MEMBER)
-  isActive            Boolean                   @default(true)
-  createdAt           DateTime                  @default(now())
-  updatedAt           DateTime                  @updatedAt
-  messages            Message[]
-  conversations       ConversationParticipant[]
-  passwordResetTokens PasswordResetToken[]
-  formResponses       FormResponse[]
+  id                   String                    @id @default(cuid())
+  email                String                    @unique
+  name                 String?
+  lastName             String?
+  dni                  String?                   @unique
+  birthDate            DateTime?
+  gender               Gender?
+  address              String?
+  phone                String?
+  observations         String?
+  nationality          String?
+  maritalStatus        String?
+  password             String
+  role                 Role                      @default(MEMBER)
+  isActive             Boolean                   @default(true)
+  createdAt            DateTime                  @default(now())
+  updatedAt            DateTime                  @updatedAt
+  messages             Message[]
+  conversations        ConversationParticipant[]
+  passwordResetTokens  PasswordResetToken[]
+  formResponses        FormResponse[]
   activityParticipants ActivityParticipant[]
-  children            Child[]
+  children             Child[]
 }
 
 model PasswordResetToken {
@@ -72,80 +72,81 @@ model Message {
 }
 
 model Form {
-  id        String       @id @default(cuid())
+  id        String         @id @default(cuid())
   title     String
   fields    FormField[]
   responses FormResponse[]
-  createdAt DateTime     @default(now())
+  createdAt DateTime       @default(now())
 }
 
 model FormField {
-  id      String @id @default(cuid())
-  formId  String
-  form    Form   @relation(fields: [formId], references: [id])
-  label   String
-  type    String
-  options Json?
+  id       String  @id @default(cuid())
+  formId   String
+  form     Form    @relation(fields: [formId], references: [id])
+  label    String
+  type     String
+  options  Json?
   required Boolean @default(false)
-  order   Int
+  order    Int
 }
 
 model FormResponse {
-  id        String @id @default(cuid())
+  id        String   @id @default(cuid())
   formId    String
-  form      Form   @relation(fields: [formId], references: [id])
+  form      Form     @relation(fields: [formId], references: [id])
   userId    String?
-  user      User?  @relation(fields: [userId], references: [id])
+  user      User?    @relation(fields: [userId], references: [id])
   data      Json
   createdAt DateTime @default(now())
 }
 
 model Activity {
-  id          String             @id @default(cuid())
-  name        String
-  date        DateTime
-  frequency   ActivityFrequency @default(ONE_TIME)
-  image       String?
-  description String?
-  price       Int                @default(0)
+  id           String                @id @default(cuid())
+  name         String
+  date         DateTime
+  frequency    ActivityFrequency     @default(ONE_TIME)
+  image        String?
+  description  String?
+  price        Int                   @default(0)
+  capacity     Int?
   participants ActivityParticipant[]
-  createdAt   DateTime @default(now())
+  createdAt    DateTime              @default(now())
 }
 
 model ActivityParticipant {
-  id      String @id @default(cuid())
-  activityId String
-  userId  String
-  childId String?
-  receipt String?
+  id          String    @id @default(cuid())
+  activityId  String
+  userId      String
+  childId     String?
+  receipt     String?
   receiptDate DateTime?
-  activity   Activity @relation(fields: [activityId], references: [id])
-  user    User  @relation(fields: [userId], references: [id])
-  child   Child? @relation(fields: [childId], references: [id])
+  activity    Activity  @relation(fields: [activityId], references: [id])
+  user        User      @relation(fields: [userId], references: [id])
+  child       Child?    @relation(fields: [childId], references: [id])
 
   @@unique([activityId, userId, childId])
 }
 
 model Child {
-  id        String   @id @default(cuid())
-  userId    String
-  user      User     @relation(fields: [userId], references: [id])
-  name      String
-  lastName  String?
-  documentType   String?
-  documentNumber String?
-  birthDate DateTime?
-  address   String?
-  gender    Gender?
-  nationality String?
-  maritalStatus String?
-  observations String?
-  createdAt DateTime @default(now())
+  id                   String                @id @default(cuid())
+  userId               String
+  user                 User                  @relation(fields: [userId], references: [id])
+  name                 String
+  lastName             String?
+  documentType         String?
+  documentNumber       String?
+  birthDate            DateTime?
+  address              String?
+  gender               Gender?
+  nationality          String?
+  maritalStatus        String?
+  observations         String?
+  createdAt            DateTime              @default(now())
   activityParticipants ActivityParticipant[]
 }
 
 model SiteSetting {
-  id              Int    @id
+  id              Int     @id
   logo            String?
   favicon         String?
   navbarColor     String?

--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -13,6 +13,7 @@ interface EditActivityFormProps {
     image?: string | null;
     description?: string | null;
     price: number;
+    capacity?: number | null;
   };
 }
 
@@ -25,6 +26,7 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
   const [image, setImage] = useState(activity.image || '');
   const [description, setDescription] = useState(activity.description || '');
   const [price, setPrice] = useState(String(activity.price));
+  const [capacity, setCapacity] = useState(activity.capacity?.toString() ?? '');
   const router = useRouter();
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
@@ -43,10 +45,11 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         body: JSON.stringify({
           name,
           date,
-          image,
-          description,
+          image: image || undefined,
+          description: description || undefined,
           frequency,
           price: Number(price),
+          capacity: capacity ? Number(capacity) : undefined,
         }),
       });
       if (!res.ok) throw new Error('Request failed');
@@ -108,6 +111,14 @@ export default function EditActivityForm({ activity }: EditActivityFormProps) {
         placeholder="Precio"
         value={price}
         onChange={(e) => setPrice(e.target.value)}
+        className={inputClass}
+      />
+      <input
+        type="number"
+        min={1}
+        placeholder="Cupo de inscripciones (opcional)"
+        value={capacity}
+        onChange={(e) => setCapacity(e.target.value)}
         className={inputClass}
       />
       {error && <p className="text-destructive text-sm">{error}</p>}

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -36,6 +36,7 @@ export default async function EditActivityPage({
           image: activity.image ?? '',
           description: activity.description ?? '',
           price: activity.price,
+          capacity: activity.capacity ?? null,
         }}
       />
     </main>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -6,6 +6,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import { Button } from '@/components/ui/button';
 
 interface ActivityPageProps {
   params: { id: string };
@@ -40,6 +41,12 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     MONTHLY: 'Mensual',
     ONE_TIME: 'Un solo pago',
   };
+  const enrolledCount = activity.participants.length;
+  const hasCapacity = activity.capacity != null;
+  const remainingSpots = hasCapacity
+    ? Math.max(activity.capacity - enrolledCount, 0)
+    : null;
+  const isFull = hasCapacity && remainingSpots === 0;
 
   return (
     <main>
@@ -105,7 +112,13 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                 { label: 'Precio', value: `$${activity.price}` },
                 {
                   label: 'Inscriptos',
-                  value: `${activity.participants.length} personas`,
+                  value: `${enrolledCount} personas`,
+                },
+                {
+                  label: 'Cupo',
+                  value: hasCapacity
+                    ? `${activity.capacity} lugares`
+                    : 'Ilimitado',
                 },
                 activity.date && {
                   label: 'Fecha',
@@ -162,10 +175,27 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                   / {frequencyLabels[activity.frequency]?.toLowerCase()}
                 </p>
               )}
+              {hasCapacity && (
+                <p
+                  className={`text-xs font-body mt-1 ${
+                    isFull ? 'text-destructive' : 'text-muted-foreground'
+                  }`}
+                >
+                  {isFull
+                    ? 'Cupo completo'
+                    : `${remainingSpots} lugares disponibles`}
+                </p>
+              )}
             </div>
 
             <div className="space-y-3 pt-2">
-              <RegisterButton activityId={activity.id} />
+              {isFull ? (
+                <Button disabled className="w-full">
+                  Cupo completo
+                </Button>
+              ) : (
+                <RegisterButton activityId={activity.id} />
+              )}
               <Link
                 href="/contact"
                 className="block text-center text-sm text-muted-foreground hover:text-foreground underline underline-offset-4 font-body"
@@ -176,7 +206,9 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
             <div className="pt-2 border-t border-border">
               <p className="text-xs text-muted-foreground font-body text-center">
-                {activity.participants.length} personas ya inscriptas
+                {hasCapacity
+                  ? `${enrolledCount} de ${activity.capacity} lugares ocupados`
+                  : `${enrolledCount} personas ya inscriptas`}
               </p>
             </div>
           </div>

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -10,6 +10,7 @@ export default function CreateActivityForm() {
   const [image, setImage] = useState('');
   const [description, setDescription] = useState('');
   const [price, setPrice] = useState('');
+  const [capacity, setCapacity] = useState('');
   const [frequency, setFrequency] = useState<
     'DAILY' | 'WEEKLY' | 'MONTHLY' | 'ONE_TIME'
   >('ONE_TIME');
@@ -31,10 +32,11 @@ export default function CreateActivityForm() {
         body: JSON.stringify({
           name,
           date,
-          image,
-          description,
+          image: image || undefined,
+          description: description || undefined,
           frequency,
           price: Number(price),
+          capacity: capacity ? Number(capacity) : undefined,
         }),
       });
       if (!res.ok) throw new Error('Request failed');
@@ -44,6 +46,7 @@ export default function CreateActivityForm() {
       setImage('');
       setDescription('');
       setPrice('');
+      setCapacity('');
       setFrequency('ONE_TIME');
       setTimeout(() => {
         router.push('/activities');
@@ -102,6 +105,14 @@ export default function CreateActivityForm() {
         placeholder="Precio"
         value={price}
         onChange={(e) => setPrice(e.target.value)}
+        className={inputClass}
+      />
+      <input
+        type="number"
+        min={1}
+        placeholder="Cupo de inscripciones (opcional)"
+        value={capacity}
+        onChange={(e) => setCapacity(e.target.value)}
         className={inputClass}
       />
       {error && <p className="text-destructive text-sm">{error}</p>}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -74,7 +74,11 @@ export default async function ActivitiesPage() {
                   <span>·</span>
                   <span>${activity.price}</span>
                   <span>·</span>
-                  <span>{activity.participants.length} suscriptos</span>
+                  <span>
+                    {activity.capacity
+                      ? `${activity.participants.length}/${activity.capacity} cupo`
+                      : `${activity.participants.length} suscriptos`}
+                  </span>
                 </div>
               </div>
               <Link

--- a/src/app/api/activities/[id]/checkout/route.ts
+++ b/src/app/api/activities/[id]/checkout/route.ts
@@ -35,7 +35,9 @@ export async function GET(
   const checkoutSettings = getMercadoPagoCheckoutSettings();
 
   if (!accessToken) {
-    console.error(`[checkout] Access token de Mercado Pago no configurado para ${environment}`);
+    console.error(
+      `[checkout] Access token de Mercado Pago no configurado para ${environment}`
+    );
     return NextResponse.json(
       { error: 'Configuración de pago incompleta. Contactá al administrador.' },
       { status: 500 }
@@ -47,7 +49,10 @@ export async function GET(
 
   let activity: any = null;
   try {
-    activity = await prisma.activity.findUnique({ where: { id: params.id } });
+    activity = await prisma.activity.findUnique({
+      where: { id: params.id },
+      include: { participants: true },
+    });
   } catch (e: any) {
     console.error('[checkout] DB error:', e?.message);
     return NextResponse.json(
@@ -60,6 +65,16 @@ export async function GET(
     return NextResponse.json(
       { error: 'Actividad no encontrada' },
       { status: 404 }
+    );
+  }
+
+  if (
+    activity.capacity != null &&
+    activity.participants.length >= activity.capacity
+  ) {
+    return NextResponse.json(
+      { error: 'La actividad ya alcanzó su cupo de inscripciones.' },
+      { status: 409 }
     );
   }
 
@@ -125,8 +140,11 @@ export async function GET(
         binary_mode: checkoutSettings.binaryMode,
         payment_methods: {
           installments: checkoutSettings.maxInstallments,
-          excluded_payment_methods: checkoutSettings.excludedPaymentMethodIds.map((id) => ({ id })),
-          excluded_payment_types: checkoutSettings.excludedPaymentTypeIds.map((id) => ({ id })),
+          excluded_payment_methods:
+            checkoutSettings.excludedPaymentMethodIds.map((id) => ({ id })),
+          excluded_payment_types: checkoutSettings.excludedPaymentTypeIds.map(
+            (id) => ({ id })
+          ),
         },
         expires: true,
         expiration_date_to: preferenceExpiresAt.toISOString(),

--- a/src/app/api/mercadopago/notifications/route.ts
+++ b/src/app/api/mercadopago/notifications/route.ts
@@ -42,6 +42,40 @@ export async function POST(req: NextRequest) {
       if (payment.status === 'approved' && payment.external_reference) {
         const [activityId, userId, childId] =
           payment.external_reference.split(':');
+        const activity = await prisma.activity.findUnique({
+          where: { id: activityId },
+          select: {
+            capacity: true,
+            participants: {
+              select: {
+                id: true,
+              },
+            },
+          },
+        });
+        if (!activity) {
+          return NextResponse.json({ received: true });
+        }
+        const existingParticipant = await prisma.activityParticipant.findFirst({
+          where: {
+            activityId,
+            userId,
+            childId: childId || null,
+          },
+          select: {
+            id: true,
+          },
+        });
+        if (
+          activity.capacity != null &&
+          !existingParticipant &&
+          activity.participants.length >= activity.capacity
+        ) {
+          console.warn(
+            `[mercadopago] Activity ${activityId} reached capacity, skipping participant upsert`
+          );
+          return NextResponse.json({ received: true });
+        }
         const receipt = payment.id?.toString();
         const date =
           payment.date_approved || payment.date_created || new Date();

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -177,7 +177,10 @@ export default async function Home() {
                         {activity.name}
                       </div>
                       <div className="mt-2 text-xs text-muted-foreground font-body">
-                        {activity.participants.length} inscriptos · $
+                        {activity.capacity
+                          ? `${activity.participants.length}/${activity.capacity} cupo`
+                          : `${activity.participants.length} inscriptos`}
+                        {' · $'}
                         {activity.price}
                       </div>
                     </div>

--- a/src/lib/mercadopago.ts
+++ b/src/lib/mercadopago.ts
@@ -56,12 +56,17 @@ export function getMercadoPagoCredentials() {
 }
 
 export function getMercadoPagoCheckoutSettings(): MercadoPagoCheckoutSettings {
-  const autoReturnValue = (process.env.MP_AUTO_RETURN || 'approved').toLowerCase();
+  const autoReturnValue = (
+    process.env.MP_AUTO_RETURN || 'approved'
+  ).toLowerCase();
 
   return {
     autoReturn: autoReturnValue === 'all' ? 'all' : 'approved',
     binaryMode: toBoolean(process.env.MP_BINARY_MODE, false),
-    expiresInMinutes: toPositiveInt(process.env.MP_PREFERENCE_EXPIRES_MINUTES, 60),
+    expiresInMinutes: toPositiveInt(
+      process.env.MP_PREFERENCE_EXPIRES_MINUTES,
+      60
+    ),
     maxInstallments: toPositiveInt(process.env.MP_MAX_INSTALLMENTS, 1),
     excludedPaymentMethodIds: toArray(process.env.MP_EXCLUDED_PAYMENT_METHODS),
     excludedPaymentTypeIds: toArray(process.env.MP_EXCLUDED_PAYMENT_TYPES),

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -7,4 +7,5 @@ export const activityCreateSchema = z.object({
   image: z.string().url().optional(),
   description: z.string().optional(),
   price: z.number().int().nonnegative(),
+  capacity: z.number().int().positive().optional(),
 });


### PR DESCRIPTION
## What changed
- Added an optional `capacity` field to activities in Prisma, the API validation layer, and the activity create/edit forms.
- Surfaced capacity and remaining spots across the activity detail page, activities list, and home page.
- Prevented new checkouts and payment registrations when an activity is already full.
- Added the migration files needed to reconcile the existing Prisma history with the live database and apply the new `capacity` column.

## Why
- Activities could be registered without any limit, so there was no way to cap enrollments or show availability to users/admins.

## Impact
- Admins can now set a seat limit per activity.
- Users see whether an activity is full before starting checkout.
- The payment notification path also guards against over-enrollment if a late payment arrives after capacity is exhausted.

## Validation
- `npm run lint`
- `npm run build`
- Applied Prisma migrations successfully against the live Neon database