### PR TITLE
Agregar foto de perfil con cámara y Vercel Blob

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@prisma/client": "^5.9.0",
+    "@vercel/blob": "^2.3.3",
     "bcrypt": "^5.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.0.0",
     "lucide-react": "^0.368.0",
+    "mercadopago": "^2.0.0",
     "next": "14.2.5",
     "next-auth": "^4.24.7",
     "react": "^18.2.0",
@@ -25,8 +27,7 @@
     "socket.io-client": "^4.7.5",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.22.4",
-    "mercadopago": "^2.0.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/prisma/migrations/20260425000003_add_user_profile_photo/migration.sql
+++ b/prisma/migrations/20260425000003_add_user_profile_photo/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "User" ADD COLUMN "profilePhoto" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -18,6 +18,7 @@ model User {
   address              String?
   phone                String?
   observations         String?
+  profilePhoto         String?
   nationality          String?
   maritalStatus        String?
   password             String

--- a/src/app/api/profile/photo/route.ts
+++ b/src/app/api/profile/photo/route.ts
@@ -1,0 +1,86 @@
+import { del, put } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+function extensionFor(file: File) {
+  const mimeToExt: Record<string, string> = {
+    'image/jpeg': '.jpg',
+    'image/jpg': '.jpg',
+    'image/png': '.png',
+    'image/webp': '.webp',
+    'image/gif': '.gif',
+    'image/avif': '.avif',
+    'image/heic': '.heic',
+    'image/heif': '.heif',
+  };
+
+  const fallback = file.name.includes('.')
+    ? file.name.slice(file.name.lastIndexOf('.'))
+    : '';
+  return mimeToExt[file.type] ?? (fallback || '.jpg');
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const file = formData.get('photo');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'No se recibió ninguna foto' },
+      { status: 400 }
+    );
+  }
+
+  if (!file.type.startsWith('image/')) {
+    return NextResponse.json(
+      { error: 'El archivo debe ser una imagen' },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > 5 * 1024 * 1024) {
+    return NextResponse.json(
+      { error: 'La foto debe pesar menos de 5 MB' },
+      { status: 400 }
+    );
+  }
+
+  const currentUser = await prisma.user.findUnique({
+    where: { id: (session.user as any).id },
+    select: { profilePhoto: true },
+  });
+
+  const pathname = `profile-photos/${session.user.id}/${crypto.randomUUID()}${extensionFor(file)}`;
+  const blob = await put(pathname, file, {
+    access: 'public',
+    contentType: file.type,
+  });
+
+  try {
+    await prisma.user.update({
+      where: { id: (session.user as any).id },
+      data: { profilePhoto: blob.url },
+    });
+  } catch {
+    await del(blob.url).catch(() => undefined);
+    return NextResponse.json(
+      { error: 'No se pudo guardar la foto de perfil' },
+      { status: 500 }
+    );
+  }
+
+  if (currentUser?.profilePhoto) {
+    await del(currentUser.profilePhoto).catch(() => undefined);
+  }
+
+  return NextResponse.json({
+    profilePhoto: blob.url,
+  });
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -62,6 +62,7 @@ export async function PATCH(req: Request) {
       email: true,
       name: true,
       lastName: true,
+      profilePhoto: true,
       dni: true,
       birthDate: true,
       gender: true,

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 type User = {
   name: string | null;
   lastName: string | null;
+  profilePhoto?: string | null;
   dni: string | null;
   birthDate: string | null;
   gender: string | null;

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import ProfileForm from './form';
+import ProfilePhotoUpload from './profile-photo-upload';
 import ChildrenManager from './children';
 
 export default async function ProfilePage() {
@@ -15,6 +16,7 @@ export default async function ProfilePage() {
     select: {
       name: true,
       lastName: true,
+      profilePhoto: true,
       dni: true,
       birthDate: true,
       gender: true,
@@ -29,8 +31,23 @@ export default async function ProfilePage() {
     redirect('/');
   }
   return (
-    <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
-      <h1 className="text-2xl font-bold tracking-tight">Mi perfil</h1>
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div className="rounded-2xl border bg-card p-6 shadow-sm">
+        <div className="grid gap-6 md:grid-cols-[220px,1fr] md:items-center">
+          <ProfilePhotoUpload
+            initialPhoto={user.profilePhoto}
+            name={user.name}
+            lastName={user.lastName}
+          />
+          <div className="space-y-2">
+            <h1 className="text-2xl font-bold tracking-tight">Mi perfil</h1>
+            <p className="text-sm text-muted-foreground">
+              Actualizá tus datos y guardá una foto de perfil tomada con la
+              cámara o subida desde tu dispositivo.
+            </p>
+          </div>
+        </div>
+      </div>
       <div className="rounded-xl border bg-card p-6 shadow-sm">
         <ProfileForm
           user={{

--- a/src/app/profile/profile-photo-upload.tsx
+++ b/src/app/profile/profile-photo-upload.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Camera, ImageUp, X } from 'lucide-react';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+type Props = {
+  initialPhoto: string | null;
+  name: string | null;
+  lastName: string | null;
+};
+
+export default function ProfilePhotoUpload({
+  initialPhoto,
+  name,
+  lastName,
+}: Props) {
+  const [photoUrl, setPhotoUrl] = useState(initialPhoto ?? '');
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const [isCameraOpen, setIsCameraOpen] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const router = useRouter();
+
+  useEffect(() => {
+    setPhotoUrl(initialPhoto ?? '');
+  }, [initialPhoto]);
+
+  useEffect(() => {
+    if (!isCameraOpen) return;
+
+    let active = true;
+
+    async function startCamera() {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: 'user' },
+          audio: false,
+        });
+        if (!active) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play();
+        }
+      } catch {
+        setError('No se pudo abrir la cámara');
+        setIsCameraOpen(false);
+      }
+    }
+
+    startCamera();
+
+    return () => {
+      active = false;
+      streamRef.current?.getTracks().forEach((track) => track.stop());
+      streamRef.current = null;
+    };
+  }, [isCameraOpen]);
+
+  const stopCamera = () => {
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    streamRef.current = null;
+    if (videoRef.current) {
+      videoRef.current.srcObject = null;
+    }
+  };
+
+  const uploadFile = async (file: File) => {
+    setError('');
+    setMessage('');
+    setIsUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append('photo', file);
+      const res = await fetch('/api/profile/photo', {
+        method: 'POST',
+        body: formData,
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error || 'Upload failed');
+      }
+      const data = (await res.json()) as { profilePhoto?: string };
+      if (data.profilePhoto) {
+        setPhotoUrl(data.profilePhoto);
+      }
+      setMessage('Foto actualizada');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo subir la foto');
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    await uploadFile(file);
+  };
+
+  const handleCapture = async () => {
+    const video = videoRef.current;
+    if (!video || !video.videoWidth || !video.videoHeight) {
+      setError('La cámara todavía no está lista');
+      return;
+    }
+
+    const canvas = document.createElement('canvas');
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const context = canvas.getContext('2d');
+    if (!context) {
+      setError('No se pudo procesar la foto');
+      return;
+    }
+
+    context.drawImage(video, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob(
+      async (blob) => {
+        if (!blob) {
+          setError('No se pudo generar la foto');
+          return;
+        }
+        const file = new File([blob], `profile-photo-${Date.now()}.jpg`, {
+          type: 'image/jpeg',
+        });
+        stopCamera();
+        setIsCameraOpen(false);
+        await uploadFile(file);
+      },
+      'image/jpeg',
+      0.92
+    );
+  };
+
+  const initials = `${name?.[0] ?? ''}${lastName?.[0] ?? ''}`.trim() || 'P';
+
+  return (
+    <div className="space-y-4">
+      <div className="mx-auto flex h-40 w-40 items-center justify-center overflow-hidden rounded-full border bg-muted/30 shadow-sm">
+        {photoUrl ? (
+          <div className="relative h-full w-full">
+            <Image
+              src={photoUrl}
+              alt="Foto de perfil"
+              fill
+              className="object-cover"
+              sizes="160px"
+            />
+          </div>
+        ) : (
+          <span className="text-4xl font-bold tracking-tight text-muted-foreground">
+            {initials}
+          </span>
+        )}
+      </div>
+
+      {isCameraOpen ? (
+        <div className="space-y-3">
+          <div className="overflow-hidden rounded-2xl border bg-black shadow-sm">
+            <video
+              ref={videoRef}
+              className="aspect-square w-full object-cover"
+              playsInline
+              muted
+              autoPlay
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              onClick={handleCapture}
+              disabled={isUploading}
+            >
+              <Camera className="mr-2 h-4 w-4" />
+              Tomar foto
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                stopCamera();
+                setIsCameraOpen(false);
+              }}
+              disabled={isUploading}
+            >
+              <X className="mr-2 h-4 w-4" />
+              Cancelar
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          <div className="flex flex-wrap gap-2">
+            <Button
+              type="button"
+              onClick={() => setIsCameraOpen(true)}
+              disabled={isUploading}
+            >
+              <Camera className="mr-2 h-4 w-4" />
+              Usar cámara
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+            >
+              <ImageUp className="mr-2 h-4 w-4" />
+              Subir foto
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            La imagen queda guardada en Vercel Blob y se usa como foto de
+            perfil.
+          </p>
+        </div>
+      )}
+
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="user"
+        className="hidden"
+        onChange={handleFileChange}
+      />
+
+      {isUploading && (
+        <p className="text-sm text-muted-foreground">Subiendo foto...</p>
+      )}
+      {message && <p className="text-sm text-success">{message}</p>}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Resumen
- Agrega un bloque en `/profile` para tomar una foto con la cámara o subir una imagen manualmente.
- Sube la imagen a Vercel Blob desde el servidor y guarda la URL en `User.profilePhoto`.
- Incluye migración de Prisma para el nuevo campo.
- Mantiene la foto actual visible en el perfil y reemplaza la anterior al subir una nueva.

## Validación
- `npm run lint`
- `npm run build`
- `npx prisma migrate deploy`