### PR TITLE
feat: integrate Chivo font across app

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -23,9 +23,10 @@
     --destructive-foreground: 0 0% 98%;
     --success: 160 55% 34%;
     --radius: 0.5rem;
-    --font-heading: Georgia, 'Times New Roman', serif;
-    --font-body:
-      system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+
+    /* Typography */
+    --font-heading: var(--font-chivo), system-ui, sans-serif;
+    --font-body: var(--font-chivo), system-ui, sans-serif;
   }
 
   * {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,18 @@
 import './globals.css';
 import type { ReactNode } from 'react';
 import type { Viewport } from 'next';
+import { Chivo } from 'next/font/google';
 import Navbar from '@/components/navbar';
 import Footer from '@/components/footer';
 import Providers from '@/components/providers';
 import { isMercadoPagoTestingEnvironment } from '@/lib/mercadopago';
+
+const chivo = Chivo({
+  subsets: ['latin'],
+  weight: ['300', '400', '500', '600', '700', '800', '900'],
+  variable: '--font-chivo',
+  display: 'swap',
+});
 
 export const dynamic = 'force-dynamic';
 
@@ -29,7 +37,7 @@ export default async function RootLayout({
 }) {
   return (
     <html lang="es">
-      <body className="min-h-screen text-foreground flex flex-col font-body">
+      <body className={`${chivo.variable} min-h-screen text-foreground flex flex-col font-body`}>
         <Providers>
           {isMercadoPagoTestingEnvironment() ? (
             <div className="w-full bg-yellow-300 text-yellow-950 text-sm font-semibold text-center py-2 px-4">


### PR DESCRIPTION
## Summary
Integrates Google Font **Chivo** as the primary typography across the Hualas app.

## Changes
- Added `next/font/google` Chivo loader
- Applied font via CSS variable `--font-chivo`
- Replaced body and heading fonts to use Chivo
- Maintained system fallbacks

## Why
Chivo provides a modern, clean, and highly readable UI suitable for Hualas design system.

## Visual impact
- Consistent typography across app
- Better readability
- Stronger brand identity

## Notes
No breaking changes expected.
