### PR TITLE
[codex] db audit log

### DIFF
--- a/prisma/migrations/20260427050000_add_db_audit_logs/migration.sql
+++ b/prisma/migrations/20260427050000_add_db_audit_logs/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "DbAuditLog" (
+    "id" TEXT NOT NULL,
+    "model" TEXT NOT NULL,
+    "action" TEXT NOT NULL,
+    "recordId" TEXT,
+    "before" JSONB,
+    "after" JSONB,
+    "args" JSONB,
+    "userId" TEXT,
+    "requestId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DbAuditLog_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "DbAuditLog_model_idx" ON "DbAuditLog"("model");
+
+-- CreateIndex
+CREATE INDEX "DbAuditLog_action_idx" ON "DbAuditLog"("action");
+
+-- CreateIndex
+CREATE INDEX "DbAuditLog_createdAt_idx" ON "DbAuditLog"("createdAt");
+
+-- CreateIndex
+CREATE INDEX "DbAuditLog_userId_idx" ON "DbAuditLog"("userId");
+
+-- CreateIndex
+CREATE INDEX "DbAuditLog_requestId_idx" ON "DbAuditLog"("requestId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -294,6 +294,25 @@ model MercadoPagoNotification {
   createdAt DateTime @default(now())
 }
 
+model DbAuditLog {
+  id        String   @id @default(cuid())
+  model     String
+  action    String
+  recordId  String?
+  before    Json?
+  after     Json?
+  args      Json?
+  userId    String?
+  requestId String?
+  createdAt DateTime @default(now())
+
+  @@index([model])
+  @@index([action])
+  @@index([createdAt])
+  @@index([userId])
+  @@index([requestId])
+}
+
 enum Role {
   ADMIN
   COUNTER

--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -1,9 +1,12 @@
+import { randomUUID } from 'node:crypto';
 import { PrismaClient } from '@prisma/client';
 
-const globalForPrisma = globalThis as unknown as { prisma: PrismaClient };
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
 
-export const prisma =
-  globalForPrisma.prisma ||
+const basePrisma =
+  globalForPrisma.prisma ??
   new PrismaClient({
     log:
       process.env.NODE_ENV === 'development'
@@ -11,4 +14,115 @@ export const prisma =
         : ['error'],
   });
 
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma;
+if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = basePrisma;
+
+const WRITE_ACTIONS = new Set([
+  'create',
+  'createMany',
+  'update',
+  'updateMany',
+  'upsert',
+  'delete',
+  'deleteMany',
+]);
+
+const AUDITED_ACTIONS = new Set(['update', 'delete', 'upsert', 'updateMany', 'deleteMany']);
+
+function toJsonString<T>(value: T): string | null {
+  if (value === undefined) {
+    return null;
+  }
+
+  return JSON.stringify(value, (_key, currentValue) =>
+    typeof currentValue === 'bigint' ? currentValue.toString() : currentValue,
+  );
+}
+
+function toRecordId(result: unknown, args: unknown) {
+  const resultId = (result as { id?: unknown } | null)?.id;
+  if (resultId !== undefined && resultId !== null) {
+    return String(resultId);
+  }
+
+  const whereId = (args as { where?: { id?: unknown } } | null)?.where?.id;
+  if (whereId !== undefined && whereId !== null) {
+    return String(whereId);
+  }
+
+  return null;
+}
+
+export const prisma = basePrisma.$extends({
+  name: 'audit-log',
+  query: {
+    $allModels: {
+      async $allOperations({ model, operation, args, query }) {
+        if (!model || String(model) === 'DbAuditLog' || !WRITE_ACTIONS.has(operation)) {
+          return query(args);
+        }
+
+        let before: unknown = null;
+
+        try {
+          if (AUDITED_ACTIONS.has(operation)) {
+            const where = (args as { where?: Record<string, any> } | null)?.where;
+
+            if (operation === 'updateMany' || operation === 'deleteMany') {
+              const delegateName = model.charAt(0).toLowerCase() + model.slice(1);
+              before = await (basePrisma as Record<string, any>)[delegateName].findMany({
+                where,
+                take: 100,
+              });
+            } else if (where) {
+              const delegateName = model.charAt(0).toLowerCase() + model.slice(1);
+              before = await (basePrisma as Record<string, any>)[delegateName].findUnique({
+                where,
+              });
+            }
+          }
+        } catch {
+          before = null;
+        }
+
+        const result = await query(args);
+
+        try {
+          const beforeJson = toJsonString(before);
+          const afterJson = toJsonString(result);
+          const argsJson = toJsonString(args);
+          const recordId = toRecordId(result, args);
+
+          await basePrisma.$executeRaw`
+            INSERT INTO "DbAuditLog" (
+              "id",
+              "model",
+              "action",
+              "recordId",
+              "before",
+              "after",
+              "args",
+              "userId",
+              "requestId",
+              "createdAt"
+            ) VALUES (
+              ${randomUUID()},
+              ${model},
+              ${operation},
+              ${recordId},
+              ${beforeJson}::jsonb,
+              ${afterJson}::jsonb,
+              ${argsJson}::jsonb,
+              ${null},
+              ${null},
+              NOW()
+            )
+          `;
+        } catch (error) {
+          console.error('[DbAuditLog] failed', error);
+        }
+
+        return result;
+      },
+    },
+  },
+});


### PR DESCRIPTION
## What changed
- Added `DbAuditLog` to Prisma schema with the requested indexes.
- Replaced the shared Prisma client export with a `$extends` query interceptor that audits write operations automatically.
- Added the migration SQL for the new table.

## Why
- We want automatic DB write auditing without touching every service or route.
- The implementation keeps the change centralized in the shared Prisma client.

## Validation
- `node_modules/.bin/prisma validate`
- `node_modules/.bin/prisma generate`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/prisma migrate deploy`

## Notes
- `userId` and `requestId` are currently written as `null` because the shared Prisma client does not yet receive request context.
- The audit insert uses raw SQL so it does not depend on a generated `dbAuditLog` delegate being present in this environment.