### PR TITLE
Fix activity images not displaying via private blob proxy

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -306,9 +306,10 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
       {activity.image ? (
         <div className="relative w-full h-52 overflow-hidden">
           <Image
-            src={activity.image}
+            src={`/api/activities/${activity.id}/image`}
             alt={activity.name}
             fill
+            unoptimized
             className="object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />

--- a/src/app/activities/activity-image-upload.tsx
+++ b/src/app/activities/activity-image-upload.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { ImageUp, Trash2, X } from 'lucide-react';
+import { ImageUp, Trash2 } from 'lucide-react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
 
@@ -17,7 +17,7 @@ export default function ActivityImageUpload({
   onSuccess,
 }: Props) {
   const [hasCurrentImage, setHasCurrentImage] = useState(!!currentImageUrl);
-  const [imageUrl, setImageUrl] = useState(currentImageUrl);
+  const [imageVersion, setImageVersion] = useState<number>(Date.now());
   const [error, setError] = useState('');
   const [message, setMessage] = useState('');
   const [isUploading, setIsUploading] = useState(false);
@@ -26,7 +26,7 @@ export default function ActivityImageUpload({
 
   useEffect(() => {
     setHasCurrentImage(!!currentImageUrl);
-    setImageUrl(currentImageUrl);
+    setImageVersion(Date.now());
   }, [currentImageUrl]);
 
   const uploadFile = async (file: File) => {
@@ -44,9 +44,9 @@ export default function ActivityImageUpload({
         const body = await res.json().catch(() => null);
         throw new Error(body?.error || 'Upload failed');
       }
-      const data = await res.json().catch(() => null);
+      await res.json().catch(() => null);
       setHasCurrentImage(true);
-      setImageUrl(data?.url || currentImageUrl);
+      setImageVersion(Date.now());
       setMessage('Imagen actualizada');
       onSuccess?.();
     } catch (err) {
@@ -101,7 +101,7 @@ export default function ActivityImageUpload({
         throw new Error(body?.error || 'Delete failed');
       }
       setHasCurrentImage(false);
-      setImageUrl(undefined);
+      setImageVersion(Date.now());
       setMessage('Imagen eliminada');
       onSuccess?.();
     } catch (err) {
@@ -123,10 +123,10 @@ export default function ActivityImageUpload({
         onDragOver={handleDragOver}
         onDragLeave={handleDragLeave}
       >
-        {hasCurrentImage && imageUrl ? (
+        {hasCurrentImage ? (
           <div className="relative h-full w-full">
             <Image
-              src={imageUrl}
+              src={`/api/activities/${activityId}/image?v=${imageVersion}`}
               alt="Imagen de actividad"
               fill
               unoptimized

--- a/src/app/api/activities/[id]/image/route.ts
+++ b/src/app/api/activities/[id]/image/route.ts
@@ -1,9 +1,37 @@
-import { del, put } from '@vercel/blob';
+import { del, get, put } from '@vercel/blob';
 import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { extensionFor } from '@/lib/image-utils';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+    select: { image: true },
+  });
+
+  if (!activity?.image) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const blob = await get(activity.image, { access: 'private' });
+    if (!blob || blob.statusCode !== 200) {
+      return new NextResponse(null, { status: 404 });
+    }
+
+    const headers = Object.fromEntries(blob.headers.entries());
+    headers['Cache-Control'] = 'public, max-age=300, stale-while-revalidate=60';
+
+    return new NextResponse(blob.stream, { headers });
+  } catch {
+    return new NextResponse(null, { status: 404 });
+  }
+}
 
 export async function POST(
   req: Request,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -137,7 +137,9 @@ export default async function Home() {
                       className="h-36 bg-muted bg-cover bg-center"
                       style={
                         activity.image
-                          ? { backgroundImage: `url(${activity.image})` }
+                          ? {
+                              backgroundImage: `url(/api/activities/${activity.id}/image)`,
+                            }
                           : {
                               background:
                                 'linear-gradient(135deg, #2a4a2c, #3D5A3E)',


### PR DESCRIPTION
### Motivation
- Activity images stored as private Vercel Blob URLs were not rendering on public pages because the frontend attempted to load private blob URLs directly.  
- The intent is to securely stream those private blobs through the server so public pages can display images without exposing private blob URLs.  
- The admin upload preview also needed cache-busting so newly uploaded/deleted images appear immediately in the UI.  

### Description
- Added `GET /api/activities/[id]/image` which reads the `activity.image` URL from the DB, fetches the private Vercel Blob via `@vercel/blob.get`, and streams it back with short public caching. (`src/app/api/activities/[id]/image/route.ts`)  
- Updated the home activities cards to use the proxy URL `url(/api/activities/{id}/image)` for background images instead of the raw stored blob URL. (`src/app/page.tsx`)  
- Updated the activity detail hero to load the image from `/api/activities/{id}/image` and set `unoptimized` on the Next image to avoid Next's remote-image rules. (`src/app/activities/[id]/page.tsx`)  
- Changed the admin `ActivityImageUpload` preview to request `/api/activities/{id}/image?v={timestamp}` and bump the `?v=` version on upload/delete to avoid stale previews. Also removed an unused import. (`src/app/activities/activity-image-upload.tsx`)  

### Testing
- Ran `git diff --check` which succeeded with no whitespace/merge errors.  
- Attempted `pnpm lint`, which failed in this environment because Corepack could not download `pnpm` due to a network/proxy 403 error (environment limitation).  
- No additional automated unit/integration tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f6f56ef083339e15b0041c9f3e27)