### PR TITLE
Mostrar nombres de personas en el resumen del registro de auditoría

### DIFF
--- a/src/app/admin/audit-log/audit-log-table.tsx
+++ b/src/app/admin/audit-log/audit-log-table.tsx
@@ -19,6 +19,7 @@ interface ApiResponse {
   total: number;
   page: number;
   pageSize: number;
+  usersById?: Record<string, string>;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -45,11 +46,19 @@ function getStringField(
   return null;
 }
 
-function buildHumanSummary(log: AuditLog) {
+function resolvePersonLabel(
+  candidate: string | null | undefined,
+  usersById: Record<string, string>
+) {
+  if (!candidate) return 'Sistema';
+  return usersById[candidate] ?? candidate;
+}
+
+function buildHumanSummary(log: AuditLog, usersById: Record<string, string>) {
   const after = asRecord(log.after);
   const before = asRecord(log.before);
   const args = asRecord(log.args);
-  const actor = log.userId ?? 'Sistema';
+  const actor = resolvePersonLabel(log.userId, usersById);
 
   if (log.model === 'User' && log.action === 'create') {
     const userLabel =
@@ -63,13 +72,19 @@ function buildHumanSummary(log: AuditLog) {
 
   if (log.model === 'Message' && log.action === 'create') {
     const fromUser =
-      getStringField(after, ['senderId', 'authorId', 'fromUserId']) ??
+      resolvePersonLabel(
+        getStringField(after, ['senderId', 'authorId', 'fromUserId']) ??
+          getStringField(before, ['senderId', 'authorId', 'fromUserId']),
+        usersById
+      ) ??
       actor;
-    const toUser =
+    const toUserRaw =
       getStringField(after, ['receiverId', 'toUserId']) ??
+      getStringField(before, ['receiverId', 'toUserId']) ??
       getStringField(args ? asRecord(args.data) : null, ['receiverId']) ??
       getStringField(args ? asRecord(args.where) : null, ['id']) ??
       'destinatario';
+    const toUser = resolvePersonLabel(toUserRaw, usersById);
     const text = getStringField(after, ['text', 'content', 'message']) ?? '—';
 
     return `Mensaje enviado de ${fromUser} a ${toUser}: ${text}`;
@@ -83,18 +98,18 @@ function buildHumanSummary(log: AuditLog) {
   }
 
   if (log.action === 'update') {
-    return `${log.model} actualizado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+    return `${log.model} actualizado por ${actor}.`;
   }
 
   if (log.action === 'delete') {
-    return `${log.model} eliminado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+    return `${log.model} eliminado por ${actor}.`;
   }
 
   if (log.action === 'create') {
-    return `${log.model} creado (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+    return `${log.model} creado por ${actor}.`;
   }
 
-  return `${log.model} ${log.action} (ID: ${log.recordId ?? '—'}) por ${actor}.`;
+  return `${log.model} ${log.action} por ${actor}.`;
 }
 
 export default function AuditLogTable() {
@@ -175,7 +190,9 @@ export default function AuditLogTable() {
                     <td className="whitespace-nowrap px-4 py-2 text-xs text-muted-foreground">
                       {new Date(log.createdAt).toLocaleString('es-AR')}
                     </td>
-                    <td className="px-4 py-2">{buildHumanSummary(log)}</td>
+                    <td className="px-4 py-2">
+                      {buildHumanSummary(log, data.usersById ?? {})}
+                    </td>
                     <td className="px-4 py-2 font-mono">{log.model}</td>
                     <td className="px-4 py-2 font-mono">{log.action}</td>
                     <td className="px-4 py-2 text-xs text-blue-600 underline">

--- a/src/app/api/admin/audit-log/route.ts
+++ b/src/app/api/admin/audit-log/route.ts
@@ -1,9 +1,71 @@
 import { getServerSession } from 'next-auth';
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 
 const PAGE_SIZE = 25;
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null;
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function collectUserIdsFromLog(log: {
+  userId: string | null;
+  recordId: string | null;
+  model: string;
+  before: Prisma.JsonValue | null;
+  after: Prisma.JsonValue | null;
+  args: Prisma.JsonValue | null;
+}) {
+  const userIds = new Set<string>();
+
+  if (log.userId) {
+    userIds.add(log.userId);
+  }
+
+  if (log.model === 'User' && log.recordId) {
+    userIds.add(log.recordId);
+  }
+
+  const after = asRecord(log.after);
+  const before = asRecord(log.before);
+  const args = asRecord(log.args);
+  const argsData = asRecord(args?.data);
+  const argsWhere = asRecord(args?.where);
+
+  const candidateValues = [
+    after?.senderId,
+    after?.receiverId,
+    after?.authorId,
+    after?.fromUserId,
+    after?.toUserId,
+    before?.senderId,
+    before?.receiverId,
+    before?.authorId,
+    before?.fromUserId,
+    before?.toUserId,
+    argsData?.senderId,
+    argsData?.receiverId,
+    argsData?.authorId,
+    argsData?.fromUserId,
+    argsData?.toUserId,
+    argsWhere?.id,
+    argsWhere?.userId,
+  ];
+
+  for (const value of candidateValues) {
+    if (typeof value === 'string' && value.trim()) {
+      userIds.add(value.trim());
+    }
+  }
+
+  return userIds;
+}
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
@@ -31,5 +93,31 @@ export async function GET(req: NextRequest) {
     prisma.dbAuditLog.count({ where }),
   ]);
 
-  return NextResponse.json({ logs, total, page, pageSize: PAGE_SIZE });
+  const userIds = new Set<string>();
+  for (const log of logs) {
+    for (const userId of collectUserIdsFromLog(log)) {
+      userIds.add(userId);
+    }
+  }
+
+  const users = userIds.size
+    ? await prisma.user.findMany({
+        where: { id: { in: Array.from(userIds) } },
+        select: { id: true, name: true, lastName: true, email: true },
+      })
+    : [];
+
+  const usersById = users.reduce<Record<string, string>>((acc, user) => {
+    const fullName = [user.name, user.lastName].filter(Boolean).join(' ').trim();
+    acc[user.id] = fullName || user.email;
+    return acc;
+  }, {});
+
+  return NextResponse.json({
+    logs,
+    total,
+    page,
+    pageSize: PAGE_SIZE,
+    usersById,
+  });
 }


### PR DESCRIPTION
- what changed
  - Enriquecí la respuesta de `GET /api/admin/audit-log` con un diccionario `usersById` (ID → nombre + apellido, fallback a email) y adapté la UI de la tabla para mostrar esos nombres en el texto resumen en lugar de IDs crudos.
- files touched
  - `src/app/api/admin/audit-log/route.ts`
  - `src/app/admin/audit-log/audit-log-table.tsx`
- tests or verification run
  - Intenté ejecutar `pnpm lint`, pero fallo por una restricción de red al descargar `pnpm` vía `corepack` (error `Proxy response (403)`), por lo que no se pudieron ejecutar linters automáticos.
  - Verifiqué manualmente los diffs y la integración local de las funciones cambiadas revisando las modificaciones aplicadas en los archivos mencionados.
- unresolved risks
  - Si un ID aparece en campos no contemplados por la heurística de extracción, el resumen seguirá mostrando ese valor como fallback en lugar del nombre legible.
  - En el panel expandido de detalle aún se muestran `Record ID` y `User ID`; el cambio solo afecta el texto del resumen que describe "qué pasó".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0bb6faa1883338485a85fc2196d47)