### PR TITLE
feat(navbar): add Administrador dropdown for super-admin links

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -166,17 +166,29 @@ export default function Navbar() {
                 {t.forms}
               </Link>
               {isSuperAdmin && (
-                <>
-                  <Link href="/admin/notifications" className={linkClass}>
-                    {t.notifications}
-                  </Link>
-                  <Link href="/admin/audit-log" className={linkClass}>
-                    {t.auditLog}
-                  </Link>
-                  <Link href="/admin/site" className={linkClass}>
-                    {t.admin}
-                  </Link>
-                </>
+                <div className="relative group">
+                  <button className={linkClass}>Administrador</button>
+                  <div className="absolute right-0 top-full hidden group-hover:block bg-card border rounded-md shadow-lg z-50 min-w-56">
+                    <Link
+                      href="/admin/site"
+                      className="block w-full text-left px-4 py-2 hover:bg-muted text-sm text-black"
+                    >
+                      /admin/site
+                    </Link>
+                    <Link
+                      href="/admin/notifications"
+                      className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
+                    >
+                      Notificaciones
+                    </Link>
+                    <Link
+                      href="/admin/audit-log"
+                      className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
+                    >
+                      Registro de auditoría
+                    </Link>
+                  </div>
+                </div>
               )}
             </>
           )}
@@ -309,29 +321,32 @@ export default function Navbar() {
                 {t.forms}
               </Link>
               {isSuperAdmin && (
-                <>
+                <div className="flex flex-col gap-2">
+                  <span className="text-sm font-medium opacity-90">
+                    Administrador
+                  </span>
+                  <Link
+                    href="/admin/site"
+                    className={linkClass}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    /admin/site
+                  </Link>
                   <Link
                     href="/admin/notifications"
                     className={linkClass}
                     onClick={() => setMenuOpen(false)}
                   >
-                    {t.notifications}
+                    Notificaciones
                   </Link>
                   <Link
                     href="/admin/audit-log"
                     className={linkClass}
                     onClick={() => setMenuOpen(false)}
                   >
-                    {t.auditLog}
+                    Registro de auditoría
                   </Link>
-                  <Link
-                    href="/admin/site"
-                    className={linkClass}
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    {t.admin}
-                  </Link>
-                </>
+                </div>
               )}
             </>
           )}


### PR DESCRIPTION
### Motivation
- Group SUPER_ADMIN-only controls into a single “Administrador” dropdown to declutter the navbar and provide a clear place for site settings, notifications and the audit log.

### Description
- Replaced top-level super-admin links in `src/components/navbar.tsx` with a desktop dropdown (`div.relative.group` + `group-hover` panel) containing `/admin/site`, `Notificaciones` (`/admin/notifications`) and `Registro de auditoría` (`/admin/audit-log`).
- Updated the mobile menu to show an “Administrador” heading and the same three links, closing the menu when a link is clicked.
- Preserved existing admin links for `/admin/users` and `/admin/forms` and kept role checks unchanged.
- Files touched: `src/components/navbar.tsx`.

### Testing
- Attempted to run `pnpm lint`, but bootstrap failed due to network/proxy errors when Corepack tried to fetch the `pnpm` tarball, so linting could not be executed (failure).
- Changes were committed successfully to the repo and the modified file is `src/components/navbar.tsx`.
- What changed: desktop dropdown labeled “Administrador” and mobile grouping for super-admin links.
- Files touched: `src/components/navbar.tsx`.
- Tests or verification run: attempted `pnpm lint` (failed to run due to environment network restrictions).
- Unresolved risks: UI/UX small regressions (hover/focus behavior, dropdown positioning, mobile spacing) were not validated by automated checks and should be verified locally or in a browser after running the dev server.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f04bab89a48333a7a1fea8c1c4e1d3)