### PR TITLE
Add payments page, cart status component, and navbar payments link with badge

### DIFF
--- a/src/app/profile/payments/cart-status.tsx
+++ b/src/app/profile/payments/cart-status.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { ACTIVITY_CART_STORAGE_KEY, ActivityCartItem } from '@/lib/cart';
+
+export default function CartStatus() {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const updateCount = () => {
+      try {
+        const raw = window.localStorage.getItem(ACTIVITY_CART_STORAGE_KEY);
+        if (!raw) {
+          setCount(0);
+          return;
+        }
+
+        const items = JSON.parse(raw) as ActivityCartItem[];
+        setCount(items.length);
+      } catch {
+        setCount(0);
+      }
+    };
+
+    updateCount();
+
+    const handleFocus = () => updateCount();
+    const handleStorage = (event: StorageEvent) => {
+      if (event.key === ACTIVITY_CART_STORAGE_KEY) {
+        updateCount();
+      }
+    };
+
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('storage', handleStorage);
+
+    return () => {
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('storage', handleStorage);
+    };
+  }, []);
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <h2 className="text-lg font-semibold">Carrito</h2>
+        <p className="text-sm text-muted-foreground">
+          Actividades pendientes para pagar.
+        </p>
+        {count > 0 && (
+          <p className="mt-2 inline-flex rounded-full bg-amber-100 text-amber-800 px-2 py-0.5 text-xs font-semibold">
+            Tenés {count} {count === 1 ? 'actividad pendiente' : 'actividades pendientes'} en el carrito.
+          </p>
+        )}
+      </div>
+      <Link
+        href="/activities/cart"
+        className="inline-flex items-center gap-2 rounded-md border px-3 py-2 text-sm hover:bg-muted"
+      >
+        Ver carrito
+        {count > 0 && (
+          <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-0.5 text-xs font-semibold">
+            {count}
+          </span>
+        )}
+      </Link>
+    </div>
+  );
+}

--- a/src/app/profile/payments/page.tsx
+++ b/src/app/profile/payments/page.tsx
@@ -1,0 +1,101 @@
+import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import CartStatus from './cart-status';
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  }).format(amount);
+}
+
+export default async function ProfilePaymentsPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    redirect('/login');
+  }
+
+  const payments = await prisma.activityParticipant.findMany({
+    where: {
+      OR: [
+        { userId: session.user.id },
+        { child: { userId: session.user.id } },
+      ],
+      receipt: { not: null },
+    },
+    orderBy: { receiptDate: 'desc' },
+    include: {
+      activity: { select: { name: true, price: true } },
+      user: { select: { name: true, lastName: true } },
+      child: { select: { name: true, lastName: true } },
+    },
+  });
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Pagos</h1>
+        <p className="text-sm text-muted-foreground">
+          Revisá tu carrito actual y el historial de pagos aprobados.
+        </p>
+      </header>
+
+      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
+        <CartStatus />
+      </section>
+
+      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-4">
+        <h2 className="text-lg font-semibold">Historial de pagos</h2>
+
+        {payments.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            Todavía no tenés pagos registrados.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="border-b text-left">
+                  <th className="px-3 py-2 font-medium">Fecha</th>
+                  <th className="px-3 py-2 font-medium">Actividad</th>
+                  <th className="px-3 py-2 font-medium">Participante</th>
+                  <th className="px-3 py-2 font-medium">Comprobante</th>
+                  <th className="px-3 py-2 font-medium text-right">Monto</th>
+                </tr>
+              </thead>
+              <tbody>
+                {payments.map((payment) => {
+                  const participant = payment.child ?? payment.user;
+                  const participantName = [participant?.name, participant?.lastName]
+                    .filter(Boolean)
+                    .join(' ');
+
+                  return (
+                    <tr key={payment.id} className="border-b last:border-0">
+                      <td className="px-3 py-2 text-muted-foreground">
+                        {payment.receiptDate
+                          ? payment.receiptDate.toLocaleDateString('es-AR')
+                          : '-'}
+                      </td>
+                      <td className="px-3 py-2">{payment.activity.name}</td>
+                      <td className="px-3 py-2">{participantName || 'Sin nombre'}</td>
+                      <td className="px-3 py-2">{payment.receipt ?? '-'}</td>
+                      <td className="px-3 py-2 text-right font-medium">
+                        {formatCurrency(payment.activity.price)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -287,6 +287,19 @@ export default function Navbar() {
                   >
                     {actions.myChildren}
                   </Link>
+                  <Link
+                    href="/profile/payments"
+                    className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
+                  >
+                    <span className="inline-flex items-center gap-2">
+                      <span>Pagos</span>
+                      {cartItemsCount > 0 && (
+                        <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-0.5 text-[11px] font-semibold">
+                          {cartItemsCount}
+                        </span>
+                      )}
+                    </span>
+                  </Link>
                   <select
                     value={lang}
                     onChange={(e) => setLang(e.target.value as Lang)}
@@ -464,6 +477,18 @@ export default function Navbar() {
                 onClick={() => setMenuOpen(false)}
               >
                 {actions.myChildren}
+              </Link>
+              <Link
+                href="/profile/payments"
+                className={`${linkClass} inline-flex items-center gap-2`}
+                onClick={() => setMenuOpen(false)}
+              >
+                <span>Pagos</span>
+                {cartItemsCount > 0 && (
+                  <span className="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
+                    {cartItemsCount}
+                  </span>
+                )}
               </Link>
               <select
                 value={lang}


### PR DESCRIPTION
### Motivation
- Provide a dedicated Payments area where users can inspect their cart and payment history.
- Show quick visibility of pending cart items in the profile navbar to improve discoverability of unpaid activities.

### Description
- Add a server-rendered payments page `ProfilePaymentsPage` at `src/app/profile/payments/page.tsx` that requires authentication via `getServerSession` and redirects to `/login` when absent.
- Query payment history with `prisma.activityParticipant.findMany` and render a table with localized currency formatting using `formatCurrency` (es-AR, ARS).
- Add a client component `CartStatus` at `src/app/profile/payments/cart-status.tsx` that reads `ACTIVITY_CART_STORAGE_KEY` from `localStorage`, listens for `focus` and `storage` events, and displays the cart count and link to `/activities/cart`.
- Update `src/components/navbar.tsx` to include a `Pagos` entry linking to `/profile/payments` and render a cart badge using `cartItemsCount` in both desktop and mobile menu variants.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f147b0e6fc833384ee2cdbeb5aa73a)