### PR TITLE
Agregar sección Pagos en perfil (carrito + historial)

### DIFF
--- a/src/app/profile/payments/page.tsx
+++ b/src/app/profile/payments/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export default async function ProfilePaymentsPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    redirect('/login');
+  }
+
+  const payments = await prisma.activityParticipant.findMany({
+    where: {
+      OR: [
+        { userId: session.user.id },
+        { child: { parentId: session.user.id } },
+      ],
+      receipt: { not: null },
+    },
+    orderBy: { receiptDate: 'desc' },
+    include: {
+      activity: { select: { name: true, price: true } },
+      user: { select: { name: true, lastName: true } },
+      child: { select: { name: true, lastName: true } },
+    },
+  });
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Pagos</h1>
+        <p className="text-sm text-muted-foreground">
+          Revisá tu carrito actual y el historial de pagos aprobados.
+        </p>
+      </header>
+
+      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <h2 className="text-lg font-semibold">Carrito</h2>
+            <p className="text-sm text-muted-foreground">
+              Actividades pendientes para pagar.
+            </p>
+          </div>
+          <Link
+            href="/activities/cart"
+            className="rounded-md border px-3 py-2 text-sm hover:bg-muted"
+          >
+            Ver carrito
+          </Link>
+        </div>
+      </section>
+
+      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold">Historial de pagos</h2>
+
+        {payments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Todavía no tenés pagos registrados.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="px-3 py-2 font-medium">Fecha</th>
+                  <th className="px-3 py-2 font-medium">Actividad</th>
+                  <th className="px-3 py-2 font-medium">Participante</th>
+                  <th className="px-3 py-2 font-medium">Comprobante</th>
+                  <th className="px-3 py-2 font-medium text-right">Monto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {payments.map((payment) => {
+                  const participant = payment.child ?? payment.user;
+                  const participantName = [participant?.name, participant?.lastName]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  return (
+                    <tr key={payment.id} className="border-b last:border-0">
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {payment.receiptDate
+                          ? payment.receiptDate.toLocaleDateString('es-AR')
+                          : '-'}
+                      </td>
+                      <td className="px-3 py-2">{payment.activity.name}</td>
+                      <td className="px-3 py-2">{participantName || 'Sin nombre'}</td>
+                      <td className="px-3 py-2">{payment.receipt ?? '-'}</td>
+                      <td className="px-3 py-2 text-right font-medium">
+                        {formatCurrency(payment.activity.price)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/app/profile/payments/page.tsx
+++ b/src/app/profile/payments/page.tsx
@@ -23,7 +23,7 @@ export default async function ProfilePaymentsPage() {
     where: {
       OR: [
         { userId: session.user.id },
-        { child: { parentId: session.user.id } },
+        { child: { userId: session.user.id } },
       ],
       receipt: { not: null },
     },

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -287,6 +287,12 @@ export default function Navbar() {
                   >
                     {actions.myChildren}
                   </Link>
+                  <Link
+                    href="/profile/payments"
+                    className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
+                  >
+                    Pagos
+                  </Link>
                   <select
                     value={lang}
                     onChange={(e) => setLang(e.target.value as Lang)}
@@ -464,6 +470,13 @@ export default function Navbar() {
                 onClick={() => setMenuOpen(false)}
               >
                 {actions.myChildren}
+              </Link>
+              <Link
+                href="/profile/payments"
+                className={linkClass}
+                onClick={() => setMenuOpen(false)}
+              >
+                Pagos
               </Link>
               <select
                 value={lang}


### PR DESCRIPTION
### Motivation
- Permitir a los miembros ver rápidamente su carrito y el historial de pagos desde el menú de perfil, unificando el acceso a pagos aprobados y pendientes.

### Description
- Se agregó la nueva página autenticada `src/app/profile/payments/page.tsx` que muestra un acceso al carrito y un historial de pagos (consulta `activityParticipant` filtrando por `userId` o hijos y `receipt` no nulo). 
- Se añadió el link `Pagos` en el dropdown de perfil en desktop y en el menú móvil dentro de `src/components/navbar.tsx` para acceso directo desde el navbar. 
- La vista renderiza fecha, actividad, participante, comprobante y monto formateado, y reutiliza el patrón de acceso/redirect con `getServerSession` y `redirect('/login')`.
- Archivos tocados: `src/app/profile/payments/page.tsx`, `src/components/navbar.tsx`.

### Testing
- Intenté ejecutar `pnpm lint` como verificación automática, pero falló debido a un error de `corepack`/`pnpm` al descargar paquetes por restricciones de red/proxy en el entorno, por lo que el lint no se completó. 
- No se ejecutaron otros tests automáticos; se recomienda correr `pnpm install` + `pnpm lint` y `pnpm build` en un entorno con acceso a la registry (CI/local) antes de mergear para validar tipos y estilos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f147b0e6fc833384ee2cdbeb5aa73a)