### PR TITLE
[codex] db audit log

### DIFF
--- a/prisma/migrations/20260427060000_drop_broken_updated_at_triggers/migration.sql
+++ b/prisma/migrations/20260427060000_drop_broken_updated_at_triggers/migration.sql
@@ -1,0 +1,8 @@
+-- The legacy schema used a generic updated_at trigger on several tables.
+-- Message, ConversationParticipant, and PasswordResetToken no longer have
+-- an updatedAt column in the application schema, so those triggers now fail
+-- whenever an update hits rows in those tables.
+
+DROP TRIGGER IF EXISTS trg_message_updated_at ON "Message";
+DROP TRIGGER IF EXISTS trg_conversation_participant_updated_at ON "ConversationParticipant";
+DROP TRIGGER IF EXISTS trg_password_reset_token_updated_at ON "PasswordResetToken";


### PR DESCRIPTION
## What changed
- Added `DbAuditLog` to Prisma schema with the requested indexes.
- Replaced the shared Prisma client export with a `$extends` query interceptor that audits write operations automatically.
- Added the migration SQL for the new table.
- Added a follow-up migration to remove stale `Message` / `ConversationParticipant` / `PasswordResetToken` update triggers that were breaking chat updates.

## Why
- We want automatic DB write auditing without touching every service or route.
- The chat error was caused by legacy triggers left behind after schema renames.

## Validation
- `node_modules/.bin/prisma validate`
- `node_modules/.bin/prisma generate`
- `node_modules/.bin/tsc --noEmit`
- `node_modules/.bin/prisma migrate deploy`
- Re-ran the exact failing `prisma.message.updateMany(...)` query against Neon; it now completes without error.

## Notes
- `userId` and `requestId` are currently written as `null` because the shared Prisma client does not yet receive request context.
- The audit insert uses raw SQL so it does not depend on a generated `dbAuditLog` delegate being present in this environment.