### PR TITLE
Separar Carrito e Historial de pagos en el menú de perfil

### DIFF
--- a/src/app/profile/cart/page.tsx
+++ b/src/app/profile/cart/page.tsx
@@ -1,0 +1,27 @@
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { authOptions } from '@/lib/auth';
+import CartStatus from '../payments/cart-status';
+
+export default async function ProfileCartPage() {
+  const session = await getServerSession(authOptions);
+
+  if (!session?.user?.id) {
+    redirect('/login');
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-bold tracking-tight">Carrito</h1>
+        <p className="text-sm text-muted-foreground">
+          Revisá y gestioná tus actividades pendientes de pago.
+        </p>
+      </header>
+
+      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
+        <CartStatus />
+      </section>
+    </main>
+  );
+}

--- a/src/app/profile/payments/page.tsx
+++ b/src/app/profile/payments/page.tsx
@@ -3,7 +3,6 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import CartStatus from './cart-status';
 
 function formatCurrency(amount: number) {
   return new Intl.NumberFormat('es-AR', {
@@ -39,18 +38,14 @@ export default async function ProfilePaymentsPage() {
   return (
     <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">
       <header className="space-y-2">
-        <h1 className="text-2xl font-bold tracking-tight">Pagos</h1>
+        <h1 className="text-2xl font-bold tracking-tight">Historial de pagos</h1>
         <p className="text-sm text-muted-foreground">
-          Revisá tu carrito actual y el historial de pagos aprobados.
+          Revisá tus pagos aprobados de actividades.
         </p>
       </header>
 
-      <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
-        <CartStatus />
-      </section>
-
       <section className="rounded-xl border bg-card p-5 shadow-sm space-y-4">
-        <h2 className="text-lg font-semibold">Historial de pagos</h2>
+        <h2 className="text-lg font-semibold">Pagos aprobados</h2>
 
         {payments.length === 0 ? (
           <p className="text-sm text-muted-foreground">

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -292,13 +292,19 @@ export default function Navbar() {
                     {actions.myChildren}
                   </Link>
                   <Link
-                    href="/profile/payments"
+                    href="/profile/cart"
                     className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
                   >
                     <span className="inline-flex items-center gap-2">
-                      <span>Pagos</span>
+                      <span>Carrito</span>
                       {cartItemsCount > 0 && renderCartNotificationIcon()}
                     </span>
+                  </Link>
+                  <Link
+                    href="/profile/payments"
+                    className="block w-full text-left px-4 py-2 hover:bg-muted text-sm border-t text-black"
+                  >
+                    Historial de pagos
                   </Link>
                   <select
                     value={lang}
@@ -475,12 +481,19 @@ export default function Navbar() {
                 {actions.myChildren}
               </Link>
               <Link
-                href="/profile/payments"
+                href="/profile/cart"
                 className={`${linkClass} inline-flex items-center gap-2`}
                 onClick={() => setMenuOpen(false)}
               >
-                <span>Pagos</span>
+                <span>Carrito</span>
                 {cartItemsCount > 0 && renderCartNotificationIcon()}
+              </Link>
+              <Link
+                href="/profile/payments"
+                className={linkClass}
+                onClick={() => setMenuOpen(false)}
+              >
+                Historial de pagos
               </Link>
               <select
                 value={lang}


### PR DESCRIPTION
### Motivation
- Separar la opción única `Pagos` del dropdown de perfil en dos accesos claros: `Carrito` (actividades pendientes de pago) y `Historial de pagos` (pagos aprobados).

### Description
- Actualicé `src/components/navbar.tsx` para reemplazar el enlace único de `Pagos` por dos enlaces separados (`/profile/cart` y `/profile/payments`) tanto en la vista de escritorio como en mobile. 
- Añadí la nueva página `src/app/profile/cart/page.tsx` que reutiliza el componente `CartStatus` para mostrar sólo el estado del carrito. 
- Modifiqué `src/app/profile/payments/page.tsx` para eliminar la sección del carrito y ajustar título/descripcion para enfocarla en el historial de pagos aprobados. 
- Archivos tocados: `src/components/navbar.tsx`, `src/app/profile/cart/page.tsx`, `src/app/profile/payments/page.tsx`.

### Testing
- Ejecuté el lint con `pnpm -s lint` pero falló por una limitación del entorno al descargar `pnpm` vía `corepack` (errores de red/proxy), por lo que no se pudieron completar las verificaciones automáticas en este entorno. 
- No se ejecutaron otras pruebas automáticas debido a la misma restricción de red; se recomienda revisar en CI o en entorno local con dependencias resueltas para confirmar tipado y estilos.
- Unresolved risks: verificar en CI que las rutas ` /profile/cart` y `/profile/payments` funcionan con la misma autorización/guardas que antes y que no hay impactos en enlaces existentes o tests de integración.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1603f686c8333b8998c5cd0e0339a)