### PR TITLE
fix(audit): exclude Message.updateMany from audit logging

### DIFF
--- a/src/lib/prisma.ts
+++ b/src/lib/prisma.ts
@@ -27,6 +27,11 @@ const WRITE_ACTIONS = new Set([
 ]);
 
 const AUDITED_ACTIONS = new Set(['update', 'delete', 'upsert', 'updateMany', 'deleteMany']);
+const AUDIT_EXCLUDED_OPERATIONS = new Set(['Message:updateMany']);
+
+function shouldSkipAudit(model: string, operation: string) {
+  return AUDIT_EXCLUDED_OPERATIONS.has(`${model}:${operation}`);
+}
 
 function toJsonString<T>(value: T): string | null {
   if (value === undefined) {
@@ -58,6 +63,10 @@ export const prisma = basePrisma.$extends({
     $allModels: {
       async $allOperations({ model, operation, args, query }) {
         if (!model || String(model) === 'DbAuditLog' || !WRITE_ACTIONS.has(operation)) {
+          return query(args);
+        }
+
+        if (shouldSkipAudit(model, operation)) {
           return query(args);
         }
 


### PR DESCRIPTION
### Motivation
- Avoid noisy/large `DbAuditLog` entries produced by bulk `updateMany` operations used to mark `Message` rows as read, which don't need per-row audit records.

### Description
- Added `AUDIT_EXCLUDED_OPERATIONS` and helper `shouldSkipAudit` to `src/lib/prisma.ts` and an early return in the Prisma audit extension to skip auditing for `Message:updateMany` while keeping all other audit behavior unchanged.

### Testing
- Attempted to run `pnpm lint` but it failed in this environment due to Corepack/pnpm network proxy error (403), so no automated lint/tests ran; manual verification via `git diff` and the repository commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f009a814348333b46a1469054d6509)