### PR TITLE
Corregir render de foto de perfil privada

### DIFF
--- a/src/app/profile/profile-photo-upload.tsx
+++ b/src/app/profile/profile-photo-upload.tsx
@@ -161,6 +161,7 @@ export default function ProfilePhotoUpload({
               src={`/api/profile/photo?v=${currentPhotoVersion}`}
               alt="Foto de perfil"
               fill
+              unoptimized
               className="object-cover"
               sizes="160px"
             />


### PR DESCRIPTION
## Resumen
- Evita que `next/image` pase la foto de perfil privada por `/_next/image`.
- Renderiza la imagen directamente desde `/api/profile/photo` para que la sesión autenticada pueda leer el blob privado.
- Mantiene el flujo de subida a Vercel Blob y la referencia en `User.profilePhoto`.

## Validación
- `npm run lint`
- `npm run build`