### PR TITLE
Corregir foto de perfil para store privado de Vercel Blob

### DIFF
--- a/src/app/api/profile/photo/route.ts
+++ b/src/app/api/profile/photo/route.ts
@@ -1,4 +1,4 @@
-import { del, put } from '@vercel/blob';
+import { del, get, put } from '@vercel/blob';
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
@@ -59,7 +59,7 @@ export async function POST(req: Request) {
 
   const pathname = `profile-photos/${session.user.id}/${crypto.randomUUID()}${extensionFor(file)}`;
   const blob = await put(pathname, file, {
-    access: 'public',
+    access: 'private',
     contentType: file.type,
   });
 
@@ -80,7 +80,33 @@ export async function POST(req: Request) {
     await del(currentUser.profilePhoto).catch(() => undefined);
   }
 
-  return NextResponse.json({
-    profilePhoto: blob.url,
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const currentUser = await prisma.user.findUnique({
+    where: { id: (session.user as any).id },
+    select: { profilePhoto: true },
+  });
+
+  if (!currentUser?.profilePhoto) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const blob = await get(currentUser.profilePhoto, { access: 'private' });
+  if (!blob || blob.statusCode !== 200) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const headers = Object.fromEntries(blob.headers.entries());
+  headers['Cache-Control'] = 'private, no-store, max-age=0';
+
+  return new NextResponse(blob.stream, {
+    headers,
   });
 }

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -17,6 +17,7 @@ export default async function ProfilePage() {
       name: true,
       lastName: true,
       profilePhoto: true,
+      updatedAt: true,
       dni: true,
       birthDate: true,
       gender: true,
@@ -35,7 +36,8 @@ export default async function ProfilePage() {
       <div className="rounded-2xl border bg-card p-6 shadow-sm">
         <div className="grid gap-6 md:grid-cols-[220px,1fr] md:items-center">
           <ProfilePhotoUpload
-            initialPhoto={user.profilePhoto}
+            hasPhoto={Boolean(user.profilePhoto)}
+            photoVersion={user.updatedAt.getTime()}
             name={user.name}
             lastName={user.lastName}
           />

--- a/src/app/profile/profile-photo-upload.tsx
+++ b/src/app/profile/profile-photo-upload.tsx
@@ -7,17 +7,20 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
 type Props = {
-  initialPhoto: string | null;
+  hasPhoto: boolean;
+  photoVersion: number;
   name: string | null;
   lastName: string | null;
 };
 
 export default function ProfilePhotoUpload({
-  initialPhoto,
+  hasPhoto,
+  photoVersion,
   name,
   lastName,
 }: Props) {
-  const [photoUrl, setPhotoUrl] = useState(initialPhoto ?? '');
+  const [hasCurrentPhoto, setHasCurrentPhoto] = useState(hasPhoto);
+  const [currentPhotoVersion, setCurrentPhotoVersion] = useState(photoVersion);
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
   const [isUploading, setIsUploading] = useState(false);
@@ -28,8 +31,12 @@ export default function ProfilePhotoUpload({
   const router = useRouter();
 
   useEffect(() => {
-    setPhotoUrl(initialPhoto ?? '');
-  }, [initialPhoto]);
+    setHasCurrentPhoto(hasPhoto);
+  }, [hasPhoto]);
+
+  useEffect(() => {
+    setCurrentPhotoVersion(photoVersion);
+  }, [photoVersion]);
 
   useEffect(() => {
     if (!isCameraOpen) return;
@@ -89,10 +96,9 @@ export default function ProfilePhotoUpload({
         const body = await res.json().catch(() => null);
         throw new Error(body?.error || 'Upload failed');
       }
-      const data = (await res.json()) as { profilePhoto?: string };
-      if (data.profilePhoto) {
-        setPhotoUrl(data.profilePhoto);
-      }
+      await res.json().catch(() => null);
+      setHasCurrentPhoto(true);
+      setCurrentPhotoVersion(Date.now());
       setMessage('Foto actualizada');
       router.refresh();
     } catch (err) {
@@ -149,10 +155,10 @@ export default function ProfilePhotoUpload({
   return (
     <div className="space-y-4">
       <div className="mx-auto flex h-40 w-40 items-center justify-center overflow-hidden rounded-full border bg-muted/30 shadow-sm">
-        {photoUrl ? (
+        {hasCurrentPhoto ? (
           <div className="relative h-full w-full">
             <Image
-              src={photoUrl}
+              src={`/api/profile/photo?v=${currentPhotoVersion}`}
               alt="Foto de perfil"
               fill
               className="object-cover"


### PR DESCRIPTION
## Resumen
- Cambia la subida de foto de perfil a `access: 'private'` para que coincida con el store configurado.
- Sirve la imagen desde `/api/profile/photo` para usuarios autenticados, en lugar de apuntar directo al blob.
- Mantiene la referencia del blob en `User.profilePhoto`.

## Validación
- `npm run lint`
- `npm run build`