### PR TITLE
Add unread chat badges in navbar and conversation list

### DIFF
--- a/src/app/api/messages/[userId]/route.ts
+++ b/src/app/api/messages/[userId]/route.ts
@@ -14,6 +14,20 @@ export async function GET(
 
   const otherUserId = params.userId;
 
+  await prisma.message.updateMany({
+    where: {
+      readAt: null,
+      senderId: otherUserId,
+      conversation: {
+        participants: { some: { userId: session.user.id } },
+        AND: { participants: { some: { userId: otherUserId } } },
+      },
+    },
+    data: {
+      readAt: new Date(),
+    },
+  });
+
   const conversations = await prisma.conversation.findMany({
     where: {
       participants: {
@@ -37,6 +51,7 @@ export async function GET(
       from: m.senderId,
       content: m.body,
       createdAt: m.createdAt.toISOString(),
+      readAt: m.readAt?.toISOString() ?? null,
     }));
 
   return NextResponse.json(messages);

--- a/src/app/api/messages/route.ts
+++ b/src/app/api/messages/route.ts
@@ -39,7 +39,11 @@ export async function GET(req: NextRequest) {
       from: m.senderId,
       content: m.body,
       createdAt: m.createdAt.toISOString(),
+      readAt: m.readAt?.toISOString() ?? null,
     })),
+    unreadCount: c.messages.filter(
+      (m) => m.senderId !== session.user.id && m.readAt === null
+    ).length,
   }));
 
   return NextResponse.json(data);

--- a/src/app/chat/chat-client.tsx
+++ b/src/app/chat/chat-client.tsx
@@ -13,11 +13,17 @@ type User = {
   name: string | null;
   role: 'ADMIN' | 'MEMBER' | 'SUPER_ADMIN';
 };
-type Message = { from: string; content: string; createdAt?: string };
+type Message = {
+  from: string;
+  content: string;
+  createdAt?: string;
+  readAt?: string | null;
+};
 type Conversation = {
   id: string;
   participants: { id: string; name: string | null }[];
   messages: Message[];
+  unreadCount?: number;
 };
 
 const AVATAR_COLORS = [
@@ -83,6 +89,16 @@ function Avatar({
   );
 }
 
+function UnreadIndicator() {
+  return (
+    <span
+      className="inline-flex h-2.5 w-2.5 rounded-full bg-red-500"
+      aria-label="Mensajes sin leer"
+      title="Mensajes sin leer"
+    />
+  );
+}
+
 export default function ChatClient() {
   const { data: session } = useSession();
   const [users, setUsers] = useState<User[]>([]);
@@ -125,10 +141,10 @@ export default function ChatClient() {
       setMessages([]);
       return;
     }
-    fetchThread(recipient);
+    fetchThread(recipient).then(fetchHistory);
     const id = window.setInterval(() => fetchThread(recipient), POLL_THREAD_MS);
     return () => window.clearInterval(id);
-  }, [recipient, fetchThread]);
+  }, [recipient, fetchThread, fetchHistory]);
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -146,6 +162,7 @@ export default function ChatClient() {
       user: User;
       lastMessage: Message | null;
       lastAt: number;
+      unreadCount: number;
     };
 
     const items: Contact[] = selectable.map((u) => {
@@ -154,7 +171,12 @@ export default function ChatClient() {
       );
       const last = conv?.messages[conv.messages.length - 1] ?? null;
       const lastAt = last?.createdAt ? new Date(last.createdAt).getTime() : 0;
-      return { user: u, lastMessage: last, lastAt };
+      return {
+        user: u,
+        lastMessage: last,
+        lastAt,
+        unreadCount: conv?.unreadCount ?? 0,
+      };
     });
 
     items.sort((a, b) => {
@@ -209,8 +231,9 @@ export default function ChatClient() {
                 No hay contactos disponibles
               </p>
             ) : (
-              contacts.map(({ user, lastMessage }) => {
+              contacts.map(({ user, lastMessage, unreadCount }) => {
                 const isSelected = recipient === user.id;
+                const hasUnread = unreadCount > 0;
                 const previewSender =
                   lastMessage && lastMessage.from === session?.user.id
                     ? 'Vos: '
@@ -230,11 +253,14 @@ export default function ChatClient() {
                         <span className="truncate font-semibold text-sm">
                           {user.name ?? 'Sin nombre'}
                         </span>
-                        {lastMessage?.createdAt && (
-                          <span className="shrink-0 text-xs text-muted-foreground">
-                            {formatPreviewTime(lastMessage.createdAt)}
-                          </span>
-                        )}
+                        <div className="flex items-center gap-2">
+                          {hasUnread && <UnreadIndicator />}
+                          {lastMessage?.createdAt && (
+                            <span className="shrink-0 text-xs text-muted-foreground">
+                              {formatPreviewTime(lastMessage.createdAt)}
+                            </span>
+                          )}
+                        </div>
                       </div>
                       <p className="truncate text-xs text-muted-foreground">
                         {lastMessage

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -25,6 +25,7 @@ export default function Navbar() {
   const { lang, setLang } = useLang();
   const [menuOpen, setMenuOpen] = useState(false);
   const [settings, setSettings] = useState<SiteSettings | null>(null);
+  const [hasUnreadMessages, setHasUnreadMessages] = useState(false);
 
   useEffect(() => {
     fetch('/api/site-settings')
@@ -32,12 +33,52 @@ export default function Navbar() {
       .then((data) => setSettings(data));
   }, []);
 
+  useEffect(() => {
+    if (!session) {
+      setHasUnreadMessages(false);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchUnread = async () => {
+      try {
+        const res = await fetch('/api/messages');
+        if (!res.ok) return;
+        const conversations = (await res.json()) as { unreadCount?: number }[];
+        if (!cancelled) {
+          setHasUnreadMessages(
+            conversations.some((c) => (c.unreadCount ?? 0) > 0)
+          );
+        }
+      } catch {
+        if (!cancelled) {
+          setHasUnreadMessages(false);
+        }
+      }
+    };
+
+    fetchUnread();
+    const id = window.setInterval(fetchUnread, 8000);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [session]);
+
   const logoUrl = settings?.logo
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`
     : defaultLogo;
 
   const linkClass =
     'opacity-80 hover:opacity-100 transition-opacity text-sm font-medium';
+
+  const renderUnreadIcon = () => (
+    <span
+      className="inline-flex h-2.5 w-2.5 rounded-full bg-red-500"
+      aria-label="Mensajes sin leer"
+      title="Mensajes sin leer"
+    />
+  );
 
   return (
     <nav className="px-4 py-3 text-white shadow-md bg-slate-800">
@@ -69,8 +110,12 @@ export default function Navbar() {
             {t.activities}
           </Link>
           {session && (
-            <Link href="/chat" className={linkClass}>
-              {t.chat}
+            <Link
+              href="/chat"
+              className={`${linkClass} inline-flex items-center gap-2`}
+            >
+              <span>{t.chat}</span>
+              {hasUnreadMessages && renderUnreadIcon()}
             </Link>
           )}
           {isAdmin && (
@@ -145,10 +190,11 @@ export default function Navbar() {
           {session && (
             <Link
               href="/chat"
-              className={linkClass}
+              className={`${linkClass} inline-flex items-center gap-2`}
               onClick={() => setMenuOpen(false)}
             >
-              {t.chat}
+              <span>{t.chat}</span>
+              {hasUnreadMessages && renderUnreadIcon()}
             </Link>
           )}
           {isAdmin && (


### PR DESCRIPTION
### Motivation
- Mostrar un indicador cuando hay mensajes sin leer en el navbar y en el listado de conversaciones para mejorar la visibilidad de nuevos chats.
- Marcar mensajes como leídos al abrir la conversación para que los indicadores se actualicen de forma inmediata.

### Description
- Extendí el endpoint de historial `GET /api/messages` para devolver `unreadCount` por conversación y `readAt` en cada mensaje (archivo `src/app/api/messages/route.ts`).
- Hice que `GET /api/messages/[userId]` marque como leídos los mensajes entrantes con `prisma.message.updateMany(...)` y devuelva `readAt` en la respuesta (archivo `src/app/api/messages/[userId]/route.ts`).
- Añadí un indicador visual (`UnreadIndicator`) y manejo de `unreadCount` en el cliente de chat para pintar una bola roja junto a los contactos con mensajes sin leer (archivo `src/app/chat/chat-client.tsx`).
- Añadí estado y polling en el `Navbar` para consultar `/api/messages` cada 8s y renderizar un badge junto al enlace `Chat` tanto en desktop como en el menú móvil (archivo `src/components/navbar.tsx`).
- Hice que al abrir un hilo se refresque la lista de conversaciones (`fetchThread(...).then(fetchHistory)`) para limpiar el badge inmediatamente tras marcar como leídos.

### Testing
- Ejecuté `pnpm lint`, pero falló por una restricción de red/proxy al intentar que `corepack` descargue `pnpm` (error 403 durante la instalación), por lo que no se pudieron ejecutar linters locales en este entorno.
- No se ejecutaron otras suites automáticas en este entorno; los cambios incluyen actualizaciones de tipos y endpoints para soportar el nuevo flujo y requieren pruebas de integración locales o en CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed51d5acd8833383cb288653e38d0d)