### PR TITLE
fix(admin): allow selecting COUNTER role when editing users

### DIFF
--- a/src/app/admin/users/[id]/form.tsx
+++ b/src/app/admin/users/[id]/form.tsx
@@ -260,6 +260,7 @@ export default function EditUserForm({ user }: { user: User }) {
           onChange={(e) => setRole(e.target.value)}
         >
           <option value="ADMIN">ADMIN</option>
+          <option value="COUNTER">COUNTER</option>
           <option value="MEMBER">MEMBER</option>
           <option value="PROFESSOR">PROFESSOR</option>
           <option value="SUPER_ADMIN">SUPER_ADMIN</option>


### PR DESCRIPTION
### Motivation
- The admin user edit form did not include the `COUNTER` role option, preventing super-admins from assigning accounting users when editing a user.

### Description
- Added `<option value="COUNTER">COUNTER</option>` to the role `<select>` in `src/app/admin/users/[id]/form.tsx`, keeping the option visible only when `canEditRole` is true and aligning with the existing backend role enum.

### Testing
- Attempted to run `pnpm lint`, but the run failed due to a Corepack/pnpm download error (HTTP tunneling/proxy 403), so no automated tests completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69effbc81b948333a00476a883287508)