### PR TITLE
Mostrar foto de perfil en los avatares del chat

### DIFF
--- a/src/app/api/users/[id]/photo/route.ts
+++ b/src/app/api/users/[id]/photo/route.ts
@@ -1,0 +1,36 @@
+import { get } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: params.id },
+    select: { profilePhoto: true },
+  });
+
+  if (!user?.profilePhoto) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const blob = await get(user.profilePhoto, { access: 'private' });
+  if (!blob || blob.statusCode !== 200) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const headers = Object.fromEntries(blob.headers.entries());
+  headers['Cache-Control'] = 'private, no-store, max-age=0';
+
+  return new NextResponse(blob.stream, {
+    headers,
+  });
+}

--- a/src/app/api/users/[id]/photo/route.ts
+++ b/src/app/api/users/[id]/photo/route.ts
@@ -10,7 +10,7 @@ export async function GET(
 ) {
   const session = await getServerSession(authOptions);
   if (!session) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    return new NextResponse(null, { status: 401 });
   }
 
   const user = await prisma.user.findUnique({
@@ -19,18 +19,22 @@ export async function GET(
   });
 
   if (!user?.profilePhoto) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return new NextResponse(null, { status: 404 });
   }
 
-  const blob = await get(user.profilePhoto, { access: 'private' });
-  if (!blob || blob.statusCode !== 200) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  try {
+    const blob = await get(user.profilePhoto, { access: 'private' });
+    if (!blob || blob.statusCode !== 200) {
+      return new NextResponse(null, { status: 404 });
+    }
+
+    const headers = Object.fromEntries(blob.headers.entries());
+    headers['Cache-Control'] = 'private, no-store, max-age=0';
+
+    return new NextResponse(blob.stream, {
+      headers,
+    });
+  } catch {
+    return new NextResponse(null, { status: 404 });
   }
-
-  const headers = Object.fromEntries(blob.headers.entries());
-  headers['Cache-Control'] = 'private, no-store, max-age=0';
-
-  return new NextResponse(blob.stream, {
-    headers,
-  });
 }

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -10,7 +10,13 @@ export async function GET() {
   }
 
   const users = await prisma.user.findMany({
-    select: { id: true, name: true, lastName: true, role: true },
+    select: {
+      id: true,
+      name: true,
+      lastName: true,
+      role: true,
+      updatedAt: true,
+    },
   });
 
   return NextResponse.json(users);

--- a/src/app/chat/chat-client.tsx
+++ b/src/app/chat/chat-client.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useSession } from 'next-auth/react';
+import Image from 'next/image';
 import { ArrowLeft, Send } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -12,6 +13,7 @@ type User = {
   id: string;
   name: string | null;
   role: 'ADMIN' | 'MEMBER' | 'SUPER_ADMIN';
+  updatedAt: string;
 };
 type Message = { from: string; content: string; createdAt?: string };
 type Conversation = {
@@ -64,21 +66,50 @@ function formatPreviewTime(iso: string | undefined) {
 function Avatar({
   id,
   name,
+  photoVersion,
   size = 'md',
 }: {
   id: string;
   name: string | null;
+  photoVersion: number;
   size?: 'sm' | 'md';
 }) {
+  const [photoFailed, setPhotoFailed] = useState(false);
+
+  useEffect(() => {
+    setPhotoFailed(false);
+  }, [id, photoVersion]);
+
   return (
     <div
       className={cn(
-        'shrink-0 rounded-full text-white grid place-items-center font-semibold',
+        'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
         size === 'md' ? 'h-11 w-11 text-sm' : 'h-9 w-9 text-xs',
-        avatarColor(id)
+        !photoFailed && 'bg-transparent'
       )}
     >
-      {initials(name)}
+      {!photoFailed ? (
+        <div className="relative h-full w-full">
+          <Image
+            src={`/api/users/${id}/photo?v=${photoVersion}`}
+            alt={name ?? 'Foto de perfil'}
+            fill
+            unoptimized
+            className="object-cover"
+            sizes={size === 'md' ? '44px' : '36px'}
+            onError={() => setPhotoFailed(true)}
+          />
+        </div>
+      ) : (
+        <span
+          className={cn(
+            'grid h-full w-full place-items-center text-white',
+            avatarColor(id)
+          )}
+        >
+          {initials(name)}
+        </span>
+      )}
     </div>
   );
 }
@@ -224,7 +255,11 @@ export default function ChatClient() {
                       isSelected && 'bg-muted'
                     )}
                   >
-                    <Avatar id={user.id} name={user.name} />
+                    <Avatar
+                      id={user.id}
+                      name={user.name}
+                      photoVersion={new Date(user.updatedAt).getTime()}
+                    />
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center justify-between gap-2">
                         <span className="truncate font-semibold text-sm">
@@ -268,6 +303,7 @@ export default function ChatClient() {
                 <Avatar
                   id={selectedUser.id}
                   name={selectedUser.name}
+                  photoVersion={new Date(selectedUser.updatedAt).getTime()}
                   size="sm"
                 />
                 <span className="font-semibold">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { Menu, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
+import { cn } from '@/lib/utils';
 import type { SiteSettings } from '@/types/site';
 import {
   useTranslation,
@@ -16,6 +17,30 @@ import type { Lang } from '@/lib/i18n';
 const defaultLogo =
   'https://lh6.googleusercontent.com/hX1qgSPLZYte1_e1xQwiDdMTxlxH3h1isoxUqgXoFnylzCCyiLC8q9dvMSSM-cbtHBdkrl_wlkqyknspAH12YnDAIEIdo5fmegdteoOHIUNEK_nu_0fHbE6J6S5WtghSXZiqIPcd1A=w16383';
 
+const AVATAR_COLORS = [
+  'bg-rose-500',
+  'bg-amber-500',
+  'bg-emerald-500',
+  'bg-sky-500',
+  'bg-violet-500',
+  'bg-fuchsia-500',
+  'bg-teal-500',
+  'bg-orange-500',
+];
+
+function avatarColor(id: string) {
+  let hash = 0;
+  for (let i = 0; i < id.length; i++) {
+    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
+  }
+  return AVATAR_COLORS[hash % AVATAR_COLORS.length];
+}
+
+function initials(name: string | null) {
+  const parts = (name ?? '?').trim().split(/\s+/);
+  return (parts[0]?.[0] ?? '?').concat(parts[1]?.[0] ?? '').toUpperCase();
+}
+
 export default function Navbar() {
   const { data: session } = useSession();
   const role = session?.user.role;
@@ -25,12 +50,17 @@ export default function Navbar() {
   const { lang, setLang } = useLang();
   const [menuOpen, setMenuOpen] = useState(false);
   const [settings, setSettings] = useState<SiteSettings | null>(null);
+  const [photoFailed, setPhotoFailed] = useState(false);
 
   useEffect(() => {
     fetch('/api/site-settings')
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => setSettings(data));
   }, []);
+
+  useEffect(() => {
+    setPhotoFailed(false);
+  }, [session?.user?.id, session?.user?.updatedAt]);
 
   const logoUrl = settings?.logo
     ? `https://gateway.pinata.cloud/ipfs/${settings.logo}`
@@ -95,7 +125,33 @@ export default function Navbar() {
             {t.contact}
           </Link>
           {session ? (
-            <>
+            <div className="flex items-center gap-4">
+              <div className={cn(
+                'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
+                'h-9 w-9 text-xs',
+                !photoFailed && 'bg-transparent'
+              )}>
+                {!photoFailed ? (
+                  <div className="relative h-full w-full">
+                    <Image
+                      src={`/api/users/${session.user.id}/photo?v=${new Date(session.user.updatedAt || Date.now()).getTime()}`}
+                      alt={session.user.name ?? 'Profile photo'}
+                      fill
+                      unoptimized
+                      className="object-cover"
+                      sizes="36px"
+                      onError={() => setPhotoFailed(true)}
+                    />
+                  </div>
+                ) : (
+                  <span className={cn(
+                    'grid h-full w-full place-items-center text-white',
+                    avatarColor(session.user.id)
+                  )}>
+                    {initials(session.user.name)}
+                  </span>
+                )}
+              </div>
               <Link href="/profile" className={linkClass}>
                 {t.profile}
               </Link>
@@ -105,7 +161,7 @@ export default function Navbar() {
               >
                 {t.logout}
               </button>
-            </>
+            </div>
           ) : (
             <>
               <Link href="/login" className={linkClass}>
@@ -194,6 +250,35 @@ export default function Navbar() {
           </Link>
           {session ? (
             <>
+              <div className="flex items-center gap-3 py-2">
+                <div className={cn(
+                  'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
+                  'h-9 w-9 text-xs',
+                  !photoFailed && 'bg-transparent'
+                )}>
+                  {!photoFailed ? (
+                    <div className="relative h-full w-full">
+                      <Image
+                        src={`/api/users/${session.user.id}/photo?v=${new Date(session.user.updatedAt || Date.now()).getTime()}`}
+                        alt={session.user.name ?? 'Profile photo'}
+                        fill
+                        unoptimized
+                        className="object-cover"
+                        sizes="36px"
+                        onError={() => setPhotoFailed(true)}
+                      />
+                    </div>
+                  ) : (
+                    <span className={cn(
+                      'grid h-full w-full place-items-center text-white',
+                      avatarColor(session.user.id)
+                    )}>
+                      {initials(session.user.name)}
+                    </span>
+                  )}
+                </div>
+                <span className="text-sm opacity-80">{session.user.name || 'Usuario'}</span>
+              </div>
               <Link
                 href="/profile"
                 className={linkClass}


### PR DESCRIPTION
## Resumen
- Reemplaza las iniciales del chat por la foto de perfil del usuario cuando exista.
- Sirve las fotos por un endpoint autenticado por `userId`, manteniendo el blob privado en Vercel.
- Agrega `updatedAt` como cache-buster para evitar fotos stale en la lista y el encabezado del chat.

## Validación
- `npm run lint`
- `npm run build`