### PR TITLE
Show remaining slots in activity listings

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -76,7 +76,7 @@ export default async function ActivitiesPage() {
                   <span>·</span>
                   <span>
                     {activity.capacity
-                      ? `${activity.participants.length}/${activity.capacity} cupo`
+                      ? `${Math.max(activity.capacity - activity.participants.length, 0)} cupos restantes`
                       : `${activity.participants.length} suscriptos`}
                   </span>
                 </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,7 +178,7 @@ export default async function Home() {
                       </div>
                       <div className="mt-2 text-xs text-muted-foreground font-body">
                         {activity.capacity
-                          ? `${activity.participants.length}/${activity.capacity} cupo`
+                          ? `${Math.max(activity.capacity - activity.participants.length, 0)} cupos disponibles`
                           : `${activity.participants.length} inscriptos`}
                         {' · $'}
                         {activity.price}


### PR DESCRIPTION
### Motivation
- Make activity cards show remaining available slots (capacity minus already enrolled) so admins and users see how many places remain at a glance.

### Description
- Replaced the enrolled/total capacity label with a remaining-slots calculation in two UI locations using `Math.max(activity.capacity - activity.participants.length, 0)` to avoid negative values.
- Files changed: `src/app/activities/page.tsx` and `src/app/page.tsx` and unlimited-capacity text behavior was left unchanged.

### Testing
- Verified the code changes and committed them; attempted to run `pnpm lint` but it failed because Corepack could not download `pnpm` in this environment (proxy returned 403), so automated lint/tests were not executed.
- Recommend running `pnpm install` and `pnpm lint` in CI or locally to validate formatting and catch any runtime issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee8b28d2248333bc8f670795dbf343)