### PR TITLE
[codex] restrict notifications to super admin

### DIFF
--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -5,10 +5,7 @@ import { prisma } from '@/lib/prisma';
 
 export default async function NotificationsPage() {
   const session = await getServerSession(authOptions);
-  if (
-    !session ||
-    (session.user.role !== 'ADMIN' && session.user.role !== 'SUPER_ADMIN')
-  ) {
+  if (!session || session.user.role !== 'SUPER_ADMIN') {
     redirect('/');
   }
 

--- a/src/app/api/mercadopago/notifications/route.ts
+++ b/src/app/api/mercadopago/notifications/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getActivityParticipantKey } from '@/lib/activity-participants';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { MercadoPagoConfig, Payment } from 'mercadopago';
 import { getMercadoPagoCredentials } from '@/lib/mercadopago';
@@ -121,6 +123,11 @@ export async function OPTIONS() {
 }
 
 export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || session.user.role !== 'SUPER_ADMIN') {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const notifications = await prisma.mercadoPagoNotification.findMany({
     orderBy: { createdAt: 'desc' },
   });

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -160,13 +160,15 @@ export default function Navbar() {
               <Link href="/admin/forms" className={linkClass}>
                 {t.forms}
               </Link>
-              <Link href="/admin/notifications" className={linkClass}>
-                {t.notifications}
-              </Link>
               {isSuperAdmin && (
-                <Link href="/admin/site" className={linkClass}>
-                  {t.admin}
-                </Link>
+                <>
+                  <Link href="/admin/notifications" className={linkClass}>
+                    {t.notifications}
+                  </Link>
+                  <Link href="/admin/site" className={linkClass}>
+                    {t.admin}
+                  </Link>
+                </>
               )}
             </>
           )}
@@ -175,11 +177,13 @@ export default function Navbar() {
           </Link>
           {session ? (
             <div className="flex items-center gap-3">
-              <div className={cn(
-                'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
-                'h-9 w-9 text-xs',
-                !photoFailed && 'bg-transparent'
-              )}>
+              <div
+                className={cn(
+                  'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
+                  'h-9 w-9 text-xs',
+                  !photoFailed && 'bg-transparent'
+                )}
+              >
                 {!photoFailed ? (
                   <div className="relative h-full w-full">
                     <Image
@@ -193,18 +197,18 @@ export default function Navbar() {
                     />
                   </div>
                 ) : (
-                  <span className={cn(
-                    'grid h-full w-full place-items-center text-white',
-                    avatarColor(session.user.id)
-                  )}>
+                  <span
+                    className={cn(
+                      'grid h-full w-full place-items-center text-white',
+                      avatarColor(session.user.id)
+                    )}
+                  >
                     {initials(session.user.name)}
                   </span>
                 )}
               </div>
               <div className="relative group">
-                <button className={linkClass}>
-                  {t.profile}
-                </button>
+                <button className={linkClass}>{t.profile}</button>
                 <div className="absolute right-0 top-full hidden group-hover:block bg-card border rounded-md shadow-lg z-50 min-w-48">
                   <Link
                     href="/profile"
@@ -289,21 +293,23 @@ export default function Navbar() {
               >
                 {t.forms}
               </Link>
-              <Link
-                href="/admin/notifications"
-                className={linkClass}
-                onClick={() => setMenuOpen(false)}
-              >
-                {t.notifications}
-              </Link>
               {isSuperAdmin && (
-                <Link
-                  href="/admin/site"
-                  className={linkClass}
-                  onClick={() => setMenuOpen(false)}
-                >
-                  {t.admin}
-                </Link>
+                <>
+                  <Link
+                    href="/admin/notifications"
+                    className={linkClass}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {t.notifications}
+                  </Link>
+                  <Link
+                    href="/admin/site"
+                    className={linkClass}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    {t.admin}
+                  </Link>
+                </>
               )}
             </>
           )}
@@ -317,11 +323,13 @@ export default function Navbar() {
           {session ? (
             <>
               <div className="flex items-center gap-3 py-2">
-                <div className={cn(
-                  'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
-                  'h-9 w-9 text-xs',
-                  !photoFailed && 'bg-transparent'
-                )}>
+                <div
+                  className={cn(
+                    'shrink-0 overflow-hidden rounded-full text-white grid place-items-center font-semibold bg-muted',
+                    'h-9 w-9 text-xs',
+                    !photoFailed && 'bg-transparent'
+                  )}
+                >
                   {!photoFailed ? (
                     <div className="relative h-full w-full">
                       <Image
@@ -335,15 +343,19 @@ export default function Navbar() {
                       />
                     </div>
                   ) : (
-                    <span className={cn(
-                      'grid h-full w-full place-items-center text-white',
-                      avatarColor(session.user.id)
-                    )}>
+                    <span
+                      className={cn(
+                        'grid h-full w-full place-items-center text-white',
+                        avatarColor(session.user.id)
+                      )}
+                    >
                       {initials(session.user.name)}
                     </span>
                   )}
                 </div>
-                <span className="text-sm opacity-80">{session.user.name || 'Usuario'}</span>
+                <span className="text-sm opacity-80">
+                  {session.user.name || 'Usuario'}
+                </span>
               </div>
               <Link
                 href="/profile"
@@ -405,8 +417,7 @@ export default function Navbar() {
                 ))}
               </select>
             </>
-          )
-        }
+          )}
         </div>
       )}
     </nav>


### PR DESCRIPTION
## What changed
- Restricted `/admin/notifications` so only `SUPER_ADMIN` can access it.
- Hid the notifications link from the navbar for non-super-admin users, including the mobile menu.
- Locked the GET endpoint for Mercado Pago notifications to `SUPER_ADMIN` as well.
- Added `package-lock.json` to `.gitignore` so it stays out of the repo.

## Why
- The notifications view contains operational/payment data that should be visible only to the highest-privilege admin role.
- The UI and the data endpoint need to match, otherwise a normal admin could still reach the underlying data.

## Validation
- `node_modules/.bin/eslint "src/app/admin/notifications/page.tsx" "src/app/api/mercadopago/notifications/route.ts" "src/components/navbar.tsx"`
- `node_modules/.bin/prettier --write "src/components/navbar.tsx"`
- `git push -u origin codex/admin-notifications-super-admin`
