### PR TITLE
[codex] edit activity sessions

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -51,6 +51,7 @@ Important models:
 - `ActivityParticipant`: user or child registered to an activity.
 - `ActivityProfessor`: professor assignments for activities.
 - `ActivityDay`: scheduled day for an activity with location, description, and schedule.
+- `ActivityDayProfessor`: professor assignments for activity days.
 - `ActivityDayAttendance`: per-day confirmation record for registered participants.
 - `Form`, `FormField`, `FormResponse`: custom admin forms.
 - `Conversation`, `Message`: internal chat.

--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -139,6 +139,10 @@ Agents should check this before searching the codebase.
   - File: `src/app/api/activities/[id]/days/route.ts`
   - Validation: `src/lib/validations/activity.ts`
 
+- `PUT /api/activity-days/[dayId]` → update activity day
+  - File: `src/app/api/activity-days/[dayId]/route.ts`
+  - Validation: `src/lib/validations/activity.ts`
+
 - `PATCH /api/activity-days/[dayId]/attendance` → confirm attendance for a day
   - File: `src/app/api/activity-days/[dayId]/attendance/route.ts`
   - Validation: `src/lib/validations/activity.ts`

--- a/prisma/migrations/20260427020000_add_activity_day_professors/migration.sql
+++ b/prisma/migrations/20260427020000_add_activity_day_professors/migration.sql
@@ -1,0 +1,23 @@
+-- CreateTable
+CREATE TABLE "ActivityDayProfessor" (
+    "id" TEXT NOT NULL,
+    "activityDayId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "ActivityDayProfessor_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityDayProfessor_activityDayId_userId_key" ON "ActivityDayProfessor"("activityDayId", "userId");
+
+-- CreateIndex
+CREATE INDEX "ActivityDayProfessor_userId_idx" ON "ActivityDayProfessor"("userId");
+
+-- CreateIndex
+CREATE INDEX "ActivityDayProfessor_activityDayId_idx" ON "ActivityDayProfessor"("activityDayId");
+
+-- AddForeignKey
+ALTER TABLE "ActivityDayProfessor" ADD CONSTRAINT "ActivityDayProfessor_activityDayId_fkey" FOREIGN KEY ("activityDayId") REFERENCES "ActivityDay"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityDayProfessor" ADD CONSTRAINT "ActivityDayProfessor_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,40 +8,41 @@ datasource db {
 }
 
 model User {
-  id                   String                    @id @default(cuid())
-  email                String                    @unique
-  name                 String?
-  lastName             String?
-  dni                  String?                   @unique
-  birthDate            DateTime?
-  gender               Gender?
-  address              String?
-  phone                String?
-  observations         String?
-  allergies            String?
-  regularMedication    String?
-  relevantDiseases     String?
-  previousInjuries     String?
-  physicalRestrictions String?
-  bloodGroup           String?
-  primaryDoctor        String?
-  doctorPhone          String?
-  profilePhoto         String?
-  nationality          String?
-  maritalStatus        String?
-  password             String
-  role                 Role                      @default(MEMBER)
-  isActive             Boolean                   @default(true)
-  createdAt            DateTime                  @default(now())
-  updatedAt            DateTime                  @updatedAt
-  messages             Message[]
-  conversations        ConversationParticipant[]
-  passwordResetTokens  PasswordResetToken[]
-  formResponses        FormResponse[]
-  activityParticipants ActivityParticipant[]
-  activityProfessors   ActivityProfessor[]
-  createdActivityDays  ActivityDay[]             @relation("ActivityDayCreatedBy")
-  children             Child[]
+  id                    String                    @id @default(cuid())
+  email                 String                    @unique
+  name                  String?
+  lastName              String?
+  dni                   String?                   @unique
+  birthDate             DateTime?
+  gender                Gender?
+  address               String?
+  phone                 String?
+  observations          String?
+  allergies             String?
+  regularMedication     String?
+  relevantDiseases      String?
+  previousInjuries      String?
+  physicalRestrictions  String?
+  bloodGroup            String?
+  primaryDoctor         String?
+  doctorPhone           String?
+  profilePhoto          String?
+  nationality           String?
+  maritalStatus         String?
+  password              String
+  role                  Role                      @default(MEMBER)
+  isActive              Boolean                   @default(true)
+  createdAt             DateTime                  @default(now())
+  updatedAt             DateTime                  @updatedAt
+  messages              Message[]
+  conversations         ConversationParticipant[]
+  passwordResetTokens   PasswordResetToken[]
+  formResponses         FormResponse[]
+  activityParticipants  ActivityParticipant[]
+  activityProfessors    ActivityProfessor[]
+  createdActivityDays   ActivityDay[]             @relation("ActivityDayCreatedBy")
+  activityDayProfessors ActivityDayProfessor[]
+  children              Child[]
 }
 
 model PasswordResetToken {
@@ -167,8 +168,22 @@ model ActivityDay {
   activity    Activity                @relation(fields: [activityId], references: [id], onDelete: Cascade)
   createdBy   User                    @relation("ActivityDayCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
   attendances ActivityDayAttendance[]
+  professors  ActivityDayProfessor[]
 
   @@index([activityId, date])
+}
+
+model ActivityDayProfessor {
+  id            String      @id @default(cuid())
+  activityDayId String
+  userId        String
+  createdAt     DateTime    @default(now())
+  activityDay   ActivityDay @relation(fields: [activityDayId], references: [id], onDelete: Cascade)
+  user          User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([activityDayId, userId])
+  @@index([userId])
+  @@index([activityDayId])
 }
 
 model ActivityDayAttendance {

--- a/src/app/activities/[id]/activity-day-form.tsx
+++ b/src/app/activities/[id]/activity-day-form.tsx
@@ -1,0 +1,235 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import ProfessorPicker from '../professor-picker';
+
+type ProfessorOption = {
+  id: string;
+  name: string | null;
+  lastName: string | null;
+  email: string;
+};
+
+type Coordinates = {
+  latitude: number;
+  longitude: number;
+};
+
+type ActivityDayValues = {
+  date: string;
+  schedule: string;
+  description: string;
+  geoLocation: string;
+  coordinates: Coordinates | null;
+  professorIds: string[];
+};
+
+interface ActivityDayFormProps {
+  activityId: string;
+  mode: 'create' | 'edit';
+  professors: ProfessorOption[];
+  defaultProfessorIds: string[];
+  initialValues?: ActivityDayValues;
+  dayId?: string;
+  onSaved?: () => void;
+  onCancel?: () => void;
+}
+
+const LocationMapPicker = dynamic(() => import('../location-map-picker'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-80 items-center justify-center rounded-lg border bg-muted/20 text-sm text-muted-foreground">
+      Cargando mapa...
+    </div>
+  ),
+});
+
+const inputClass =
+  'w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+function buildInitialState(
+  initialValues: ActivityDayValues | undefined,
+  defaultProfessorIds: string[]
+): ActivityDayValues {
+  return (
+    initialValues ?? {
+      date: '',
+      schedule: '',
+      description: '',
+      geoLocation: '',
+      coordinates: null,
+      professorIds: defaultProfessorIds,
+    }
+  );
+}
+
+export default function ActivityDayForm({
+  activityId,
+  mode,
+  professors,
+  defaultProfessorIds,
+  initialValues,
+  dayId,
+  onSaved,
+  onCancel,
+}: ActivityDayFormProps) {
+  const router = useRouter();
+  const [date, setDate] = useState(
+    buildInitialState(initialValues, defaultProfessorIds).date
+  );
+  const [schedule, setSchedule] = useState(
+    buildInitialState(initialValues, defaultProfessorIds).schedule
+  );
+  const [description, setDescription] = useState(
+    buildInitialState(initialValues, defaultProfessorIds).description
+  );
+  const [geoLocation, setGeoLocation] = useState(
+    buildInitialState(initialValues, defaultProfessorIds).geoLocation
+  );
+  const [coordinates, setCoordinates] = useState<Coordinates | null>(
+    buildInitialState(initialValues, defaultProfessorIds).coordinates
+  );
+  const [professorIds, setProfessorIds] = useState<string[]>(
+    buildInitialState(initialValues, defaultProfessorIds).professorIds
+  );
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const isEdit = mode === 'edit';
+
+  const resetCreateForm = () => {
+    setDate('');
+    setSchedule('');
+    setDescription('');
+    setGeoLocation('');
+    setCoordinates(null);
+    setProfessorIds(defaultProfessorIds);
+  };
+
+  async function submitForm(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+    try {
+      if (!coordinates) {
+        throw new Error('Seleccioná un punto en el mapa');
+      }
+      if (professorIds.length === 0) {
+        throw new Error('Seleccioná al menos un profesor');
+      }
+
+      const res = await fetch(
+        isEdit && dayId
+          ? `/api/activity-days/${dayId}`
+          : `/api/activities/${activityId}/days`,
+        {
+          method: isEdit ? 'PUT' : 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            date,
+            schedule,
+            description: description || undefined,
+            geoLocation,
+            latitude: coordinates.latitude,
+            longitude: coordinates.longitude,
+            professorIds,
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error || 'No se pudo guardar la sesión');
+      }
+
+      if (isEdit) {
+        onSaved?.();
+        router.refresh();
+        return;
+      }
+
+      resetCreateForm();
+      router.refresh();
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo guardar la sesión'
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submitForm}
+      className="space-y-3 rounded-lg border bg-background p-4"
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+          className={inputClass}
+          required
+        />
+        <input
+          type="text"
+          value={schedule}
+          onChange={(e) => setSchedule(e.target.value)}
+          className={inputClass}
+          placeholder="Horario"
+          required
+        />
+      </div>
+      <input
+        type="text"
+        value={geoLocation}
+        onChange={(e) => setGeoLocation(e.target.value)}
+        className={inputClass}
+        placeholder="Nombre o referencia del lugar"
+        required
+      />
+      <div className="space-y-2">
+        <p className="text-sm font-medium">Punto en el mapa</p>
+        <LocationMapPicker value={coordinates} onChange={setCoordinates} />
+      </div>
+      <textarea
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        className={`${inputClass} min-h-[90px] resize-y`}
+        placeholder="Descripción de la sesión"
+      />
+      <ProfessorPicker
+        professors={professors}
+        value={professorIds}
+        onChange={setProfessorIds}
+      />
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            Guardá fecha, horario, ubicación, mapa y profesores asignados.
+          </span>
+        )}
+        <div className="flex gap-2">
+          {isEdit && onCancel && (
+            <Button type="button" variant="outline" onClick={onCancel}>
+              Cancelar
+            </Button>
+          )}
+          <Button type="submit" disabled={saving}>
+            {saving
+              ? 'Guardando...'
+              : isEdit
+                ? 'Guardar cambios'
+                : 'Agregar día'}
+          </Button>
+        </div>
+      </div>
+    </form>
+  );
+}

--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Button } from '@/components/ui/button';
+import ActivityDayForm from './activity-day-form';
 
 type AttendanceStatus = 'PENDING' | 'GOING' | 'NOT_GOING';
+
+type ProfessorOption = {
+  id: string;
+  name: string | null;
+  lastName: string | null;
+  email: string;
+};
 
 type Registration = {
   id: string;
@@ -20,6 +26,8 @@ type ActivityDay = {
   geoLocation: string;
   latitude: number | null;
   longitude: number | null;
+  assignedProfessors: ProfessorOption[];
+  canEdit: boolean;
   attendances: Array<{
     activityParticipantId: string;
     status: AttendanceStatus;
@@ -30,6 +38,8 @@ type ActivityDay = {
 interface ActivityDaysPanelProps {
   activityId: string;
   canManageDays: boolean;
+  professors: ProfessorOption[];
+  defaultProfessorIds: string[];
   registrations: Registration[];
   days: ActivityDay[];
 }
@@ -40,72 +50,18 @@ const statusLabels: Record<AttendanceStatus, string> = {
   NOT_GOING: 'No voy',
 };
 
-const LocationMapPicker = dynamic(() => import('../location-map-picker'), {
-  ssr: false,
-  loading: () => (
-    <div className="flex h-80 items-center justify-center rounded-lg border bg-muted/20 text-sm text-muted-foreground">
-      Cargando mapa...
-    </div>
-  ),
-});
-
 export default function ActivityDaysPanel({
   activityId,
   canManageDays,
+  professors,
+  defaultProfessorIds,
   registrations,
   days,
 }: ActivityDaysPanelProps) {
   const router = useRouter();
-  const [date, setDate] = useState('');
-  const [schedule, setSchedule] = useState('');
-  const [description, setDescription] = useState('');
-  const [geoLocation, setGeoLocation] = useState('');
-  const [coordinates, setCoordinates] = useState<{
-    latitude: number;
-    longitude: number;
-  } | null>(null);
+  const [editingDayId, setEditingDayId] = useState<string | null>(null);
   const [error, setError] = useState('');
-  const [saveError, setSaveError] = useState('');
   const [savingKey, setSavingKey] = useState<string | null>(null);
-
-  const inputClass =
-    'w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary';
-
-  async function createDay(e: React.FormEvent) {
-    e.preventDefault();
-    setSaveError('');
-    try {
-      if (!coordinates) {
-        throw new Error('Seleccioná un punto en el mapa');
-      }
-      const res = await fetch(`/api/activities/${activityId}/days`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          date,
-          schedule,
-          description: description || undefined,
-          geoLocation,
-          latitude: coordinates.latitude,
-          longitude: coordinates.longitude,
-        }),
-      });
-      if (!res.ok) {
-        const payload = await res.json().catch(() => null);
-        throw new Error(payload?.error || 'No se pudo crear el día');
-      }
-      setDate('');
-      setSchedule('');
-      setDescription('');
-      setGeoLocation('');
-      setCoordinates(null);
-      router.refresh();
-    } catch (err) {
-      setSaveError(
-        err instanceof Error ? err.message : 'No se pudo crear el día'
-      );
-    }
-  }
 
   async function updateAttendance(
     dayId: string,
@@ -159,56 +115,14 @@ export default function ActivityDaysPanel({
       </div>
 
       {canManageDays && (
-        <form
-          onSubmit={createDay}
-          className="mt-5 space-y-3 rounded-lg border bg-background p-4"
-        >
-          <div className="grid gap-3 sm:grid-cols-2">
-            <input
-              type="date"
-              value={date}
-              onChange={(e) => setDate(e.target.value)}
-              className={inputClass}
-              required
-            />
-            <input
-              type="text"
-              value={schedule}
-              onChange={(e) => setSchedule(e.target.value)}
-              className={inputClass}
-              placeholder="Horario"
-              required
-            />
-          </div>
-          <input
-            type="text"
-            value={geoLocation}
-            onChange={(e) => setGeoLocation(e.target.value)}
-            className={inputClass}
-            placeholder="Nombre o referencia del lugar"
-            required
+        <div className="mt-5">
+          <ActivityDayForm
+            activityId={activityId}
+            mode="create"
+            professors={professors}
+            defaultProfessorIds={defaultProfessorIds}
           />
-          <div className="space-y-2">
-            <p className="text-sm font-medium">Punto en el mapa</p>
-            <LocationMapPicker value={coordinates} onChange={setCoordinates} />
-          </div>
-          <textarea
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className={`${inputClass} min-h-[90px] resize-y`}
-            placeholder="Descripción del día"
-          />
-          <div className="flex items-center justify-between gap-3">
-            {saveError ? (
-              <p className="text-sm text-destructive">{saveError}</p>
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                Guardá una fecha, horario y ubicación para el próximo encuentro.
-              </span>
-            )}
-            <Button type="submit">Agregar día</Button>
-          </div>
-        </form>
+        </div>
       )}
 
       {days.length === 0 ? (
@@ -228,6 +142,13 @@ export default function ActivityDaysPanel({
               day.latitude != null && day.longitude != null
                 ? `https://www.openstreetmap.org/?mlat=${day.latitude}&mlon=${day.longitude}#map=17/${day.latitude}/${day.longitude}`
                 : null;
+            const professorLabels = day.assignedProfessors
+              .map(
+                (professor) =>
+                  `${professor.name ?? 'Sin nombre'}${professor.lastName ? ` ${professor.lastName}` : ''}`
+              )
+              .join(', ');
+            const isEditing = editingDayId === day.id;
 
             return (
               <article
@@ -247,6 +168,11 @@ export default function ActivityDaysPanel({
                     <p className="text-sm text-muted-foreground">
                       {day.schedule} · {day.geoLocation}
                     </p>
+                    {day.assignedProfessors.length > 0 && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Profesores: {professorLabels}
+                      </p>
+                    )}
                     {mapHref && (
                       <a
                         href={mapHref}
@@ -258,8 +184,21 @@ export default function ActivityDaysPanel({
                       </a>
                     )}
                   </div>
-                  <div className="text-xs text-muted-foreground">
-                    {goingCount} confirmados · {notGoingCount} no asistirán
+                  <div className="flex flex-col items-start gap-2 text-xs text-muted-foreground sm:items-end">
+                    <span>
+                      {goingCount} confirmados · {notGoingCount} no asistirán
+                    </span>
+                    {day.canEdit && (
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setEditingDayId(isEditing ? null : day.id)
+                        }
+                        className="text-primary hover:underline underline-offset-4"
+                      >
+                        {isEditing ? 'Cerrar edición' : 'Editar sesión'}
+                      </button>
+                    )}
                   </div>
                 </div>
 
@@ -267,6 +206,37 @@ export default function ActivityDaysPanel({
                   <p className="mt-3 text-sm text-muted-foreground">
                     {day.description}
                   </p>
+                )}
+
+                {isEditing && (
+                  <div className="mt-4">
+                    <ActivityDayForm
+                      key={day.id}
+                      activityId={activityId}
+                      mode="edit"
+                      dayId={day.id}
+                      professors={professors}
+                      defaultProfessorIds={defaultProfessorIds}
+                      initialValues={{
+                        date: day.date.slice(0, 10),
+                        schedule: day.schedule,
+                        description: day.description ?? '',
+                        geoLocation: day.geoLocation,
+                        coordinates:
+                          day.latitude != null && day.longitude != null
+                            ? {
+                                latitude: day.latitude,
+                                longitude: day.longitude,
+                              }
+                            : null,
+                        professorIds: day.assignedProfessors.map(
+                          (professor) => professor.id
+                        ),
+                      }}
+                      onSaved={() => setEditingDayId(null)}
+                      onCancel={() => setEditingDayId(null)}
+                    />
+                  </div>
                 )}
 
                 {registrations.length > 0 && (

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -60,7 +60,8 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     );
   }
 
-  const [participants, professors, days] = await Promise.all([
+  const [participants, activityProfessors, professorOptions, days] =
+    await Promise.all([
     prisma.activityParticipant
       .findMany({
         where: { activityId: activity.id },
@@ -94,11 +95,44 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         console.error('[activity-page] professors query failed', error);
         return [];
       }),
+    prisma.user
+      .findMany({
+        where: {
+          role: 'PROFESSOR',
+          isActive: true,
+        },
+        select: {
+          id: true,
+          name: true,
+          lastName: true,
+          email: true,
+        },
+        orderBy: [{ name: 'asc' }, { lastName: 'asc' }],
+      })
+      .catch((error) => {
+        console.error(
+          '[activity-page] professor options query failed',
+          error
+        );
+        return [];
+      }),
     prisma.activityDay
       .findMany({
         where: { activityId: activity.id },
         orderBy: { date: 'asc' },
         include: {
+          professors: {
+            include: {
+              user: {
+                select: {
+                  id: true,
+                  name: true,
+                  lastName: true,
+                  email: true,
+                },
+              },
+            },
+          },
           attendances: {
             select: {
               activityParticipantId: true,
@@ -121,6 +155,9 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     ONE_TIME: 'Un solo pago',
   };
   const enrolledCount = participants.length;
+  const activityProfessorIds = activityProfessors.map(
+    (assignment: { userId: string }) => assignment.userId
+  );
   const capacity = activity.capacity;
   const hasCapacity = capacity != null;
   const remainingSpots = hasCapacity
@@ -129,9 +166,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   const isFull = hasCapacity && remainingSpots === 0;
   const canManageDays =
     isAdmin ||
-    professors.some(
-      (assignment: { userId: string }) => assignment.userId === session?.user.id
-    );
+    activityProfessorIds.includes(session?.user.id ?? '');
 
   let registrations: Array<{
     id: string;
@@ -153,7 +188,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     }));
   }
 
-  const professorLabels = professors.map((assignment: any) => {
+  const professorLabels = activityProfessors.map((assignment: any) => {
     const professor = assignment.user;
     return `${professor.name ?? 'Sin nombre'}${professor.lastName ? ` ${professor.lastName}` : ''}`;
   });
@@ -231,7 +266,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                     ? `${capacity} lugares`
                     : 'Ilimitado',
                 },
-                professors.length > 0 && {
+                activityProfessors.length > 0 && {
                   label: 'Profesores',
                   value: professorLabels.join(', '),
                 },

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -48,47 +48,9 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   const isAdmin =
     session?.user.role === 'ADMIN' || session?.user.role === 'SUPER_ADMIN';
 
-  let activity: any = null;
-  try {
-    activity = await prisma.activity.findUnique({
-      where: { id: params.id },
-      include: {
-        participants: isAdmin
-          ? {
-              include: {
-                user: true,
-                child: true,
-              },
-            }
-          : true,
-        professors: {
-          include: {
-            user: {
-              select: {
-                id: true,
-                name: true,
-                lastName: true,
-              },
-            },
-          },
-        },
-        days: {
-          orderBy: { date: 'asc' },
-          include: {
-            attendances: {
-              select: {
-                activityParticipantId: true,
-                status: true,
-                confirmedAt: true,
-              },
-            },
-          },
-        },
-      },
-    });
-  } catch (e: any) {
-    activity = null;
-  }
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+  });
 
   if (!activity) {
     return (
@@ -98,23 +60,113 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     );
   }
 
+  const [participants, activityProfessors, professorOptions, days] =
+    await Promise.all([
+      prisma.activityParticipant
+        .findMany({
+          where: { activityId: activity.id },
+          include: isAdmin
+            ? {
+                user: true,
+                child: true,
+              }
+            : {
+                child: true,
+              },
+        })
+        .catch((error) => {
+          console.error('[activity-page] participants query failed', error);
+          return [];
+        }),
+      prisma.activityProfessor
+        .findMany({
+          where: { activityId: activity.id },
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                lastName: true,
+                email: true,
+              },
+            },
+          },
+        })
+        .catch((error) => {
+          console.error('[activity-page] professors query failed', error);
+          return [];
+        }),
+      prisma.user
+        .findMany({
+          where: {
+            role: 'PROFESSOR',
+            isActive: true,
+          },
+          select: {
+            id: true,
+            name: true,
+            lastName: true,
+            email: true,
+          },
+          orderBy: [{ name: 'asc' }, { lastName: 'asc' }],
+        })
+        .catch((error) => {
+          console.error(
+            '[activity-page] professor options query failed',
+            error
+          );
+          return [];
+        }),
+      prisma.activityDay
+        .findMany({
+          where: { activityId: activity.id },
+          orderBy: { date: 'asc' },
+          include: {
+            professors: {
+              include: {
+                user: {
+                  select: {
+                    id: true,
+                    name: true,
+                    lastName: true,
+                    email: true,
+                  },
+                },
+              },
+            },
+            attendances: {
+              select: {
+                activityParticipantId: true,
+                status: true,
+                confirmedAt: true,
+              },
+            },
+          },
+        })
+        .catch((error) => {
+          console.error('[activity-page] days query failed', error);
+          return [];
+        }),
+    ]);
+
   const frequencyLabels: Record<string, string> = {
     DAILY: 'Diaria',
     WEEKLY: 'Semanal',
     MONTHLY: 'Mensual',
     ONE_TIME: 'Un solo pago',
   };
-  const enrolledCount = activity.participants.length;
-  const hasCapacity = activity.capacity != null;
+  const enrolledCount = participants.length;
+  const activityProfessorIds = activityProfessors.map(
+    (assignment: { userId: string }) => assignment.userId
+  );
+  const capacity = activity.capacity;
+  const hasCapacity = capacity != null;
   const remainingSpots = hasCapacity
-    ? Math.max(activity.capacity - enrolledCount, 0)
+    ? Math.max(capacity - enrolledCount, 0)
     : null;
   const isFull = hasCapacity && remainingSpots === 0;
   const canManageDays =
-    isAdmin ||
-    activity.professors.some(
-      (assignment: { userId: string }) => assignment.userId === session?.user.id
-    );
+    isAdmin || activityProfessorIds.includes(session?.user.id ?? '');
 
   let registrations: Array<{
     id: string;
@@ -122,22 +174,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   }> = [];
 
   if (session) {
-    const activityParticipants = await prisma.activityParticipant.findMany({
-      where: {
-        activityId: activity.id,
-        OR: [
-          { userId: session.user.id },
-          { child: { userId: session.user.id } },
-        ],
-      },
-      include: {
-        child: {
-          select: {
-            name: true,
-            lastName: true,
-          },
-        },
-      },
+    const activityParticipants = participants.filter((participant: any) => {
+      const isOwner = participant.userId === session.user.id;
+      const childOwner = participant.child?.userId === session.user.id;
+      return isOwner || childOwner;
     });
 
     registrations = activityParticipants.map((participant: any) => ({
@@ -148,10 +188,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     }));
   }
 
-  const professorLabels = activity.professors.map((assignment: any) => {
+  const professorLabels = activityProfessors.map((assignment: any) => {
     const professor = assignment.user;
     return `${professor.name ?? 'Sin nombre'}${professor.lastName ? ` ${professor.lastName}` : ''}`;
   });
+  const adminParticipants = participants as ActivityParticipantDetail[];
 
   return (
     <main>
@@ -222,10 +263,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                 {
                   label: 'Cupo',
                   value: hasCapacity
-                    ? `${activity.capacity} lugares`
+                    ? `${capacity} lugares`
                     : 'Ilimitado',
                 },
-                activity.professors.length > 0 && {
+                activityProfessors.length > 0 && {
                   label: 'Profesores',
                   value: professorLabels.join(', '),
                 },
@@ -316,7 +357,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
             <div className="pt-2 border-t border-border">
               <p className="text-xs text-muted-foreground font-body text-center">
                 {hasCapacity
-                  ? `${enrolledCount} de ${activity.capacity} lugares ocupados`
+                  ? `${enrolledCount} de ${capacity} lugares ocupados`
                   : `${enrolledCount} personas ya inscriptas`}
               </p>
             </div>
@@ -326,8 +367,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         <ActivityDaysPanel
           activityId={activity.id}
           canManageDays={canManageDays}
+          professors={professorOptions}
+          defaultProfessorIds={activityProfessorIds}
           registrations={registrations}
-          days={activity.days.map((day: any) => ({
+          days={days.map((day: any) => ({
             id: day.id,
             date: day.date.toISOString(),
             schedule: day.schedule,
@@ -335,6 +378,19 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
             geoLocation: day.geoLocation,
             latitude: day.latitude,
             longitude: day.longitude,
+            canEdit:
+              isAdmin ||
+              activityProfessorIds.includes(session?.user.id ?? '') ||
+              day.professors.some(
+                (assignment: { userId: string }) =>
+                  assignment.userId === session?.user.id
+              ),
+            assignedProfessors: day.professors.map((assignment: any) => ({
+              id: assignment.user.id,
+              name: assignment.user.name,
+              lastName: assignment.user.lastName,
+              email: assignment.user.email,
+            })),
             attendances: day.attendances.map((attendance: any) => ({
               activityParticipantId: attendance.activityParticipantId,
               status: attendance.status,
@@ -364,51 +420,49 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
               )}
             </div>
 
-            {activity.participants.length === 0 ? (
+            {adminParticipants.length === 0 ? (
               <p className="mt-6 text-sm text-muted-foreground font-body">
                 Aún no hay inscriptos en esta actividad.
               </p>
             ) : (
               <ul className="mt-6 divide-y divide-border">
-                {activity.participants.map(
-                  (participant: ActivityParticipantDetail) => (
-                    <li
-                      key={participant.id}
-                      className="py-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
-                    >
-                      <div>
-                        <p className="font-medium">
-                          {getParticipantName(participant)}
-                        </p>
-                        <p className="text-sm text-muted-foreground font-body">
-                          {getParticipantSubtitle(participant)}
-                        </p>
-                        <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground font-body">
-                          {participant.receipt && (
-                            <span>Comprobante {participant.receipt}</span>
-                          )}
-                          {participant.receiptDate && (
-                            <span>
-                              {participant.receipt ? '· ' : ''}
-                              Pago aprobado el{' '}
-                              {participant.receiptDate.toLocaleDateString(
-                                'es-AR',
-                                {
-                                  day: 'numeric',
-                                  month: 'long',
-                                  year: 'numeric',
-                                }
-                              )}
-                            </span>
-                          )}
-                        </div>
+                {adminParticipants.map((participant) => (
+                  <li
+                    key={participant.id}
+                    className="py-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <p className="font-medium">
+                        {getParticipantName(participant)}
+                      </p>
+                      <p className="text-sm text-muted-foreground font-body">
+                        {getParticipantSubtitle(participant)}
+                      </p>
+                      <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground font-body">
+                        {participant.receipt && (
+                          <span>Comprobante {participant.receipt}</span>
+                        )}
+                        {participant.receiptDate && (
+                          <span>
+                            {participant.receipt ? '· ' : ''}
+                            Pago aprobado el{' '}
+                            {participant.receiptDate.toLocaleDateString(
+                              'es-AR',
+                              {
+                                day: 'numeric',
+                                month: 'long',
+                                year: 'numeric',
+                              }
+                            )}
+                          </span>
+                        )}
                       </div>
-                      <div className="text-sm text-muted-foreground font-body">
-                        {participant.child ? 'Hijo/a' : 'Titular'}
-                      </div>
-                    </li>
-                  )
-                )}
+                    </div>
+                    <div className="text-sm text-muted-foreground font-body">
+                      {participant.child ? 'Hijo/a' : 'Titular'}
+                    </div>
+                  </li>
+                ))}
               </ul>
             )}
           </section>

--- a/src/app/api/activity-days/[dayId]/route.ts
+++ b/src/app/api/activity-days/[dayId]/route.ts
@@ -48,12 +48,7 @@ export async function PUT(
     (assignment) => assignment.userId === session.user.id
   );
 
-  if (
-    !isAdmin &&
-    session.user.role !== 'PROFESSOR' &&
-    !isActivityProfessor &&
-    !isDayProfessor
-  ) {
+  if (!isAdmin && !isActivityProfessor && !isDayProfessor) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/activity-days/[dayId]/route.ts
+++ b/src/app/api/activity-days/[dayId]/route.ts
@@ -2,47 +2,62 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { activityDayCreateSchema } from '@/lib/validations/activity';
+import { activityDayUpdateSchema } from '@/lib/validations/activity';
 
-export async function POST(
+export async function PUT(
   req: Request,
-  { params }: { params: { id: string } }
+  { params }: { params: { dayId: string } }
 ) {
   const session = await getServerSession(authOptions);
   if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const activity = await prisma.activity.findUnique({
-    where: { id: params.id },
+  const day = await prisma.activityDay.findUnique({
+    where: { id: params.dayId },
     select: {
       id: true,
+      activityId: true,
       professors: {
         select: {
           userId: true,
         },
       },
+      activity: {
+        select: {
+          professors: {
+            select: {
+              userId: true,
+            },
+          },
+        },
+      },
     },
   });
 
-  if (!activity) {
-    return NextResponse.json(
-      { error: 'Actividad no encontrada' },
-      { status: 404 }
-    );
+  if (!day) {
+    return NextResponse.json({ error: 'Día no encontrado' }, { status: 404 });
   }
 
   const isAdmin =
     session.user.role === 'ADMIN' || session.user.role === 'SUPER_ADMIN';
-  const isAssignedProfessor = activity.professors.some(
+  const isActivityProfessor = day.activity.professors.some(
+    (assignment) => assignment.userId === session.user.id
+  );
+  const isDayProfessor = day.professors.some(
     (assignment) => assignment.userId === session.user.id
   );
 
-  if (!isAdmin && !isAssignedProfessor) {
+  if (
+    !isAdmin &&
+    session.user.role !== 'PROFESSOR' &&
+    !isActivityProfessor &&
+    !isDayProfessor
+  ) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const data = activityDayCreateSchema.parse(await req.json());
+  const data = activityDayUpdateSchema.parse(await req.json());
   const professorIds = Array.from(new Set(data.professorIds));
   const validProfessors = await prisma.user.findMany({
     where: {
@@ -59,10 +74,9 @@ export async function POST(
     );
   }
 
-  const activityDay = await prisma.activityDay.create({
+  const updatedDay = await prisma.activityDay.update({
+    where: { id: day.id },
     data: {
-      activityId: activity.id,
-      createdById: session.user.id,
       date: data.date,
       schedule: data.schedule,
       description: data.description,
@@ -70,12 +84,27 @@ export async function POST(
       latitude: data.latitude,
       longitude: data.longitude,
       professors: {
+        deleteMany: {},
         create: professorIds.map((userId) => ({
           user: { connect: { id: userId } },
         })),
       },
     },
+    include: {
+      professors: {
+        include: {
+          user: {
+            select: {
+              id: true,
+              name: true,
+              lastName: true,
+              email: true,
+            },
+          },
+        },
+      },
+    },
   });
 
-  return NextResponse.json(activityDay);
+  return NextResponse.json(updatedDay);
 }

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -18,7 +18,10 @@ export const activityDayCreateSchema = z.object({
   geoLocation: z.string().min(1),
   latitude: z.number(),
   longitude: z.number(),
+  professorIds: z.array(z.string().min(1)).min(1),
 });
+
+export const activityDayUpdateSchema = activityDayCreateSchema;
 
 export const activityDayAttendanceSchema = z.object({
   participantId: z.string().min(1),


### PR DESCRIPTION
Agrega edición de sesiones/días de actividad con asignación de profesores por sesión.

Cambios clave:
- cada sesión ahora guarda profesores asignados
- profesores, admin y super admin pueden editar sesiones
- la UI permite editar fecha, horario, ubicación, mapa y profesores
- se agregó la migración de `ActivityDayProfessor` y se aplicó en la base remota

Verificación:
- `npm run build`
- login en navegador como `professor@test.com`
- apertura de la actividad `cmekxgc9y0003trzv45htj3rf`
- edición y guardado de una sesión asignada al profesor