### PR TITLE
Agrupar acción de editar con menú de acciones en móvil (padres)

### DIFF
--- a/src/app/admin/users/users-list.tsx
+++ b/src/app/admin/users/users-list.tsx
@@ -92,7 +92,10 @@ export default function UsersList({ users }: { users: User[] }) {
                 {u.role}
               </span>
             </Link>
-            <Link href={`/admin/users/${u.id}`} className={linkClass}>
+            <Link
+              href={`/admin/users/${u.id}`}
+              className={`${linkClass} hidden sm:inline`}
+            >
               {t.edit}
             </Link>
             <details className="group relative">
@@ -103,6 +106,12 @@ export default function UsersList({ users }: { users: User[] }) {
                 <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
               </summary>
               <div className="absolute right-0 z-10 mt-2 w-56 rounded-md border bg-card p-1 shadow-lg">
+                <Link
+                  href={`/admin/users/${u.id}`}
+                  className={`${menuItemClass} sm:hidden`}
+                >
+                  {t.edit}
+                </Link>
                 <Link
                   href={`/admin/users/${u.id}/child-enrollment`}
                   className={menuItemClass}


### PR DESCRIPTION
### Motivation
- Evitar que el botón de `Editar` quede separado de las demás acciones en pantallas pequeñas para mejorar la usabilidad del listado de padres.
- Agrupar las acciones relacionadas (editar, inscripción, reset y eliminar) en un único menú en móvil para coherencia visual. 

### Description
- Modificado `src/app/admin/users/users-list.tsx` para ocultar el enlace de `Editar` en pantallas pequeñas añadiendo la clase `hidden sm:inline` al enlace original.
- Añadido un enlace `Editar` dentro del menú de acciones (`details`) visible solo en móvil con la clase `sm:hidden`, usando `menuItemClass` para mantener el mismo estilo de ítems del menú.
- No se cambió la lógica de las acciones existentes; solo se ajustaron clases y la ubicación del enlace `Editar` para dispositivos móviles.

### Testing
- Ejecutado `npm run lint`, que finalizó correctamente sin errores bloqueantes y sólo mostró warnings preexistentes de `@next/next/no-img-element` en archivos relacionados con imágenes.
- No se añadieron tests automatizados; los cambios se verificaron mediante lint y revisión del componente visual en código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7839ca588333a8296b0c0e0b45d7)