### PR TITLE
Habilita chat completo para usuarios COUNTER

### DIFF
--- a/src/app/api/messages/[userId]/route.ts
+++ b/src/app/api/messages/[userId]/route.ts
@@ -92,9 +92,10 @@ export async function POST(
 
   const senderRole = session.user.role;
   const isSenderAdmin = senderRole === 'ADMIN' || senderRole === 'SUPER_ADMIN';
+  const isSenderCounter = senderRole === 'COUNTER';
   const isRecipientAdmin =
     recipient.role === 'ADMIN' || recipient.role === 'SUPER_ADMIN';
-  if (!isSenderAdmin && !isRecipientAdmin) {
+  if (!isSenderAdmin && !isSenderCounter && !isRecipientAdmin) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 

--- a/src/app/chat/chat-client.tsx
+++ b/src/app/chat/chat-client.tsx
@@ -172,9 +172,12 @@ export default function ChatClient() {
     if (!session) return [];
     const isAdmin =
       session.user.role === 'ADMIN' || session.user.role === 'SUPER_ADMIN';
+    const isCounter = session.user.role === 'COUNTER';
     const selectable = isAdmin
       ? users.filter((u) => u.id !== session.user.id)
-      : users.filter((u) => u.role === 'ADMIN' || u.role === 'SUPER_ADMIN');
+      : isCounter
+        ? users.filter((u) => u.id !== session.user.id)
+        : users.filter((u) => u.role === 'ADMIN' || u.role === 'SUPER_ADMIN');
 
     type Contact = {
       user: User;

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,16 +1,12 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
-import { isCounterRole } from '@/lib/accounting';
 import ChatClient from './chat-client';
 
 export default async function ChatPage() {
   const session = await getServerSession(authOptions);
   if (!session) {
     redirect('/login');
-  }
-  if (isCounterRole(session.user.role)) {
-    redirect('/accounting');
   }
   return <ChatClient />;
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -148,7 +148,7 @@ export default function Navbar() {
               {isMember ? t.myActivities : t.activities}
             </Link>
           )}
-          {session && !isCounter && (
+          {session && (
             <Link
               href="/chat"
               className={`${linkClass} inline-flex items-center gap-2`}
@@ -279,7 +279,7 @@ export default function Navbar() {
               {isMember ? t.myActivities : t.activities}
             </Link>
           )}
-          {session && !isCounter && (
+          {session && (
             <Link
               href="/chat"
               className={`${linkClass} inline-flex items-center gap-2`}


### PR DESCRIPTION
### Motivation
- Allow users with role `COUNTER` to access the chat page and converse with other users as requested by product requirements.
- Ensure frontend visibility and backend authorization are consistent so `COUNTER` users have the same chat capabilities as admins where appropriate.

### Description
- Removed the redirect from `/chat` in `src/app/chat/page.tsx` so `COUNTER` users can open the chat page.
- Adjusted contact filtering in `src/app/chat/chat-client.tsx` so `COUNTER` sees all users (except themselves) similar to admins.
- Updated authorization in `src/app/api/messages/[userId]/route.ts` to allow `COUNTER` to post messages to any user while preserving existing admin/super_admin rules.
- Exposed the Chat link for `COUNTER` in `src/components/navbar.tsx` for both desktop and mobile menus.

### Testing
- Ran `pnpm lint`, which failed due to a network/proxy error when `corepack` attempted to download `pnpm` (request returned proxy 403), so automated linting could not complete.
- No other automated tests were executed; changes were validated by reviewing diffs and verifying that UI and API permission logic were updated consistently.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f000c18230833380c23874b014ac78)