### PR TITLE
fix: chat notifications never appeared due to readAt inheriting NOT NULL DEFAULT

### DIFF
--- a/prisma/migrations/20260427000000_fix_message_read_at/migration.sql
+++ b/prisma/migrations/20260427000000_fix_message_read_at/migration.sql
@@ -1,0 +1,9 @@
+-- Fix readAt column: remove NOT NULL and DEFAULT CURRENT_TIMESTAMP inherited from updatedAt rename.
+-- Without this fix, every new message is immediately marked as "read", so unreadCount is always 0.
+ALTER TABLE "Message" ALTER COLUMN "readAt" DROP DEFAULT;
+ALTER TABLE "Message" ALTER COLUMN "readAt" DROP NOT NULL;
+
+-- Reset existing messages that were auto-marked as read due to the bad default.
+-- Only reset messages where readAt was set by the default (equal to createdAt),
+-- preserving any messages that were intentionally marked as read.
+UPDATE "Message" SET "readAt" = NULL WHERE "readAt" = "createdAt";

--- a/prisma/seed-test-users.ts
+++ b/prisma/seed-test-users.ts
@@ -1,0 +1,44 @@
+import { PrismaClient } from '@prisma/client';
+import { hash } from 'bcrypt';
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const adminPassword = await hash('Test1234!', 12);
+  const memberPassword = await hash('Test1234!', 12);
+
+  const admin = await prisma.user.upsert({
+    where: { email: 'admin@test.com' },
+    update: { role: 'ADMIN', name: 'Admin Test', isActive: true },
+    create: {
+      email: 'admin@test.com',
+      name: 'Admin Test',
+      password: adminPassword,
+      role: 'ADMIN',
+      isActive: true,
+    },
+  });
+
+  const member = await prisma.user.upsert({
+    where: { email: 'member@test.com' },
+    update: { role: 'MEMBER', name: 'Member Test', isActive: true },
+    create: {
+      email: 'member@test.com',
+      name: 'Member Test',
+      password: memberPassword,
+      role: 'MEMBER',
+      isActive: true,
+    },
+  });
+
+  console.log('✅ Usuarios de prueba creados/actualizados:');
+  console.log(`  Admin:  admin@test.com  / Test1234!  (id: ${admin.id})`);
+  console.log(`  Member: member@test.com / Test1234!  (id: ${member.id})`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

- Added migration to drop the `NOT NULL` constraint and `DEFAULT CURRENT_TIMESTAMP` from the `Message.readAt` column, which was incorrectly inherited from a prior `updatedAt` rename
- Reset existing messages where `readAt` was auto-set equal to `createdAt` (i.e., set by the bad default), preserving intentionally read messages
- Added `prisma/seed-test-users.ts` script to quickly seed admin and member test users for local development

## Root Cause

The `readAt` column inherited `NOT NULL DEFAULT CURRENT_TIMESTAMP` from a previous migration, causing every new message to be immediately marked as read. This meant `unreadCount` was always 0 and chat notifications never appeared.

## Test plan

- [ ] Run migration on staging and verify `unreadCount` increments correctly for new messages
- [ ] Verify existing messages that were genuinely read remain with their `readAt` intact
- [ ] Send a new chat message and confirm the notification badge appears for the recipient
- [ ] Seed test users with `npx ts-node prisma/seed-test-users.ts` and verify login works

🤖 Generated with [Claude Code](https://claude.com/claude-code)