### PR TITLE
Add Mis Hijos feature for members

### DIFF
--- a/src/app/profile/children/[childId]/edit/form.tsx
+++ b/src/app/profile/children/[childId]/edit/form.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import type { Child, User } from '@prisma/client';
+
+interface ChildEditFormProps {
+  child: Child & { user: User };
+}
+
+export default function ChildEditForm({ child }: ChildEditFormProps) {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [name, setName] = useState(child.name);
+  const [lastName, setLastName] = useState(child.lastName ?? '');
+  const [birthDate, setBirthDate] = useState(
+    child.birthDate ? child.birthDate.toISOString().split('T')[0] : ''
+  );
+  const [documentType, setDocumentType] = useState(child.documentType ?? '');
+  const [documentNumber, setDocumentNumber] = useState(
+    child.documentNumber ?? ''
+  );
+  const [address, setAddress] = useState(child.address ?? '');
+  const [gender, setGender] = useState(child.gender ?? '');
+  const [nationality, setNationality] = useState(child.nationality ?? '');
+  const [maritalStatus, setMaritalStatus] = useState(child.maritalStatus ?? '');
+  const [allergies, setAllergies] = useState(child.allergies ?? '');
+  const [regularMedication, setRegularMedication] = useState(
+    child.regularMedication ?? ''
+  );
+  const [relevantDiseases, setRelevantDiseases] = useState(
+    child.relevantDiseases ?? ''
+  );
+  const [previousInjuries, setPreviousInjuries] = useState(
+    child.previousInjuries ?? ''
+  );
+  const [physicalRestrictions, setPhysicalRestrictions] = useState(
+    child.physicalRestrictions ?? ''
+  );
+  const [bloodGroup, setBloodGroup] = useState(child.bloodGroup ?? '');
+  const [primaryDoctor, setPrimaryDoctor] = useState(child.primaryDoctor ?? '');
+  const [doctorPhone, setDoctorPhone] = useState(child.doctorPhone ?? '');
+  const [observations, setObservations] = useState(child.observations ?? '');
+
+  const inputClass =
+    'w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch(`/api/users/${child.userId}/children/${child.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          lastName,
+          birthDate: birthDate ? new Date(birthDate) : null,
+          documentType,
+          documentNumber,
+          address,
+          gender: gender || undefined,
+          nationality,
+          maritalStatus,
+          allergies,
+          regularMedication,
+          relevantDiseases,
+          previousInjuries,
+          physicalRestrictions,
+          bloodGroup,
+          primaryDoctor,
+          doctorPhone,
+          observations,
+        }),
+      });
+
+      if (res.ok) {
+        router.push(`/profile/children/${child.id}`);
+      }
+    } catch (error) {
+      console.error('Error updating child:', error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-2 gap-3">
+        <input
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Nombre"
+          required
+        />
+        <input
+          className={inputClass}
+          value={lastName}
+          onChange={(e) => setLastName(e.target.value)}
+          placeholder="Apellido"
+        />
+      </div>
+
+      <select
+        className={inputClass}
+        value={documentType}
+        onChange={(e) => setDocumentType(e.target.value)}
+      >
+        <option value="">Tipo de documento</option>
+        <option value="DNI">DNI</option>
+        <option value="PASAPORTE">Pasaporte</option>
+        <option value="OTRO">Otro</option>
+      </select>
+
+      <input
+        className={inputClass}
+        value={documentNumber}
+        onChange={(e) => setDocumentNumber(e.target.value)}
+        placeholder="Número / Código"
+      />
+
+      <input
+        className={inputClass}
+        type="date"
+        value={birthDate}
+        onChange={(e) => setBirthDate(e.target.value)}
+      />
+
+      <input
+        className={inputClass}
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
+        placeholder="Domicilio"
+      />
+
+      <select
+        className={inputClass}
+        value={gender}
+        onChange={(e) => setGender(e.target.value)}
+      >
+        <option value="">Género</option>
+        <option value="FEMALE">Femenino</option>
+        <option value="MALE">Masculino</option>
+        <option value="NON_BINARY">No Binario</option>
+        <option value="UNDISCLOSED">Prefiero no decirlo</option>
+        <option value="OTHER">Otro</option>
+      </select>
+
+      <input
+        className={inputClass}
+        value={nationality}
+        onChange={(e) => setNationality(e.target.value)}
+        placeholder="Nacionalidad"
+      />
+
+      <input
+        className={inputClass}
+        value={maritalStatus}
+        onChange={(e) => setMaritalStatus(e.target.value)}
+        placeholder="Estado Civil"
+      />
+
+      {/* Medical Sheet */}
+      <div className="rounded-lg border bg-muted/20 p-4 space-y-3">
+        <h3 className="text-sm font-semibold">Ficha médica</h3>
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={allergies}
+          onChange={(e) => setAllergies(e.target.value)}
+          placeholder="Alergias"
+        />
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={regularMedication}
+          onChange={(e) => setRegularMedication(e.target.value)}
+          placeholder="Medicación habitual"
+        />
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={relevantDiseases}
+          onChange={(e) => setRelevantDiseases(e.target.value)}
+          placeholder="Enfermedades relevantes"
+        />
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={previousInjuries}
+          onChange={(e) => setPreviousInjuries(e.target.value)}
+          placeholder="Lesiones previas"
+        />
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={physicalRestrictions}
+          onChange={(e) => setPhysicalRestrictions(e.target.value)}
+          placeholder="Restricciones físicas"
+        />
+        <input
+          className={inputClass}
+          value={bloodGroup}
+          onChange={(e) => setBloodGroup(e.target.value)}
+          placeholder="Grupo sanguíneo"
+        />
+        <input
+          className={inputClass}
+          value={primaryDoctor}
+          onChange={(e) => setPrimaryDoctor(e.target.value)}
+          placeholder="Médico de cabecera"
+        />
+        <input
+          className={inputClass}
+          value={doctorPhone}
+          onChange={(e) => setDoctorPhone(e.target.value)}
+          placeholder="Teléfono médico"
+        />
+        <textarea
+          className={`${inputClass} min-h-[72px] resize-y`}
+          value={observations}
+          onChange={(e) => setObservations(e.target.value)}
+          placeholder="Observaciones"
+        />
+      </div>
+
+      <Button type="submit" disabled={isSubmitting} className="w-full">
+        {isSubmitting ? 'Guardando...' : 'Guardar cambios'}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/profile/children/[childId]/edit/page.tsx
+++ b/src/app/profile/children/[childId]/edit/page.tsx
@@ -1,0 +1,51 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import ChildEditForm from './form';
+
+export default async function EditChildPage({
+  params,
+}: {
+  params: { childId: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/login');
+  }
+
+  const child = await prisma.child.findUnique({
+    where: { id: params.childId },
+    include: { user: true },
+  });
+
+  if (!child || child.userId !== (session.user as any).id) {
+    redirect('/profile/children');
+  }
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-start justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight">
+            Editar {child.name}
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Actualiza los datos de tu hijo
+          </p>
+        </div>
+        <Link
+          href={`/profile/children/${params.childId}`}
+          className="inline-block text-sm text-primary hover:text-primary/80 underline underline-offset-4"
+        >
+          ← Volver
+        </Link>
+      </div>
+
+      <div className="rounded-xl border bg-card p-6 shadow-sm">
+        <ChildEditForm child={child} />
+      </div>
+    </div>
+  );
+}

--- a/src/app/profile/children/[childId]/page.tsx
+++ b/src/app/profile/children/[childId]/page.tsx
@@ -1,0 +1,352 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import ChildInfoSection from '@/components/child-info-section';
+
+export default async function ViewMyChildPage({
+  params,
+}: {
+  params: { childId: string };
+}) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/login');
+  }
+
+  const child = await prisma.child.findUnique({
+    where: { id: params.childId },
+    include: {
+      user: true,
+      activityParticipants: { include: { activity: true } },
+    },
+  });
+
+  if (!child || child.userId !== (session.user as any).id) {
+    redirect('/profile/children');
+  }
+
+  const now = new Date();
+  const activeActivities = child.activityParticipants.filter(
+    (ap) => ap.activity.date >= now
+  );
+  const pastActivities = child.activityParticipants.filter(
+    (ap) => ap.activity.date < now
+  );
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+      {/* Header */}
+      <div className="rounded-xl border bg-card p-6 shadow-sm space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight">
+              {child.name} {child.lastName}
+            </h1>
+          </div>
+          <div className="flex gap-2">
+            <Link
+              href={`/profile/children/${params.childId}/edit`}
+              className="inline-flex h-9 items-center justify-center rounded-full border border-primary px-4 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
+            >
+              Editar
+            </Link>
+            <Link
+              href="/profile/children"
+              className="inline-flex h-9 items-center justify-center rounded-full border border-border px-4 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              ← Volver
+            </Link>
+          </div>
+        </div>
+
+        {/* Document info summary */}
+        {(child.documentFrontPhoto || child.documentBackPhoto) && (
+          <div className="text-xs rounded-full bg-muted px-3 py-1 font-medium w-fit">
+            DNI con frente y dorso cargados
+          </div>
+        )}
+      </div>
+
+      {/* Información Personal */}
+      <ChildInfoSection title="Información Personal">
+        <div className="grid grid-cols-2 gap-4 text-sm">
+          {child.name && (
+            <div>
+              <span className="font-medium block text-foreground">Nombre</span>
+              <span className="text-muted-foreground">{child.name}</span>
+            </div>
+          )}
+          {child.lastName && (
+            <div>
+              <span className="font-medium block text-foreground">Apellido</span>
+              <span className="text-muted-foreground">{child.lastName}</span>
+            </div>
+          )}
+          {child.birthDate && (
+            <div>
+              <span className="font-medium block text-foreground">
+                Fecha de Nacimiento
+              </span>
+              <span className="text-muted-foreground">
+                {child.birthDate.toLocaleDateString('es-AR')}
+              </span>
+            </div>
+          )}
+          {child.gender && (
+            <div>
+              <span className="font-medium block text-foreground">Género</span>
+              <span className="text-muted-foreground">
+                {child.gender === 'FEMALE'
+                  ? 'Femenino'
+                  : child.gender === 'MALE'
+                    ? 'Masculino'
+                    : child.gender === 'NON_BINARY'
+                      ? 'No Binario'
+                      : child.gender === 'UNDISCLOSED'
+                        ? 'Prefiero no decirlo'
+                        : 'Otro'}
+              </span>
+            </div>
+          )}
+          {child.nationality && (
+            <div>
+              <span className="font-medium block text-foreground">
+                Nacionalidad
+              </span>
+              <span className="text-muted-foreground">{child.nationality}</span>
+            </div>
+          )}
+          {child.maritalStatus && (
+            <div>
+              <span className="font-medium block text-foreground">
+                Estado Civil
+              </span>
+              <span className="text-muted-foreground">
+                {child.maritalStatus}
+              </span>
+            </div>
+          )}
+          {child.address && (
+            <div className="col-span-2">
+              <span className="font-medium block text-foreground">
+                Domicilio
+              </span>
+              <span className="text-muted-foreground">{child.address}</span>
+            </div>
+          )}
+        </div>
+      </ChildInfoSection>
+
+      {/* Documentación */}
+      {(child.documentType ||
+        child.documentNumber ||
+        child.documentFrontPhoto ||
+        child.documentBackPhoto) && (
+        <ChildInfoSection title="Documentación">
+          <div className="space-y-4">
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              {child.documentType && (
+                <div>
+                  <span className="font-medium block text-foreground">
+                    Tipo de Documento
+                  </span>
+                  <span className="text-muted-foreground">
+                    {child.documentType}
+                  </span>
+                </div>
+              )}
+              {child.documentNumber && (
+                <div>
+                  <span className="font-medium block text-foreground">
+                    Número
+                  </span>
+                  <span className="text-muted-foreground">
+                    {child.documentNumber}
+                  </span>
+                </div>
+              )}
+            </div>
+
+            {/* Document Photos */}
+            <div className="grid grid-cols-2 gap-4">
+              {child.documentFrontPhoto && (
+                <div>
+                  <span className="font-medium block text-foreground text-sm mb-2">
+                    Foto Delantera
+                  </span>
+                  <img
+                    src={child.documentFrontPhoto}
+                    alt="Foto delantera del documento"
+                    className="rounded-lg border border-border w-full max-h-64 object-cover"
+                  />
+                </div>
+              )}
+              {child.documentBackPhoto && (
+                <div>
+                  <span className="font-medium block text-foreground text-sm mb-2">
+                    Foto Trasera
+                  </span>
+                  <img
+                    src={child.documentBackPhoto}
+                    alt="Foto trasera del documento"
+                    className="rounded-lg border border-border w-full max-h-64 object-cover"
+                  />
+                </div>
+              )}
+            </div>
+          </div>
+        </ChildInfoSection>
+      )}
+
+      {/* Ficha Médica */}
+      {[
+        child.allergies,
+        child.regularMedication,
+        child.relevantDiseases,
+        child.previousInjuries,
+        child.physicalRestrictions,
+        child.bloodGroup,
+        child.primaryDoctor,
+        child.doctorPhone,
+        child.observations,
+      ].some(Boolean) && (
+        <ChildInfoSection title="Ficha Médica">
+          <div className="grid grid-cols-2 gap-4 text-sm">
+            {child.allergies && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Alergias
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.allergies}
+                </span>
+              </div>
+            )}
+            {child.regularMedication && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Medicación Habitual
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.regularMedication}
+                </span>
+              </div>
+            )}
+            {child.relevantDiseases && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Enfermedades Relevantes
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.relevantDiseases}
+                </span>
+              </div>
+            )}
+            {child.previousInjuries && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Lesiones Previas
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.previousInjuries}
+                </span>
+              </div>
+            )}
+            {child.physicalRestrictions && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Restricciones Físicas
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.physicalRestrictions}
+                </span>
+              </div>
+            )}
+            {child.bloodGroup && (
+              <div>
+                <span className="font-medium block text-foreground">
+                  Grupo Sanguíneo
+                </span>
+                <span className="text-muted-foreground">{child.bloodGroup}</span>
+              </div>
+            )}
+            {child.primaryDoctor && (
+              <div>
+                <span className="font-medium block text-foreground">
+                  Médico de Cabecera
+                </span>
+                <span className="text-muted-foreground">
+                  {child.primaryDoctor}
+                </span>
+              </div>
+            )}
+            {child.doctorPhone && (
+              <div>
+                <span className="font-medium block text-foreground">
+                  Teléfono Médico
+                </span>
+                <span className="text-muted-foreground">
+                  {child.doctorPhone}
+                </span>
+              </div>
+            )}
+            {child.observations && (
+              <div className="col-span-2">
+                <span className="font-medium block text-foreground">
+                  Observaciones
+                </span>
+                <span className="text-muted-foreground whitespace-pre-wrap">
+                  {child.observations}
+                </span>
+              </div>
+            )}
+          </div>
+        </ChildInfoSection>
+      )}
+
+      {/* Actividades - Active/Upcoming */}
+      {activeActivities.length > 0 && (
+        <ChildInfoSection title="Actividades Próximas" defaultOpen={true}>
+          <ul className="divide-y divide-border space-y-2">
+            {activeActivities.map((ap) => (
+              <li key={ap.id} className="py-2 text-sm">
+                <span className="font-medium">{ap.activity.name}</span>
+                <span className="text-muted-foreground text-xs block mt-0.5">
+                  {ap.activity.date.toLocaleDateString('es-AR')} · $
+                  {ap.activity.price}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ChildInfoSection>
+      )}
+
+      {/* Actividades - Past */}
+      {pastActivities.length > 0 && (
+        <ChildInfoSection title="Historial de Actividades" defaultOpen={false}>
+          <ul className="divide-y divide-border space-y-2">
+            {pastActivities.map((ap) => (
+              <li key={ap.id} className="py-2 text-sm">
+                <span className="font-medium">{ap.activity.name}</span>
+                <span className="text-muted-foreground text-xs block mt-0.5">
+                  {ap.activity.date.toLocaleDateString('es-AR')} · $
+                  {ap.activity.price}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </ChildInfoSection>
+      )}
+
+      {child.activityParticipants.length === 0 && (
+        <div className="rounded-xl border bg-card p-6 shadow-sm">
+          <p className="text-sm text-muted-foreground">
+            Sin actividades registradas.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/profile/children/page.tsx
+++ b/src/app/profile/children/page.tsx
@@ -1,0 +1,118 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import Link from 'next/link';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export default async function ChildrenPage() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect('/login');
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: (session.user as any).id },
+    include: {
+      children: {
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  });
+
+  if (!user) {
+    redirect('/login');
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold tracking-tight">Mis Hijos</h1>
+        <Link
+          href="/profile"
+          className="inline-flex h-9 items-center justify-center rounded-full border border-primary px-4 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
+        >
+          Agregar hijo
+        </Link>
+      </div>
+
+      {user.children.length === 0 ? (
+        <div className="rounded-xl border bg-card p-6 shadow-sm text-center">
+          <p className="text-sm text-muted-foreground">
+            No tienes hijos registrados.
+          </p>
+          <Link
+            href="/profile"
+            className="inline-flex mt-4 h-9 items-center justify-center rounded-full border border-primary px-4 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
+          >
+            Agregar hijo
+          </Link>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {user.children.map((child) => (
+            <div
+              key={child.id}
+              className="rounded-xl border bg-card p-4 shadow-sm space-y-3"
+            >
+              {/* Child Info */}
+              <div className="space-y-2">
+                <h2 className="font-semibold">
+                  {child.name} {child.lastName}
+                </h2>
+                {child.birthDate && (
+                  <p className="text-xs text-muted-foreground">
+                    {new Date().getFullYear() - child.birthDate.getFullYear()} años
+                  </p>
+                )}
+              </div>
+
+              {/* Health Highlights */}
+              <div className="bg-muted/30 rounded-lg p-3 space-y-1 text-xs">
+                {child.bloodGroup && (
+                  <p className="text-muted-foreground">
+                    <span className="font-medium">Grupo sanguíneo:</span> {child.bloodGroup}
+                  </p>
+                )}
+                {child.allergies && (
+                  <p className="text-muted-foreground">
+                    <span className="font-medium">Alergias:</span>{' '}
+                    {child.allergies.substring(0, 50)}
+                    {child.allergies.length > 50 ? '...' : ''}
+                  </p>
+                )}
+                {child.primaryDoctor && (
+                  <p className="text-muted-foreground">
+                    <span className="font-medium">Médico:</span> {child.primaryDoctor}
+                  </p>
+                )}
+              </div>
+
+              {/* Buttons */}
+              <div className="flex gap-2 pt-2">
+                <Link
+                  href={`/profile/children/${child.id}`}
+                  className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-border px-3 text-xs font-medium hover:bg-muted transition-colors"
+                >
+                  Ver
+                </Link>
+                <Link
+                  href={`/profile/children/${child.id}/edit`}
+                  className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-primary px-3 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+                >
+                  Editar
+                </Link>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Link
+        href="/profile"
+        className="inline-block text-sm text-primary hover:text-primary/80 underline underline-offset-4"
+      >
+        ← Volver al perfil
+      </Link>
+    </div>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -46,7 +46,9 @@ export default function Navbar() {
   const role = session?.user.role;
   const isAdmin = role === 'ADMIN' || role === 'SUPER_ADMIN';
   const isSuperAdmin = role === 'SUPER_ADMIN';
-  const t = useTranslation().nav;
+  const translations = useTranslation();
+  const t = translations.nav;
+  const actions = translations.actions;
   const { lang, setLang } = useLang();
   const [menuOpen, setMenuOpen] = useState(false);
   const [settings, setSettings] = useState<SiteSettings | null>(null);
@@ -212,7 +214,7 @@ export default function Navbar() {
                     href="/profile/children"
                     className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t"
                   >
-                    {t.myChildren}
+                    {actions.myChildren}
                   </Link>
                 </div>
               </div>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -197,9 +197,25 @@ export default function Navbar() {
                   </span>
                 )}
               </div>
-              <Link href="/profile" className={linkClass}>
-                {t.profile}
-              </Link>
+              <div className="relative group">
+                <button className={linkClass}>
+                  {t.profile}
+                </button>
+                <div className="absolute right-0 top-full hidden group-hover:block bg-card border rounded-md shadow-lg z-50 min-w-48">
+                  <Link
+                    href="/profile"
+                    className="block w-full text-left px-4 py-2 hover:bg-muted text-sm"
+                  >
+                    {t.profile}
+                  </Link>
+                  <Link
+                    href="/profile/children"
+                    className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t"
+                  >
+                    {t.myChildren}
+                  </Link>
+                </div>
+              </div>
               <button
                 onClick={() => signOut({ callbackUrl: '/login' })}
                 className={linkClass}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -20,6 +20,8 @@ export const translations = {
     actions: {
       view: 'Ver',
       edit: 'Editar',
+      myChildren: 'Mis Hijos',
+      addChild: 'Agregar hijo',
       childEnrollment: 'Agregar hijo',
       resetPassword: 'Restablecer contraseña',
       delete: 'Eliminar',
@@ -53,6 +55,8 @@ export const translations = {
     actions: {
       view: 'Ver',
       edit: 'Editar',
+      myChildren: 'Meus Filhos',
+      addChild: 'Adicionar filho',
       childEnrollment: 'Adicionar filho',
       resetPassword: 'Redefinir senha',
       delete: 'Excluir',
@@ -86,6 +90,8 @@ export const translations = {
     actions: {
       view: 'View',
       edit: 'Edit',
+      myChildren: 'My Children',
+      addChild: 'Add child',
       childEnrollment: 'Add child',
       resetPassword: 'Reset password',
       delete: 'Delete',
@@ -119,6 +125,8 @@ export const translations = {
     actions: {
       view: "Voir",
       edit: "Modifier",
+      myChildren: "Mes Enfants",
+      addChild: "Ajouter un enfant",
       childEnrollment: "Ajouter un enfant",
       resetPassword: "Réinitialiser le mot de passe",
       delete: "Supprimer",


### PR DESCRIPTION
## Summary

Implement "Mis Hijos" (My Children) section for MEMBERS users. This feature allows parents to view all their children's information through a dedicated interface with cards overview and detailed views.

## Changes

- **Navbar**: Added "Mis Hijos" dropdown menu under Profile for MEMBER users
- **Children Cards Page** (`/profile/children`): Grid of cards showing all children with:
  - Name, age, and health highlights (blood group, allergies, doctor)
  - View and Edit buttons
- **Child Detail View** (`/profile/children/[childId]`): Complete child information with:
  - Expandable sections (Personal Info, Documents, Medical Sheet)
  - Activity history split into Active/Upcoming and Past activities
  - Edit button for quick access to edit page
- **Child Edit Page** (`/profile/children/[childId]/edit`): Form to update child information
- **Translations**: Added "Mis Hijos" and "Agregar hijo" keys in all 4 languages (es, pt, en, fr)

## Features

- Members can only view/edit their own children (auth checks)
- Activity history automatically separates current/future from past
- Reuses ChildInfoSection component for consistency with admin view
- Responsive grid layout for children cards

## Testing Checklist

- [ ] Log in as MEMBER user
- [ ] Hover Profile in navbar, verify "Mis Hijos" appears in dropdown
- [ ] Click "Mis Hijos" - verify cards page loads
- [ ] Verify cards show child name, age, and health highlights
- [ ] Click "Ver" - verify detail page loads with all sections
- [ ] Click "Editar" on card - verify edit page loads
- [ ] Update child info and save - verify redirect to detail view
- [ ] Log in as ADMIN - verify "Mis Hijos" does NOT appear in navbar
- [ ] Try accessing /profile/children as logged-out user - verify redirect to login

🤖 Generated with Claude Code