### PR TITLE
feat(navbar): usar notificación tipo chat para carrito y pagos

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -149,6 +149,14 @@ export default function Navbar() {
     />
   );
 
+  const renderCartNotificationIcon = () => (
+    <span
+      className="inline-flex h-2.5 w-2.5 rounded-full bg-amber-400"
+      aria-label="Tenés actividades en el carrito"
+      title="Tenés actividades en el carrito"
+    />
+  );
+
   return (
     <nav className="px-4 py-3 text-white shadow-md bg-slate-800">
       <div className="mx-auto flex max-w-6xl items-center justify-between">
@@ -187,11 +195,7 @@ export default function Navbar() {
             >
               <ShoppingCart className="h-4 w-4" aria-hidden="true" />
               <span>Carrito</span>
-              {cartItemsCount > 0 && (
-                <span className="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
-                  {cartItemsCount}
-                </span>
-              )}
+              {cartItemsCount > 0 && renderCartNotificationIcon()}
             </Link>
           )}
           {session && (
@@ -293,11 +297,7 @@ export default function Navbar() {
                   >
                     <span className="inline-flex items-center gap-2">
                       <span>Pagos</span>
-                      {cartItemsCount > 0 && (
-                        <span className="rounded-full bg-amber-100 text-amber-800 px-2 py-0.5 text-[11px] font-semibold">
-                          {cartItemsCount}
-                        </span>
-                      )}
+                      {cartItemsCount > 0 && renderCartNotificationIcon()}
                     </span>
                   </Link>
                   <select
@@ -355,11 +355,7 @@ export default function Navbar() {
             >
               <ShoppingCart className="h-4 w-4" aria-hidden="true" />
               <span>Carrito</span>
-              {cartItemsCount > 0 && (
-                <span className="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
-                  {cartItemsCount}
-                </span>
-              )}
+              {cartItemsCount > 0 && renderCartNotificationIcon()}
             </Link>
           )}
           {session && (
@@ -484,11 +480,7 @@ export default function Navbar() {
                 onClick={() => setMenuOpen(false)}
               >
                 <span>Pagos</span>
-                {cartItemsCount > 0 && (
-                  <span className="rounded-full bg-white/20 px-2 py-0.5 text-xs font-semibold">
-                    {cartItemsCount}
-                  </span>
-                )}
+                {cartItemsCount > 0 && renderCartNotificationIcon()}
               </Link>
               <select
                 value={lang}


### PR DESCRIPTION
### Motivation
- Mostrar una notificación de presencia (punto) para el carrito en el navbar y en el link "Pagos" del dropdown de perfil, similar al indicador de mensajes sin leer, para avisar cuando hay ítems en el carrito.

### Description
- Reemplacé los badges numéricos del carrito por una función `renderCartNotificationIcon` que pinta un punto de notificación en `src/components/navbar.tsx`.
- Apliqué el indicador en el navbar de escritorio, en el dropdown de perfil sobre el link "Pagos" y en el menú móvil para mantener comportamiento consistente.
- No se modificaron rutas ni lógica del carrito ni APIs, solo el renderizado visual en el componente de la navbar.

### Testing
- Intenté ejecutar `pnpm lint`, pero la ejecución falló porque el entorno no pudo descargar `pnpm` desde el registry (error de proxy 403), por lo que las comprobaciones automatizadas no se completaron.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f159eecd1c833393974be0b3f14233)