### PR TITLE
Mostrar foto de perfil de padres en listado y vista detalle

### DIFF
--- a/src/app/admin/users/[id]/view/page.tsx
+++ b/src/app/admin/users/[id]/view/page.tsx
@@ -47,11 +47,26 @@ export default async function ViewUserPage({
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
       <div className="rounded-xl border bg-card p-6 shadow-sm space-y-3">
         <div className="flex items-start justify-between">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight">
-              {user.name} {user.lastName}
-            </h1>
-            <p className="text-sm text-muted-foreground mt-1">{user.email}</p>
+          <div className="flex items-center gap-3">
+            <div className="h-14 w-14 overflow-hidden rounded-full border bg-muted shrink-0">
+              {user.profilePhoto ? (
+                <img
+                  src={`/api/users/${user.id}/photo?v=${user.updatedAt.getTime()}`}
+                  alt={`Foto de perfil de ${user.name ?? 'usuario'}`}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-sm font-semibold text-muted-foreground">
+                  {(user.name?.[0] ?? '?').toUpperCase()}
+                </div>
+              )}
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold tracking-tight">
+                {user.name} {user.lastName}
+              </h1>
+              <p className="text-sm text-muted-foreground mt-1">{user.email}</p>
+            </div>
           </div>
           <span className="text-xs rounded-full bg-muted px-3 py-1 font-medium">
             {user.role}

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -21,6 +21,8 @@ export default async function UsersPage() {
       email: true,
       dni: true,
       role: true,
+      profilePhoto: true,
+      updatedAt: true,
     },
   });
 

--- a/src/app/admin/users/users-list.tsx
+++ b/src/app/admin/users/users-list.tsx
@@ -13,6 +13,8 @@ interface User {
   email: string;
   dni: string | null;
   role: string;
+  profilePhoto: string | null;
+  updatedAt: Date;
 }
 
 export default function UsersList({ users }: { users: User[] }) {
@@ -63,6 +65,19 @@ export default function UsersList({ users }: { users: User[] }) {
       <ul className="divide-y divide-border">
         {filtered.map((u) => (
           <li key={u.id} className="flex items-center gap-3 py-3 flex-wrap">
+            <div className="h-10 w-10 shrink-0 overflow-hidden rounded-full border bg-muted">
+              {u.profilePhoto ? (
+                <img
+                  src={`/api/users/${u.id}/photo?v=${new Date(u.updatedAt).getTime()}`}
+                  alt={`Foto de perfil de ${u.name ?? 'usuario'}`}
+                  className="h-full w-full object-cover"
+                />
+              ) : (
+                <div className="flex h-full w-full items-center justify-center text-xs font-semibold text-muted-foreground">
+                  {(u.name?.[0] ?? '?').toUpperCase()}
+                </div>
+              )}
+            </div>
             <Link
               href={`/admin/users/${u.id}/view`}
               className="flex-1 rounded-md text-sm transition-colors hover:text-primary focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"

--- a/src/app/api/users/[id]/photo/route.ts
+++ b/src/app/api/users/[id]/photo/route.ts
@@ -1,0 +1,37 @@
+import { get } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (
+    !session ||
+    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: params.id },
+    select: { profilePhoto: true },
+  });
+
+  if (!user?.profilePhoto) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const blob = await get(user.profilePhoto, { access: 'private' });
+  if (!blob || blob.statusCode !== 200) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const headers = Object.fromEntries(blob.headers.entries());
+  headers['Cache-Control'] = 'private, no-store, max-age=0';
+
+  return new NextResponse(blob.stream, { headers });
+}


### PR DESCRIPTION
### Motivation
- Los listados y la vista de perfil de un padre deben mostrar su foto de perfil para facilitar la identificación visual.
- La foto es privada, por lo que hace falta un endpoint administrado que sirva la imagen con autorización.

### Description
- Agrega `profilePhoto` y `updatedAt` a la consulta de usuarios en `src/app/admin/users/page.tsx` para poder renderizar la imagen y forzar refresco de caché usando `?v=`.
- Muestra avatar circular en el listado de padres en `src/app/admin/users/users-list.tsx` con fallback a la inicial del nombre cuando no hay foto; la interfaz `User` fue actualizada para incluir `profilePhoto` y `updatedAt`.
- Muestra avatar en la vista detalle del padre en `src/app/admin/users/[id]/view/page.tsx` con el mismo fallback y cache-busting por `updatedAt`.
- Añade el endpoint protegido `GET /api/users/[id]/photo` en `src/app/api/users/[id]/photo/route.ts` que valida que el usuario sea `ADMIN` o `SUPER_ADMIN` y retorna el stream privado desde `@vercel/blob` con cabeceras apropiadas.

### Testing
- Intenté ejecutar `pnpm lint`, pero falló por una restricción de red al descargar pnpm con corepack (error HTTP tunneling/proxy 403). 
- No se ejecutaron otras pruebas automatizadas en este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed73d46f1c8333acf1c490cc5a6b48)