### PR TITLE
[codex] make activity groups staff-managed

### DIFF
--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -75,7 +75,7 @@ Important models:
 - Public users can see the home/contact pages and auth pages.
 - Logged-in users can access profile, chat, children data, activity checkout, and personal registration flows.
 - Logged-in professors can access `my-activities`, manage activity days for assigned activities, and see their assigned activities alongside enrollments.
-- Logged-in registered users can join activity groups for their own registrations.
+- Logged-in professors and admins assign registered users to activity groups.
 - Activity days can be restricted to a single group; attendance confirmation is blocked for participants outside that group.
 - `ADMIN` and `SUPER_ADMIN` can manage activities, users, forms, and notifications.
 - `SUPER_ADMIN` alone can access site settings.

--- a/PROJECT_CONTEXT.md
+++ b/PROJECT_CONTEXT.md
@@ -50,6 +50,8 @@ Important models:
 - `Activity`: club activity, course, outing, or subscription.
 - `ActivityParticipant`: user or child registered to an activity.
 - `ActivityProfessor`: professor assignments for activities.
+- `ActivityGroup`: group definitions within an activity.
+- `ActivityGroupMember`: participant membership in an activity group.
 - `ActivityDay`: scheduled day for an activity with location, description, and schedule.
 - `ActivityDayProfessor`: professor assignments for activity days.
 - `ActivityDayAttendance`: per-day confirmation record for registered participants.
@@ -73,6 +75,8 @@ Important models:
 - Public users can see the home/contact pages and auth pages.
 - Logged-in users can access profile, chat, children data, activity checkout, and personal registration flows.
 - Logged-in professors can access `my-activities`, manage activity days for assigned activities, and see their assigned activities alongside enrollments.
+- Logged-in registered users can join activity groups for their own registrations.
+- Activity days can be restricted to a single group; attendance confirmation is blocked for participants outside that group.
 - `ADMIN` and `SUPER_ADMIN` can manage activities, users, forms, and notifications.
 - `SUPER_ADMIN` alone can access site settings.
 

--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -139,6 +139,10 @@ Agents should check this before searching the codebase.
   - File: `src/app/api/activities/[id]/days/route.ts`
   - Validation: `src/lib/validations/activity.ts`
 
+- `POST /api/activities/[id]/groups` → create activity group
+  - File: `src/app/api/activities/[id]/groups/route.ts`
+  - Validation: `src/lib/validations/activity.ts`
+
 - `PUT /api/activity-days/[dayId]` → update activity day
   - File: `src/app/api/activity-days/[dayId]/route.ts`
   - Validation: `src/lib/validations/activity.ts`
@@ -146,6 +150,12 @@ Agents should check this before searching the codebase.
 - `PATCH /api/activity-days/[dayId]/attendance` → confirm attendance for a day
   - File: `src/app/api/activity-days/[dayId]/attendance/route.ts`
   - Validation: `src/lib/validations/activity.ts`
+
+- `POST /api/activity-groups/[groupId]/members` → join activity group
+  - File: `src/app/api/activity-groups/[groupId]/members/route.ts`
+
+- `DELETE /api/activity-groups/[groupId]/members` → leave activity group
+  - File: `src/app/api/activity-groups/[groupId]/members/route.ts`
 
 ### Forms
 

--- a/prisma/migrations/20260427030000_add_activity_groups/migration.sql
+++ b/prisma/migrations/20260427030000_add_activity_groups/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable
+CREATE TABLE "ActivityGroup" (
+    "id" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ActivityGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ActivityGroupMember" (
+    "id" TEXT NOT NULL,
+    "activityGroupId" TEXT NOT NULL,
+    "activityParticipantId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ActivityGroupMember_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "ActivityDay" ADD COLUMN     "activityGroupId" TEXT;
+
+-- CreateIndex
+CREATE INDEX "ActivityGroup_activityId_idx" ON "ActivityGroup"("activityId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityGroupMember_activityParticipantId_key" ON "ActivityGroupMember"("activityParticipantId");
+
+-- CreateIndex
+CREATE INDEX "ActivityGroupMember_activityGroupId_idx" ON "ActivityGroupMember"("activityGroupId");
+
+-- CreateIndex
+CREATE INDEX "ActivityDay_activityGroupId_idx" ON "ActivityDay"("activityGroupId");
+
+-- AddForeignKey
+ALTER TABLE "ActivityGroup" ADD CONSTRAINT "ActivityGroup_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityGroupMember" ADD CONSTRAINT "ActivityGroupMember_activityGroupId_fkey" FOREIGN KEY ("activityGroupId") REFERENCES "ActivityGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityGroupMember" ADD CONSTRAINT "ActivityGroupMember_activityParticipantId_fkey" FOREIGN KEY ("activityParticipantId") REFERENCES "ActivityParticipant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityDay" ADD CONSTRAINT "ActivityDay_activityGroupId_fkey" FOREIGN KEY ("activityGroupId") REFERENCES "ActivityGroup"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -123,6 +123,7 @@ model Activity {
   capacity     Int?
   participants ActivityParticipant[]
   professors   ActivityProfessor[]
+  groups       ActivityGroup[]
   days         ActivityDay[]
   createdAt    DateTime              @default(now())
 }
@@ -138,6 +139,7 @@ model ActivityParticipant {
   activity       Activity                @relation(fields: [activityId], references: [id])
   user           User                    @relation(fields: [userId], references: [id])
   child          Child?                  @relation(fields: [childId], references: [id])
+  groupMembership ActivityGroupMember?
   attendances    ActivityDayAttendance[]
 }
 
@@ -153,9 +155,35 @@ model ActivityProfessor {
   @@index([userId])
 }
 
+model ActivityGroup {
+  id          String               @id @default(cuid())
+  activityId  String
+  name        String
+  description String?
+  createdAt   DateTime             @default(now())
+  updatedAt   DateTime             @updatedAt
+  activity    Activity             @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  members     ActivityGroupMember[]
+  days        ActivityDay[]
+
+  @@index([activityId])
+}
+
+model ActivityGroupMember {
+  id                    String              @id @default(cuid())
+  activityGroupId       String
+  activityParticipantId  String              @unique
+  createdAt             DateTime            @default(now())
+  activityGroup         ActivityGroup       @relation(fields: [activityGroupId], references: [id], onDelete: Cascade)
+  activityParticipant   ActivityParticipant @relation(fields: [activityParticipantId], references: [id], onDelete: Cascade)
+
+  @@index([activityGroupId])
+}
+
 model ActivityDay {
   id          String                  @id @default(cuid())
   activityId  String
+  activityGroupId String?
   createdById String
   date        DateTime
   schedule    String
@@ -166,11 +194,13 @@ model ActivityDay {
   createdAt   DateTime                @default(now())
   updatedAt   DateTime                @updatedAt
   activity    Activity                @relation(fields: [activityId], references: [id], onDelete: Cascade)
+  activityGroup ActivityGroup?        @relation(fields: [activityGroupId], references: [id], onDelete: SetNull)
   createdBy   User                    @relation("ActivityDayCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
   attendances ActivityDayAttendance[]
   professors  ActivityDayProfessor[]
 
   @@index([activityId, date])
+  @@index([activityGroupId])
 }
 
 model ActivityDayProfessor {

--- a/src/app/activities/[id]/activity-day-form.tsx
+++ b/src/app/activities/[id]/activity-day-form.tsx
@@ -25,12 +25,19 @@ type ActivityDayValues = {
   geoLocation: string;
   coordinates: Coordinates | null;
   professorIds: string[];
+  activityGroupId: string | null;
+};
+
+type GroupOption = {
+  id: string;
+  name: string;
 };
 
 interface ActivityDayFormProps {
   activityId: string;
   mode: 'create' | 'edit';
   professors: ProfessorOption[];
+  groups: GroupOption[];
   defaultProfessorIds: string[];
   initialValues?: ActivityDayValues;
   dayId?: string;
@@ -62,6 +69,7 @@ function buildInitialState(
       geoLocation: '',
       coordinates: null,
       professorIds: defaultProfessorIds,
+      activityGroupId: null,
     }
   );
 }
@@ -70,6 +78,7 @@ export default function ActivityDayForm({
   activityId,
   mode,
   professors,
+  groups,
   defaultProfessorIds,
   initialValues,
   dayId,
@@ -95,6 +104,9 @@ export default function ActivityDayForm({
   const [professorIds, setProfessorIds] = useState<string[]>(
     buildInitialState(initialValues, defaultProfessorIds).professorIds
   );
+  const [activityGroupId, setActivityGroupId] = useState<string | null>(
+    buildInitialState(initialValues, defaultProfessorIds).activityGroupId
+  );
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
 
@@ -107,6 +119,7 @@ export default function ActivityDayForm({
     setGeoLocation('');
     setCoordinates(null);
     setProfessorIds(defaultProfessorIds);
+    setActivityGroupId(null);
   };
 
   async function submitForm(e: React.FormEvent) {
@@ -136,6 +149,7 @@ export default function ActivityDayForm({
             latitude: coordinates.latitude,
             longitude: coordinates.longitude,
             professorIds,
+            activityGroupId,
           }),
         }
       );
@@ -202,6 +216,23 @@ export default function ActivityDayForm({
         className={`${inputClass} min-h-[90px] resize-y`}
         placeholder="Descripción de la sesión"
       />
+      <div className="space-y-1">
+        <p className="text-sm font-medium">Grupo de la sesión</p>
+        <select
+          value={activityGroupId ?? ''}
+          onChange={(e) =>
+            setActivityGroupId(e.target.value ? e.target.value : null)
+          }
+          className={inputClass}
+        >
+          <option value="">Sin restricción de grupo</option>
+          {groups.map((group) => (
+            <option key={group.id} value={group.id}>
+              {group.name}
+            </option>
+          ))}
+        </select>
+      </div>
       <ProfessorPicker
         professors={professors}
         value={professorIds}
@@ -212,7 +243,8 @@ export default function ActivityDayForm({
           <p className="text-sm text-destructive">{error}</p>
         ) : (
           <span className="text-xs text-muted-foreground">
-            Guardá fecha, horario, ubicación, mapa y profesores asignados.
+            Guardá fecha, horario, ubicación, mapa, grupo y profesores
+            asignados.
           </span>
         )}
         <div className="flex gap-2">

--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -16,6 +16,13 @@ type ProfessorOption = {
 type Registration = {
   id: string;
   label: string;
+  groupId: string | null;
+  groupName: string | null;
+};
+
+type GroupOption = {
+  id: string;
+  name: string;
 };
 
 type ActivityDay = {
@@ -26,6 +33,11 @@ type ActivityDay = {
   geoLocation: string;
   latitude: number | null;
   longitude: number | null;
+  activityGroupId: string | null;
+  activityGroup: {
+    id: string;
+    name: string;
+  } | null;
   assignedProfessors: ProfessorOption[];
   canEdit: boolean;
   attendances: Array<{
@@ -39,6 +51,7 @@ interface ActivityDaysPanelProps {
   activityId: string;
   canManageDays: boolean;
   professors: ProfessorOption[];
+  groups: GroupOption[];
   defaultProfessorIds: string[];
   registrations: Registration[];
   days: ActivityDay[];
@@ -54,6 +67,7 @@ export default function ActivityDaysPanel({
   activityId,
   canManageDays,
   professors,
+  groups,
   defaultProfessorIds,
   registrations,
   days,
@@ -120,6 +134,7 @@ export default function ActivityDaysPanel({
             activityId={activityId}
             mode="create"
             professors={professors}
+            groups={groups}
             defaultProfessorIds={defaultProfessorIds}
           />
         </div>
@@ -173,6 +188,11 @@ export default function ActivityDaysPanel({
                         Profesores: {professorLabels}
                       </p>
                     )}
+                    {day.activityGroup && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Restringida al grupo {day.activityGroup.name}
+                      </p>
+                    )}
                     {mapHref && (
                       <a
                         href={mapHref}
@@ -216,6 +236,7 @@ export default function ActivityDaysPanel({
                       mode="edit"
                       dayId={day.id}
                       professors={professors}
+                      groups={groups}
                       defaultProfessorIds={defaultProfessorIds}
                       initialValues={{
                         date: day.date.slice(0, 10),
@@ -232,6 +253,7 @@ export default function ActivityDaysPanel({
                         professorIds: day.assignedProfessors.map(
                           (professor) => professor.id
                         ),
+                        activityGroupId: day.activityGroupId,
                       }}
                       onSaved={() => setEditingDayId(null)}
                       onCancel={() => setEditingDayId(null)}
@@ -254,6 +276,9 @@ export default function ActivityDaysPanel({
                           currentAttendance?.status ?? 'PENDING';
                         const key = `${day.id}:${registration.id}`;
                         const isSaving = savingKey === key;
+                        const isAllowedForDay =
+                          !day.activityGroupId ||
+                          registration.groupId === day.activityGroupId;
 
                         return (
                           <div
@@ -268,6 +293,9 @@ export default function ActivityDaysPanel({
                                 <p className="text-xs text-muted-foreground">
                                   Estado actual: {statusLabels[currentStatus]}
                                 </p>
+                                <p className="text-xs text-muted-foreground">
+                                  Grupo: {registration.groupName ?? 'Sin grupo'}
+                                </p>
                               </div>
                               {isSaving && (
                                 <span className="text-xs text-muted-foreground">
@@ -275,35 +303,42 @@ export default function ActivityDaysPanel({
                                 </span>
                               )}
                             </div>
-                            <div className="mt-3 flex flex-wrap gap-2">
-                              {(
-                                [
-                                  'GOING',
-                                  'NOT_GOING',
-                                  'PENDING',
-                                ] as AttendanceStatus[]
-                              ).map((status) => (
-                                <button
-                                  key={status}
-                                  type="button"
-                                  disabled={isSaving}
-                                  onClick={() =>
-                                    updateAttendance(
-                                      day.id,
-                                      registration.id,
-                                      status
-                                    )
-                                  }
-                                  className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                                    currentStatus === status
-                                      ? 'bg-primary text-primary-foreground'
-                                      : 'border border-border bg-background text-foreground hover:bg-muted'
-                                  }`}
-                                >
-                                  {statusLabels[status]}
-                                </button>
-                              ))}
-                            </div>
+                            {isAllowedForDay ? (
+                              <div className="mt-3 flex flex-wrap gap-2">
+                                {(
+                                  [
+                                    'GOING',
+                                    'NOT_GOING',
+                                    'PENDING',
+                                  ] as AttendanceStatus[]
+                                ).map((status) => (
+                                  <button
+                                    key={status}
+                                    type="button"
+                                    disabled={isSaving}
+                                    onClick={() =>
+                                      updateAttendance(
+                                        day.id,
+                                        registration.id,
+                                        status
+                                      )
+                                    }
+                                    className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                                      currentStatus === status
+                                        ? 'bg-primary text-primary-foreground'
+                                        : 'border border-border bg-background text-foreground hover:bg-muted'
+                                    }`}
+                                  >
+                                    {statusLabels[status]}
+                                  </button>
+                                ))}
+                              </div>
+                            ) : (
+                              <p className="mt-3 text-xs text-muted-foreground">
+                                Este día está restringido al grupo{' '}
+                                {day.activityGroup?.name ?? 'seleccionado'}.
+                              </p>
+                            )}
                           </div>
                         );
                       })}

--- a/src/app/activities/[id]/activity-group-form.tsx
+++ b/src/app/activities/[id]/activity-group-form.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+interface ActivityGroupFormProps {
+  activityId: string;
+}
+
+const inputClass =
+  'w-full rounded-md border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary';
+
+export default function ActivityGroupForm({
+  activityId,
+}: ActivityGroupFormProps) {
+  const router = useRouter();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  async function submitForm(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    setSaving(true);
+
+    try {
+      const res = await fetch(`/api/activities/${activityId}/groups`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          description: description || undefined,
+        }),
+      });
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error || 'No se pudo crear el grupo');
+      }
+
+      setName('');
+      setDescription('');
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo crear el grupo');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <form
+      onSubmit={submitForm}
+      className="space-y-3 rounded-lg border bg-background p-4"
+    >
+      <div className="grid gap-3 sm:grid-cols-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          className={inputClass}
+          placeholder="Nombre del grupo"
+          required
+        />
+        <input
+          type="text"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={inputClass}
+          placeholder="Descripción opcional"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-3">
+        {error ? (
+          <p className="text-sm text-destructive">{error}</p>
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            Creá grupos para organizar los inscriptos y restringir sesiones.
+          </span>
+        )}
+        <Button type="submit" disabled={saving}>
+          {saving ? 'Creando...' : 'Crear grupo'}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/activities/[id]/activity-groups-panel.tsx
+++ b/src/app/activities/[id]/activity-groups-panel.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import ActivityGroupForm from './activity-group-form';
+
+type ActivityGroup = {
+  id: string;
+  name: string;
+  description: string | null;
+  memberCount: number;
+  dayCount: number;
+};
+
+type Registration = {
+  id: string;
+  label: string;
+  groupId: string | null;
+  groupName: string | null;
+};
+
+interface ActivityGroupsPanelProps {
+  activityId: string;
+  canManageGroups: boolean;
+  groups: ActivityGroup[];
+  registrations: Registration[];
+}
+
+export default function ActivityGroupsPanel({
+  activityId,
+  canManageGroups,
+  groups,
+  registrations,
+}: ActivityGroupsPanelProps) {
+  const router = useRouter();
+  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  async function updateMembership(
+    groupId: string,
+    participantId: string,
+    currentGroupId: string | null
+  ) {
+    const key = `${participantId}:${groupId}`;
+    setError('');
+    setSavingKey(key);
+
+    try {
+      const isLeaving = currentGroupId === groupId;
+      const res = await fetch(`/api/activity-groups/${groupId}/members`, {
+        method: isLeaving ? 'DELETE' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantId }),
+      });
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error || 'No se pudo actualizar el grupo');
+      }
+
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'No se pudo actualizar el grupo');
+    } finally {
+      setSavingKey(null);
+    }
+  }
+
+  return (
+    <section className="mt-8 rounded-xl border bg-card p-6 shadow-sm">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h2 className="font-heading text-2xl font-semibold">Grupos</h2>
+          <p className="text-sm text-muted-foreground font-body mt-1">
+            Los grupos organizan a los inscriptos y permiten restringir
+            sesiones a un grupo específico.
+          </p>
+        </div>
+        {canManageGroups && (
+          <div className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
+            Administración de grupos
+          </div>
+        )}
+      </div>
+
+      {canManageGroups && (
+        <div className="mt-5">
+          <ActivityGroupForm activityId={activityId} />
+        </div>
+      )}
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_320px]">
+        <div className="space-y-4">
+          <h3 className="text-sm font-semibold text-foreground">
+            Tus inscriptos
+          </h3>
+          {registrations.length === 0 ? (
+            <p className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
+              No tenés inscriptos propios para agrupar.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {registrations.map((registration) => {
+                const isGrouped = registration.groupId != null;
+                return (
+                  <article
+                    key={registration.id}
+                    className="rounded-lg border bg-background p-4"
+                  >
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <p className="font-medium">{registration.label}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Grupo actual:{' '}
+                          {registration.groupName ?? 'Sin grupo'}
+                        </p>
+                      </div>
+                      {registration.groupName && (
+                        <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">
+                          {registration.groupName}
+                        </span>
+                      )}
+                    </div>
+
+                    {groups.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {groups.map((group) => {
+                          const isCurrentGroup =
+                            registration.groupId === group.id;
+                          const isSaving = savingKey === `${registration.id}:${group.id}`;
+
+                          return (
+                            <button
+                              key={group.id}
+                              type="button"
+                              disabled={isSaving}
+                              onClick={() =>
+                                updateMembership(
+                                  group.id,
+                                  registration.id,
+                                  registration.groupId
+                                )
+                              }
+                              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                                isCurrentGroup
+                                  ? 'bg-primary text-primary-foreground'
+                                  : 'border border-border bg-background text-foreground hover:bg-muted'
+                              }`}
+                            >
+                              {isSaving
+                                ? 'Guardando...'
+                                : isCurrentGroup
+                                  ? 'Salir'
+                                  : isGrouped
+                                    ? 'Mover aquí'
+                                    : 'Unirse'}
+                            </button>
+                          );
+                        })}
+                      </div>
+                    ) : (
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        Creá grupos primero para poder asignar inscriptos.
+                      </p>
+                    )}
+                  </article>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          <h3 className="text-sm font-semibold text-foreground">Grupos creados</h3>
+          {groups.length === 0 ? (
+            <p className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
+              Todavía no hay grupos creados.
+            </p>
+          ) : (
+            <div className="space-y-3">
+              {groups.map((group) => (
+                <article
+                  key={group.id}
+                  className="rounded-lg border bg-background p-4"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="font-medium">{group.name}</p>
+                      {group.description && (
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {group.description}
+                        </p>
+                      )}
+                    </div>
+                    <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">
+                      {group.memberCount} inscriptos
+                    </span>
+                  </div>
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {group.dayCount} sesión{group.dayCount === 1 ? '' : 'es'} asignada{group.dayCount === 1 ? '' : 's'}
+                  </p>
+                </article>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {error && <p className="mt-4 text-sm text-destructive">{error}</p>}
+    </section>
+  );
+}

--- a/src/app/activities/[id]/activity-groups-panel.tsx
+++ b/src/app/activities/[id]/activity-groups-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import ActivityGroupForm from './activity-group-form';
 
@@ -12,7 +12,7 @@ type ActivityGroup = {
   dayCount: number;
 };
 
-type Registration = {
+type Participant = {
   id: string;
   label: string;
   groupId: string | null;
@@ -23,46 +23,83 @@ interface ActivityGroupsPanelProps {
   activityId: string;
   canManageGroups: boolean;
   groups: ActivityGroup[];
-  registrations: Registration[];
+  participants: Participant[];
 }
 
 export default function ActivityGroupsPanel({
   activityId,
   canManageGroups,
   groups,
-  registrations,
+  participants,
 }: ActivityGroupsPanelProps) {
   const router = useRouter();
-  const [savingKey, setSavingKey] = useState<string | null>(null);
+  const [savingParticipantId, setSavingParticipantId] = useState<string | null>(
+    null
+  );
   const [error, setError] = useState('');
+  const [selectedGroups, setSelectedGroups] = useState<Record<string, string>>(
+    {}
+  );
 
-  async function updateMembership(
-    groupId: string,
-    participantId: string,
-    currentGroupId: string | null
-  ) {
-    const key = `${participantId}:${groupId}`;
+  useEffect(() => {
+    setSelectedGroups(
+      Object.fromEntries(
+        participants.map((participant) => [
+          participant.id,
+          participant.groupId ?? '',
+        ])
+      )
+    );
+  }, [participants]);
+
+  async function saveParticipantGroup(participantId: string) {
+    const participant = participants.find((item) => item.id === participantId);
+    if (!participant) {
+      return;
+    }
+
+    const nextGroupId = selectedGroups[participantId] ?? '';
+    const currentGroupId = participant.groupId ?? '';
+    if (nextGroupId === currentGroupId) {
+      return;
+    }
+
     setError('');
-    setSavingKey(key);
+    setSavingParticipantId(participantId);
 
     try {
-      const isLeaving = currentGroupId === groupId;
-      const res = await fetch(`/api/activity-groups/${groupId}/members`, {
-        method: isLeaving ? 'DELETE' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ participantId }),
-      });
-
-      if (!res.ok) {
-        const payload = await res.json().catch(() => null);
-        throw new Error(payload?.error || 'No se pudo actualizar el grupo');
+      if (!nextGroupId) {
+        if (!currentGroupId) {
+          return;
+        }
+        const res = await fetch(`/api/activity-groups/${currentGroupId}/members`, {
+          method: 'DELETE',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId }),
+        });
+        if (!res.ok) {
+          const payload = await res.json().catch(() => null);
+          throw new Error(payload?.error || 'No se pudo quitar del grupo');
+        }
+      } else {
+        const res = await fetch(`/api/activity-groups/${nextGroupId}/members`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ participantId }),
+        });
+        if (!res.ok) {
+          const payload = await res.json().catch(() => null);
+          throw new Error(payload?.error || 'No se pudo asignar el grupo');
+        }
       }
 
       router.refresh();
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'No se pudo actualizar el grupo');
+      setError(
+        err instanceof Error ? err.message : 'No se pudo actualizar el grupo'
+      );
     } finally {
-      setSavingKey(null);
+      setSavingParticipantId(null);
     }
   }
 
@@ -72,8 +109,8 @@ export default function ActivityGroupsPanel({
         <div>
           <h2 className="font-heading text-2xl font-semibold">Grupos</h2>
           <p className="text-sm text-muted-foreground font-body mt-1">
-            Los grupos organizan a los inscriptos y permiten restringir
-            sesiones a un grupo específico.
+            Los profesores y administradores crean grupos y asignan inscriptos a
+            cada uno.
           </p>
         </div>
         {canManageGroups && (
@@ -92,77 +129,67 @@ export default function ActivityGroupsPanel({
       <div className="mt-6 grid gap-4 lg:grid-cols-[1fr_320px]">
         <div className="space-y-4">
           <h3 className="text-sm font-semibold text-foreground">
-            Tus inscriptos
+            Inscriptos de la actividad
           </h3>
-          {registrations.length === 0 ? (
+          {participants.length === 0 ? (
             <p className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
-              No tenés inscriptos propios para agrupar.
+              Todavía no hay inscriptos para asignar.
             </p>
           ) : (
             <div className="space-y-3">
-              {registrations.map((registration) => {
-                const isGrouped = registration.groupId != null;
+              {participants.map((participant) => {
+                const selectedGroupId = selectedGroups[participant.id] ?? '';
+                const currentGroupId = participant.groupId ?? '';
+                const isSaving = savingParticipantId === participant.id;
+
                 return (
                   <article
-                    key={registration.id}
+                    key={participant.id}
                     className="rounded-lg border bg-background p-4"
                   >
                     <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
                       <div>
-                        <p className="font-medium">{registration.label}</p>
+                        <p className="font-medium">{participant.label}</p>
                         <p className="text-xs text-muted-foreground">
-                          Grupo actual:{' '}
-                          {registration.groupName ?? 'Sin grupo'}
+                          Grupo actual: {participant.groupName ?? 'Sin grupo'}
                         </p>
                       </div>
-                      {registration.groupName && (
+                      {participant.groupName && (
                         <span className="rounded-full border px-2 py-1 text-xs text-muted-foreground">
-                          {registration.groupName}
+                          {participant.groupName}
                         </span>
                       )}
                     </div>
 
-                    {groups.length > 0 ? (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {groups.map((group) => {
-                          const isCurrentGroup =
-                            registration.groupId === group.id;
-                          const isSaving = savingKey === `${registration.id}:${group.id}`;
-
-                          return (
-                            <button
-                              key={group.id}
-                              type="button"
-                              disabled={isSaving}
-                              onClick={() =>
-                                updateMembership(
-                                  group.id,
-                                  registration.id,
-                                  registration.groupId
-                                )
-                              }
-                              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                                isCurrentGroup
-                                  ? 'bg-primary text-primary-foreground'
-                                  : 'border border-border bg-background text-foreground hover:bg-muted'
-                              }`}
-                            >
-                              {isSaving
-                                ? 'Guardando...'
-                                : isCurrentGroup
-                                  ? 'Salir'
-                                  : isGrouped
-                                    ? 'Mover aquí'
-                                    : 'Unirse'}
-                            </button>
-                          );
-                        })}
-                      </div>
-                    ) : (
-                      <p className="mt-3 text-xs text-muted-foreground">
-                        Creá grupos primero para poder asignar inscriptos.
-                      </p>
-                    )}
+                    <div className="mt-3 grid gap-2 sm:grid-cols-[1fr_auto] sm:items-center">
+                      <select
+                        className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                        value={selectedGroupId}
+                        onChange={(e) =>
+                          setSelectedGroups((current) => ({
+                            ...current,
+                            [participant.id]: e.target.value,
+                          }))
+                        }
+                      >
+                        <option value="">Sin grupo</option>
+                        {groups.map((group) => (
+                          <option key={group.id} value={group.id}>
+                            {group.name}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        type="button"
+                        disabled={
+                          isSaving || selectedGroupId === currentGroupId
+                        }
+                        onClick={() => saveParticipantGroup(participant.id)}
+                        className="rounded-md border border-border bg-primary px-3 py-2 text-sm font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {isSaving ? 'Guardando...' : 'Guardar grupo'}
+                      </button>
+                    </div>
                   </article>
                 );
               })}
@@ -171,7 +198,9 @@ export default function ActivityGroupsPanel({
         </div>
 
         <div className="space-y-4">
-          <h3 className="text-sm font-semibold text-foreground">Grupos creados</h3>
+          <h3 className="text-sm font-semibold text-foreground">
+            Grupos creados
+          </h3>
           {groups.length === 0 ? (
             <p className="rounded-lg border bg-background p-4 text-sm text-muted-foreground">
               Todavía no hay grupos creados.
@@ -197,7 +226,8 @@ export default function ActivityGroupsPanel({
                     </span>
                   </div>
                   <p className="mt-3 text-xs text-muted-foreground">
-                    {group.dayCount} sesión{group.dayCount === 1 ? '' : 'es'} asignada{group.dayCount === 1 ? '' : 's'}
+                    {group.dayCount} sesión{group.dayCount === 1 ? '' : 'es'}{' '}
+                    asignada{group.dayCount === 1 ? '' : 's'}
                   </p>
                 </article>
               ))}

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -215,6 +215,13 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     groupName: string | null;
   }> = [];
 
+  let groupParticipants: Array<{
+    id: string;
+    label: string;
+    groupId: string | null;
+    groupName: string | null;
+  }> = [];
+
   if (session) {
     const activityParticipants = participants.filter((participant: any) => {
       const isOwner = participant.userId === session.user.id;
@@ -233,6 +240,49 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           ? activityGroupById.get(participant.groupMembership.activityGroupId) ??
             null
           : null,
+    }));
+  }
+
+  if (canManageGroups) {
+    const participantsForGroups = await prisma.activityParticipant.findMany({
+      where: { activityId: activity.id },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+            lastName: true,
+          },
+        },
+        child: {
+          select: {
+            id: true,
+            name: true,
+            lastName: true,
+          },
+        },
+        groupMembership: {
+          select: {
+            activityGroupId: true,
+            activityGroup: {
+              select: {
+                id: true,
+                name: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: { id: 'asc' },
+    });
+
+    groupParticipants = participantsForGroups.map((participant: any) => ({
+      id: participant.id,
+      label: participant.child
+        ? `${participant.child.name}${participant.child.lastName ? ` ${participant.child.lastName}` : ''}`
+        : `${participant.user.name ?? 'Sin nombre'}${participant.user.lastName ? ` ${participant.user.lastName}` : ''}`,
+      groupId: participant.groupMembership?.activityGroupId ?? null,
+      groupName: participant.groupMembership?.activityGroup?.name ?? null,
     }));
   }
 
@@ -416,7 +466,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
-        {session && (
+        {canManageGroups && (
           <ActivityGroupsPanel
             activityId={activity.id}
             canManageGroups={canManageGroups}
@@ -427,7 +477,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
               memberCount: group._count.members,
               dayCount: group._count.days,
             }))}
-            registrations={registrations}
+            participants={groupParticipants}
           />
         )}
 

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -3,6 +3,7 @@ import type { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import RegisterButton from './register-button';
 import PaymentHandler from './payment-handler';
+import ActivityGroupsPanel from './activity-groups-panel';
 import ActivityDaysPanel from './activity-days-panel';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -60,7 +61,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     );
   }
 
-  const [participants, activityProfessors, professorOptions, days] =
+  const [participants, activityProfessors, professorOptions, activityGroups, days] =
     await Promise.all([
     prisma.activityParticipant
       .findMany({
@@ -69,9 +70,19 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           ? {
               user: true,
               child: true,
+              groupMembership: {
+                select: {
+                  activityGroupId: true,
+                },
+              },
             }
           : {
               child: true,
+              groupMembership: {
+                select: {
+                  activityGroupId: true,
+                },
+              },
             },
       })
       .catch((error) => {
@@ -116,6 +127,23 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         );
         return [];
       }),
+    prisma.activityGroup
+      .findMany({
+        where: { activityId: activity.id },
+        orderBy: { createdAt: 'asc' },
+        include: {
+          _count: {
+            select: {
+              members: true,
+              days: true,
+            },
+          },
+        },
+      })
+      .catch((error) => {
+        console.error('[activity-page] activity groups query failed', error);
+        return [];
+      }),
     prisma.activityDay
       .findMany({
         where: { activityId: activity.id },
@@ -131,6 +159,12 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                   email: true,
                 },
               },
+            },
+          },
+          activityGroup: {
+            select: {
+              id: true,
+              name: true,
             },
           },
           attendances: {
@@ -158,12 +192,18 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   const activityProfessorIds = activityProfessors.map(
     (assignment: { userId: string }) => assignment.userId
   );
+  const activityGroupById = new Map(
+    activityGroups.map((group: any) => [group.id, group.name])
+  );
   const capacity = activity.capacity;
   const hasCapacity = capacity != null;
   const remainingSpots = hasCapacity
     ? Math.max(capacity - enrolledCount, 0)
     : null;
   const isFull = hasCapacity && remainingSpots === 0;
+  const canManageGroups =
+    isAdmin ||
+    activityProfessorIds.includes(session?.user.id ?? '');
   const canManageDays =
     isAdmin ||
     activityProfessorIds.includes(session?.user.id ?? '');
@@ -171,6 +211,8 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
   let registrations: Array<{
     id: string;
     label: string;
+    groupId: string | null;
+    groupName: string | null;
   }> = [];
 
   if (session) {
@@ -185,6 +227,12 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
       label: participant.child
         ? `${participant.child.name}${participant.child.lastName ? ` ${participant.child.lastName}` : ''}`
         : (session.user.name ?? 'Yo'),
+      groupId: participant.groupMembership?.activityGroupId ?? null,
+      groupName:
+        participant.groupMembership?.activityGroupId
+          ? activityGroupById.get(participant.groupMembership.activityGroupId) ??
+            null
+          : null,
     }));
   }
 
@@ -192,6 +240,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     const professor = assignment.user;
     return `${professor.name ?? 'Sin nombre'}${professor.lastName ? ` ${professor.lastName}` : ''}`;
   });
+  const activityGroupOptions = activityGroups.map((group: any) => ({
+    id: group.id,
+    name: group.name,
+  }));
   const adminParticipants = participants as ActivityParticipantDetail[];
 
   return (
@@ -364,10 +416,26 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
+        {session && (
+          <ActivityGroupsPanel
+            activityId={activity.id}
+            canManageGroups={canManageGroups}
+            groups={activityGroups.map((group: any) => ({
+              id: group.id,
+              name: group.name,
+              description: group.description,
+              memberCount: group._count.members,
+              dayCount: group._count.days,
+            }))}
+            registrations={registrations}
+          />
+        )}
+
         <ActivityDaysPanel
           activityId={activity.id}
           canManageDays={canManageDays}
           professors={professorOptions}
+          groups={activityGroupOptions}
           defaultProfessorIds={activityProfessorIds}
           registrations={registrations}
           days={days.map((day: any) => ({
@@ -378,6 +446,8 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
             geoLocation: day.geoLocation,
             latitude: day.latitude,
             longitude: day.longitude,
+            activityGroupId: day.activityGroupId,
+            activityGroup: day.activityGroup,
             canEdit:
               isAdmin ||
               activityProfessorIds.includes(session?.user.id ?? '') ||

--- a/src/app/api/activities/[id]/days/route.ts
+++ b/src/app/api/activities/[id]/days/route.ts
@@ -44,6 +44,22 @@ export async function POST(
 
   const data = activityDayCreateSchema.parse(await req.json());
   const professorIds = Array.from(new Set(data.professorIds));
+  const activityGroupId = data.activityGroupId ?? null;
+  if (activityGroupId) {
+    const group = await prisma.activityGroup.findFirst({
+      where: {
+        id: activityGroupId,
+        activityId: activity.id,
+      },
+      select: { id: true },
+    });
+    if (!group) {
+      return NextResponse.json(
+        { error: 'El grupo no pertenece a esta actividad' },
+        { status: 400 }
+      );
+    }
+  }
   const validProfessors = await prisma.user.findMany({
     where: {
       id: { in: professorIds },
@@ -69,6 +85,7 @@ export async function POST(
       geoLocation: data.geoLocation,
       latitude: data.latitude,
       longitude: data.longitude,
+      activityGroupId,
       professors: {
         create: professorIds.map((userId) => ({
           user: { connect: { id: userId } },

--- a/src/app/api/activities/[id]/groups/route.ts
+++ b/src/app/api/activities/[id]/groups/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { activityGroupCreateSchema } from '@/lib/validations/activity';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      professors: {
+        select: {
+          userId: true,
+        },
+      },
+    },
+  });
+
+  if (!activity) {
+    return NextResponse.json(
+      { error: 'Actividad no encontrada' },
+      { status: 404 }
+    );
+  }
+
+  const isAdmin =
+    session.user.role === 'ADMIN' || session.user.role === 'SUPER_ADMIN';
+  const isAssignedProfessor = activity.professors.some(
+    (assignment) => assignment.userId === session.user.id
+  );
+
+  if (!isAdmin && !isAssignedProfessor) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const data = activityGroupCreateSchema.parse(await req.json());
+
+  const group = await prisma.activityGroup.create({
+    data: {
+      activityId: activity.id,
+      name: data.name,
+      description: data.description || null,
+    },
+  });
+
+  return NextResponse.json(group);
+}

--- a/src/app/api/activity-days/[dayId]/attendance/route.ts
+++ b/src/app/api/activity-days/[dayId]/attendance/route.ts
@@ -19,6 +19,7 @@ export async function PATCH(
     select: {
       id: true,
       activityId: true,
+      activityGroupId: true,
     },
   });
 
@@ -37,6 +38,11 @@ export async function PATCH(
           userId: true,
         },
       },
+      groupMembership: {
+        select: {
+          activityGroupId: true,
+        },
+      },
     },
   });
 
@@ -51,6 +57,16 @@ export async function PATCH(
     return NextResponse.json(
       { error: 'El inscripto no pertenece a esta actividad' },
       { status: 400 }
+    );
+  }
+
+  if (
+    day.activityGroupId &&
+    participant.groupMembership?.activityGroupId !== day.activityGroupId
+  ) {
+    return NextResponse.json(
+      { error: 'El día está restringido a otro grupo' },
+      { status: 403 }
     );
   }
 

--- a/src/app/api/activity-days/[dayId]/route.ts
+++ b/src/app/api/activity-days/[dayId]/route.ts
@@ -54,6 +54,22 @@ export async function PUT(
 
   const data = activityDayUpdateSchema.parse(await req.json());
   const professorIds = Array.from(new Set(data.professorIds));
+  const activityGroupId = data.activityGroupId ?? null;
+  if (activityGroupId) {
+    const group = await prisma.activityGroup.findFirst({
+      where: {
+        id: activityGroupId,
+        activityId: day.activityId,
+      },
+      select: { id: true },
+    });
+    if (!group) {
+      return NextResponse.json(
+        { error: 'El grupo no pertenece a esta actividad' },
+        { status: 400 }
+      );
+    }
+  }
   const validProfessors = await prisma.user.findMany({
     where: {
       id: { in: professorIds },
@@ -78,6 +94,7 @@ export async function PUT(
       geoLocation: data.geoLocation,
       latitude: data.latitude,
       longitude: data.longitude,
+      activityGroupId,
       professors: {
         deleteMany: {},
         create: professorIds.map((userId) => ({

--- a/src/app/api/activity-groups/[groupId]/members/route.ts
+++ b/src/app/api/activity-groups/[groupId]/members/route.ts
@@ -1,0 +1,163 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { z } from 'zod';
+
+const membershipSchema = z.object({
+  participantId: z.string().min(1),
+});
+
+async function getAuthorizedParticipant(participantId: string) {
+  return prisma.activityParticipant.findUnique({
+    where: { id: participantId },
+    select: {
+      id: true,
+      userId: true,
+      activityId: true,
+      child: {
+        select: {
+          userId: true,
+        },
+      },
+    },
+  });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { groupId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const group = await prisma.activityGroup.findUnique({
+    where: { id: params.groupId },
+    select: {
+      id: true,
+      activityId: true,
+    },
+  });
+
+  if (!group) {
+    return NextResponse.json({ error: 'Grupo no encontrado' }, { status: 404 });
+  }
+
+  const { participantId } = membershipSchema.parse(await req.json());
+  const participant = await getAuthorizedParticipant(participantId);
+
+  if (!participant) {
+    return NextResponse.json(
+      { error: 'Inscripto no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  const isOwner =
+    participant.userId === session.user.id ||
+    participant.child?.userId === session.user.id;
+
+  if (!isOwner) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (participant.activityId !== group.activityId) {
+    return NextResponse.json(
+      { error: 'El inscripto no pertenece a esta actividad' },
+      { status: 400 }
+    );
+  }
+
+  const membership = await prisma.activityGroupMember.upsert({
+    where: {
+      activityParticipantId: participant.id,
+    },
+    create: {
+      activityGroupId: group.id,
+      activityParticipantId: participant.id,
+    },
+    update: {
+      activityGroupId: group.id,
+    },
+  });
+
+  return NextResponse.json(membership);
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { groupId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const group = await prisma.activityGroup.findUnique({
+    where: { id: params.groupId },
+    select: {
+      id: true,
+      activityId: true,
+    },
+  });
+
+  if (!group) {
+    return NextResponse.json({ error: 'Grupo no encontrado' }, { status: 404 });
+  }
+
+  const { participantId } = membershipSchema.parse(await req.json());
+  const participant = await getAuthorizedParticipant(participantId);
+
+  if (!participant) {
+    return NextResponse.json(
+      { error: 'Inscripto no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  const isOwner =
+    participant.userId === session.user.id ||
+    participant.child?.userId === session.user.id;
+
+  if (!isOwner) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  if (participant.activityId !== group.activityId) {
+    return NextResponse.json(
+      { error: 'El inscripto no pertenece a esta actividad' },
+      { status: 400 }
+    );
+  }
+
+  const currentMembership = await prisma.activityGroupMember.findUnique({
+    where: {
+      activityParticipantId: participant.id,
+    },
+    select: {
+      id: true,
+      activityGroupId: true,
+    },
+  });
+
+  if (!currentMembership) {
+    return NextResponse.json({ ok: true });
+  }
+
+  if (currentMembership.activityGroupId !== group.id) {
+    return NextResponse.json(
+      { error: 'El inscripto no pertenece a este grupo' },
+      { status: 400 }
+    );
+  }
+
+  await prisma.activityGroupMember.delete({
+    where: {
+      activityParticipantId: participant.id,
+    },
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/activity-groups/[groupId]/members/route.ts
+++ b/src/app/api/activity-groups/[groupId]/members/route.ts
@@ -24,6 +24,34 @@ async function getAuthorizedParticipant(participantId: string) {
   });
 }
 
+async function canManageGroupMembership(
+  sessionUserId: string,
+  sessionRole: string,
+  activityId: string
+) {
+  const activity = await prisma.activity.findUnique({
+    where: { id: activityId },
+    select: {
+      professors: {
+        select: {
+          userId: true,
+        },
+      },
+    },
+  });
+
+  if (!activity) {
+    return false;
+  }
+
+  const isAdmin =
+    sessionRole === 'ADMIN' || sessionRole === 'SUPER_ADMIN';
+  return (
+    isAdmin ||
+    activity.professors.some((assignment) => assignment.userId === sessionUserId)
+  );
+}
+
 export async function POST(
   req: Request,
   { params }: { params: { groupId: string } }
@@ -45,6 +73,15 @@ export async function POST(
     return NextResponse.json({ error: 'Grupo no encontrado' }, { status: 404 });
   }
 
+  const canManage = await canManageGroupMembership(
+    session.user.id,
+    session.user.role,
+    group.activityId
+  );
+  if (!canManage) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { participantId } = membershipSchema.parse(await req.json());
   const participant = await getAuthorizedParticipant(participantId);
 
@@ -53,14 +90,6 @@ export async function POST(
       { error: 'Inscripto no encontrado' },
       { status: 404 }
     );
-  }
-
-  const isOwner =
-    participant.userId === session.user.id ||
-    participant.child?.userId === session.user.id;
-
-  if (!isOwner) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   if (participant.activityId !== group.activityId) {
@@ -107,6 +136,15 @@ export async function DELETE(
     return NextResponse.json({ error: 'Grupo no encontrado' }, { status: 404 });
   }
 
+  const canManage = await canManageGroupMembership(
+    session.user.id,
+    session.user.role,
+    group.activityId
+  );
+  if (!canManage) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const { participantId } = membershipSchema.parse(await req.json());
   const participant = await getAuthorizedParticipant(participantId);
 
@@ -115,14 +153,6 @@ export async function DELETE(
       { error: 'Inscripto no encontrado' },
       { status: 404 }
     );
-  }
-
-  const isOwner =
-    participant.userId === session.user.id ||
-    participant.child?.userId === session.user.id;
-
-  if (!isOwner) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   if (participant.activityId !== group.activityId) {

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -11,6 +11,11 @@ export const activityCreateSchema = z.object({
   professorIds: z.array(z.string()).optional(),
 });
 
+export const activityGroupCreateSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+});
+
 export const activityDayCreateSchema = z.object({
   date: z.string().transform((d) => new Date(d)),
   schedule: z.string().min(1),
@@ -19,6 +24,7 @@ export const activityDayCreateSchema = z.object({
   latitude: z.number(),
   longitude: z.number(),
   professorIds: z.array(z.string().min(1)).min(1),
+  activityGroupId: z.string().min(1).nullable().optional(),
 });
 
 export const activityDayUpdateSchema = activityDayCreateSchema;


### PR DESCRIPTION
## What changed
- Removed self-service group changes for registered users.
- Restricted activity group creation and membership assignment to admins and professors assigned to the activity.
- Kept the group selector in the session form for staff only.
- Updated the activity page so only staff sees the group management panel.

## Why
- Group assignment must be controlled by professors, not by the registered users themselves.

## Validation
- `npm run build`
- `node_modules/.bin/prisma migrate deploy`

## Notes
- The database migration for activity groups is included in this branch.
