### PR TITLE
Agrupar botón de editar con acciones en móvil en listado de padres

### DIFF
--- a/src/app/admin/users/users-list.tsx
+++ b/src/app/admin/users/users-list.tsx
@@ -92,7 +92,10 @@ export default function UsersList({ users }: { users: User[] }) {
                 {u.role}
               </span>
             </Link>
-            <Link href={`/admin/users/${u.id}`} className={linkClass}>
+            <Link
+              href={`/admin/users/${u.id}`}
+              className={`${linkClass} hidden md:inline`}
+            >
               {t.edit}
             </Link>
             <details className="group relative">
@@ -103,6 +106,12 @@ export default function UsersList({ users }: { users: User[] }) {
                 <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
               </summary>
               <div className="absolute right-0 z-10 mt-2 w-56 rounded-md border bg-card p-1 shadow-lg">
+                <Link
+                  href={`/admin/users/${u.id}`}
+                  className={`${menuItemClass} md:hidden`}
+                >
+                  {t.edit}
+                </Link>
                 <Link
                   href={`/admin/users/${u.id}/child-enrollment`}
                   className={menuItemClass}


### PR DESCRIPTION
### Motivation
- Evitar que el enlace de `Editar` quede separado del resto de acciones en pantallas móviles agrupándolo dentro del menú de acciones.
- Mantener la visibilidad directa de `Editar` en desktop para accesibilidad rápida sin modificar la experiencia de escritorio.

### Description
- Se modificó `src/app/admin/users/users-list.tsx` para ocultar el enlace de `Editar` en móvil usando `hidden md:inline` fuera del menú.
- Se añadió un `Link` de `Editar` dentro del dropdown de acciones con `md:hidden` para que aparezca solo en móvil y quede junto a las otras opciones.
- No se hicieron otros cambios funcionales; el ajuste es puramente de presentación/responsive.

### Testing
- Se intentó ejecutar `pnpm lint`, pero la ejecución falló por una restricción de red al descargar `pnpm` vía Corepack (error HTTP tunnel 403), por lo que no se pudo completar el linting automático.
- Se realizó el commit del cambio en `src/app/admin/users/users-list.tsx` exitosamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7525094083339fa18e2f83cec8bf)