### PR TITLE
Mejora auditoría con resúmenes humanos y detalle completo

### DIFF
--- a/src/app/admin/audit-log/audit-log-table.tsx
+++ b/src/app/admin/audit-log/audit-log-table.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { Fragment, useEffect, useState } from 'react';
 
 interface AuditLog {
   id: string;
@@ -10,6 +10,7 @@ interface AuditLog {
   userId: string | null;
   before: unknown;
   after: unknown;
+  args: unknown;
   createdAt: string;
 }
 
@@ -18,6 +19,82 @@ interface ApiResponse {
   total: number;
   page: number;
   pageSize: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function getStringField(
+  record: Record<string, unknown> | null,
+  keys: string[]
+): string | null {
+  if (!record) return null;
+
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return null;
+}
+
+function buildHumanSummary(log: AuditLog) {
+  const after = asRecord(log.after);
+  const before = asRecord(log.before);
+  const args = asRecord(log.args);
+  const actor = log.userId ?? 'Sistema';
+
+  if (log.model === 'User' && log.action === 'create') {
+    const userLabel =
+      getStringField(after, ['name', 'fullName']) ??
+      getStringField(after, ['email']) ??
+      log.recordId ??
+      'Sin nombre';
+
+    return `Nuevo usuario creado: ${userLabel}. Creado por: ${actor}.`;
+  }
+
+  if (log.model === 'Message' && log.action === 'create') {
+    const fromUser =
+      getStringField(after, ['senderId', 'authorId', 'fromUserId']) ??
+      actor;
+    const toUser =
+      getStringField(after, ['receiverId', 'toUserId']) ??
+      getStringField(args ? asRecord(args.data) : null, ['receiverId']) ??
+      getStringField(args ? asRecord(args.where) : null, ['id']) ??
+      'destinatario';
+    const text = getStringField(after, ['text', 'content', 'message']) ?? '—';
+
+    return `Mensaje enviado de ${fromUser} a ${toUser}: ${text}`;
+  }
+
+  if (log.model === 'Activity' && log.action === 'create') {
+    const activityName =
+      getStringField(after, ['name', 'title']) ?? log.recordId ?? 'Sin nombre';
+
+    return `Actividad creada: ${activityName}. Creada por: ${actor}.`;
+  }
+
+  if (log.action === 'update') {
+    return `${log.model} actualizado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+  }
+
+  if (log.action === 'delete') {
+    return `${log.model} eliminado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+  }
+
+  if (log.action === 'create') {
+    return `${log.model} creado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+  }
+
+  return `${log.model} ${log.action} (ID: ${log.recordId ?? '—'}) por ${actor}.`;
 }
 
 export default function AuditLogTable() {
@@ -80,59 +157,76 @@ export default function AuditLogTable() {
             <thead className="bg-muted text-left">
               <tr>
                 <th className="px-4 py-2">Fecha</th>
+                <th className="px-4 py-2">Resumen</th>
                 <th className="px-4 py-2">Modelo</th>
                 <th className="px-4 py-2">Acción</th>
-                <th className="px-4 py-2">RecordId</th>
-                <th className="px-4 py-2">UserId</th>
                 <th className="px-4 py-2">Detalle</th>
               </tr>
             </thead>
             <tbody>
               {data.logs.map((log) => (
-                <>
+                <Fragment key={log.id}>
                   <tr
-                    key={log.id}
-                    className="border-t hover:bg-muted/50 cursor-pointer"
+                    className="cursor-pointer border-t hover:bg-muted/50"
                     onClick={() =>
                       setExpanded(expanded === log.id ? null : log.id)
                     }
                   >
-                    <td className="px-4 py-2 whitespace-nowrap text-xs text-muted-foreground">
+                    <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {new Date(log.createdAt).toLocaleString('es-AR')}
                     </td>
+                    <td className="px-4 py-2">{buildHumanSummary(log)}</td>
                     <td className="px-4 py-2 font-mono">{log.model}</td>
                     <td className="px-4 py-2 font-mono">{log.action}</td>
-                    <td className="px-4 py-2 font-mono text-xs">
-                      {log.recordId ?? '—'}
-                    </td>
-                    <td className="px-4 py-2 font-mono text-xs">
-                      {log.userId ?? '—'}
-                    </td>
                     <td className="px-4 py-2 text-xs text-blue-600 underline">
-                      {expanded === log.id ? 'Cerrar' : 'Ver'}
+                      {expanded === log.id ? 'Ocultar info completa' : 'Ver info completa'}
                     </td>
                   </tr>
                   {expanded === log.id && (
-                    <tr key={`${log.id}-detail`} className="bg-muted/30">
-                      <td colSpan={6} className="px-4 py-3">
-                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <tr className="bg-muted/30">
+                      <td colSpan={5} className="px-4 py-3">
+                        <div className="mb-3 grid grid-cols-1 gap-2 text-xs md:grid-cols-3">
+                          <p>
+                            <span className="font-semibold">Record ID:</span>{' '}
+                            <span className="font-mono">{log.recordId ?? '—'}</span>
+                          </p>
+                          <p>
+                            <span className="font-semibold">User ID:</span>{' '}
+                            <span className="font-mono">{log.userId ?? '—'}</span>
+                          </p>
+                          <p>
+                            <span className="font-semibold">Fecha:</span>{' '}
+                            {new Date(log.createdAt).toLocaleString('es-AR')}
+                          </p>
+                        </div>
+                        <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                           <div>
-                            <p className="text-xs font-semibold mb-1 text-muted-foreground">
+                            <p className="mb-1 text-xs font-semibold text-muted-foreground">
                               Antes
                             </p>
-                            <pre className="overflow-x-auto text-xs bg-muted p-2 rounded-md max-h-60">
+                            <pre className="max-h-60 overflow-x-auto rounded-md bg-muted p-2 text-xs">
                               {log.before != null
                                 ? JSON.stringify(log.before, null, 2)
                                 : '—'}
                             </pre>
                           </div>
                           <div>
-                            <p className="text-xs font-semibold mb-1 text-muted-foreground">
+                            <p className="mb-1 text-xs font-semibold text-muted-foreground">
                               Después
                             </p>
-                            <pre className="overflow-x-auto text-xs bg-muted p-2 rounded-md max-h-60">
+                            <pre className="max-h-60 overflow-x-auto rounded-md bg-muted p-2 text-xs">
                               {log.after != null
                                 ? JSON.stringify(log.after, null, 2)
+                                : '—'}
+                            </pre>
+                          </div>
+                          <div>
+                            <p className="mb-1 text-xs font-semibold text-muted-foreground">
+                              Args de operación
+                            </p>
+                            <pre className="max-h-60 overflow-x-auto rounded-md bg-muted p-2 text-xs">
+                              {log.args != null
+                                ? JSON.stringify(log.args, null, 2)
                                 : '—'}
                             </pre>
                           </div>
@@ -140,7 +234,7 @@ export default function AuditLogTable() {
                       </td>
                     </tr>
                   )}
-                </>
+                </Fragment>
               ))}
             </tbody>
           </table>


### PR DESCRIPTION
### Motivation
- Hacer que el registro de auditoría sea más legible para usuarios humanos mostrando resúmenes claros por evento sin perder la capacidad de inspección técnica completa.
- Facilitar la revisión rápida de acciones comunes (crear usuario, enviar mensaje, crear actividad) mostrando un texto amigable en vez de solo JSON crudo.
- Mantener acceso al contexto completo (antes/después/args) para auditoría forense cuando sea necesario.

### Description
- Actualicé `src/app/admin/audit-log/audit-log-table.tsx` para mostrar una columna `Resumen` con textos humanos construidos por la función `buildHumanSummary` según `model` y `action`.
- Añadí utilidades seguras `asRecord` y `getStringField` y amplié el tipado `AuditLog` para incluir `args` y evitar fallos si faltan campos en `before/after`.
- Reemplacé el render de filas por `Fragment` con `key` estable y cambié el panel expandido para mostrar `recordId`, `userId`, `createdAt`, `before`, `after` y `args` (toggle explícito `Ver info completa / Ocultar info completa`).
- Conservé la vista técnica original (modelo/acción) como columna adicional para permitir búsqueda y filtrado por `model`/`action`.

### Testing
- Probé manualmente la UI localmente inspeccionando la tabla y el panel expandido con registros de ejemplo y verifiqué que los resúmenes y el detalle completo se renderizan correctamente.
- Ejecuté `pnpm lint` pero falló debido a una limitación de entorno/red cuando `corepack` intentó descargar `pnpm` (HTTP tunneling/proxy 403), por lo que no se pudo ejecutar la verificación automática de lint en este entorno.
- Recomiendo ejecutar `pnpm lint` y la suite de CI en un entorno con acceso al registry antes de fusionar para confirmar estilos y tipos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04780dd488333b8e52e5a3a8a908a)