### PR TITLE
feat(checkout): sumar actividades en checkout antes del pago

### DIFF
--- a/src/app/activities/cart/page.tsx
+++ b/src/app/activities/cart/page.tsx
@@ -29,6 +29,13 @@ type QuoteResponse = {
   socialFeeAmount: number;
 };
 
+type AvailableActivity = {
+  id: string;
+  name: string;
+  date: string;
+  price: number;
+};
+
 function formatMoney(amount: number) {
   return `$${Number(amount).toLocaleString('es-AR')}`;
 }
@@ -42,6 +49,8 @@ export default function ActivitiesCartPage() {
   const [paymentMethod, setPaymentMethod] =
     useState<PaymentMethod>('MERCADO_PAGO');
   const [error, setError] = useState<string | null>(null);
+  const [availableActivities, setAvailableActivities] = useState<AvailableActivity[]>([]);
+  const [availableLoading, setAvailableLoading] = useState(false);
 
   useEffect(() => {
     const raw = window.localStorage.getItem(ACTIVITY_CART_STORAGE_KEY);
@@ -115,6 +124,45 @@ export default function ActivitiesCartPage() {
     return () => controller.abort();
   }, [hydrated, items]);
 
+  useEffect(() => {
+    if (!hydrated || items.length === 0) {
+      setAvailableActivities([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const fetchAvailable = async () => {
+      setAvailableLoading(true);
+      try {
+        const response = await fetch('/api/activities/cart/available', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items }),
+          signal: controller.signal,
+        });
+
+        const data = (await response.json().catch(() => ({}))) as {
+          activities?: AvailableActivity[];
+        };
+        if (!response.ok) {
+          setAvailableActivities([]);
+          return;
+        }
+
+        setAvailableActivities(Array.isArray(data.activities) ? data.activities : []);
+      } catch (fetchError) {
+        if ((fetchError as { name?: string } | null)?.name !== 'AbortError') {
+          setAvailableActivities([]);
+        }
+      } finally {
+        setAvailableLoading(false);
+      }
+    };
+
+    fetchAvailable();
+    return () => controller.abort();
+  }, [hydrated, items]);
+
   const persist = (next: ActivityCartItem[]) => {
     setItems(next);
     window.localStorage.setItem(
@@ -155,6 +203,8 @@ export default function ActivitiesCartPage() {
   };
 
   const canCheckout = !!quote && !quoteLoading && !submitting;
+  const defaultTarget = items[0]?.target ?? 'self';
+  const defaultTargetLabel = items[0]?.targetLabel ?? 'Para mí';
   const manualItems = items.map((item) => ({
     activityId: item.activityId,
     target: item.target === 'self' ? 'self' : item.target,
@@ -203,6 +253,52 @@ export default function ActivitiesCartPage() {
             ))}
           </section>
 
+          <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
+            <h2 className="text-lg font-semibold">Sumar actividades</h2>
+            <p className="text-sm text-muted-foreground">
+              Podés agregar otras actividades antes de finalizar el pago.
+            </p>
+            {availableLoading ? (
+              <p className="text-sm text-muted-foreground">Buscando actividades disponibles...</p>
+            ) : availableActivities.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No hay actividades adicionales disponibles.</p>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {availableActivities.map((activity) => (
+                  <article key={activity.id} className="rounded-md border p-4 space-y-2">
+                    <p className="font-medium">{activity.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(activity.date).toLocaleString('es-AR', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </p>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-semibold">{formatMoney(activity.price)}</span>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          persist([
+                            ...items,
+                            {
+                              activityId: activity.id,
+                              activityName: activity.name,
+                              price: activity.price,
+                              target: defaultTarget,
+                              targetLabel: defaultTargetLabel,
+                            },
+                          ])
+                        }
+                      >
+                        Agregar
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+
           <section className="grid gap-4 rounded-xl border bg-card p-5 shadow-sm md:grid-cols-2">
             <div className="space-y-3">
               <h2 className="text-lg font-semibold">Resumen</h2>
@@ -212,6 +308,14 @@ export default function ActivitiesCartPage() {
                 </p>
               ) : quote ? (
                 <div className="space-y-2 text-sm">
+                  <div className="space-y-1">
+                    {quote.activityLines.map((line, index) => (
+                      <div key={`${line.id}-${index}`} className="flex items-center justify-between gap-4">
+                        <span>{line.name} · {line.targetLabel}</span>
+                        <span className="font-medium">{formatMoney(line.amount)}</span>
+                      </div>
+                    ))}
+                  </div>
                   <div className="flex items-center justify-between gap-4">
                     <span>Subtotal actividades</span>
                     <span className="font-medium">

--- a/src/app/api/activities/cart/available/route.ts
+++ b/src/app/api/activities/cart/available/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+type CartItem = {
+  activityId: string;
+};
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  const items = Array.isArray((payload as { items?: unknown } | null)?.items)
+    ? ((payload as { items: CartItem[] }).items ?? [])
+    : [];
+
+  const excludedIds = new Set(items.map((item) => item.activityId));
+
+  const activities = await prisma.activity.findMany({
+    where: {
+      id: { notIn: [...excludedIds] },
+      date: { gte: new Date() },
+    },
+    select: {
+      id: true,
+      name: true,
+      date: true,
+      price: true,
+      capacity: true,
+      _count: {
+        select: { participants: true },
+      },
+    },
+    orderBy: { date: 'asc' },
+    take: 20,
+  });
+
+  const available = activities
+    .filter(
+      (activity) =>
+        activity.capacity == null || activity._count.participants < activity.capacity
+    )
+    .map((activity) => ({
+      id: activity.id,
+      name: activity.name,
+      date: activity.date,
+      price: activity.price,
+      hasAvailability:
+        activity.capacity == null || activity._count.participants < activity.capacity,
+    }));
+
+  return NextResponse.json({ activities: available });
+}

--- a/src/lib/cart-checkout.ts
+++ b/src/lib/cart-checkout.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { getActivityParticipantKey } from '@/lib/activity-participants';
 import {
   getSocialFeeAmount,
   hasSocialFeeForCurrentMonth,
@@ -64,6 +65,17 @@ export async function buildCartQuote({
   }
 
   const uniqueIds = [...new Set(items.map((item) => item.activityId))];
+  const seenSelections = new Set<string>();
+  for (const item of items) {
+    const selectionKey = `${item.activityId}:${normalizeTarget(item.target) ?? 'self'}`;
+    if (seenSelections.has(selectionKey)) {
+      throw new CartQuoteError(
+        409,
+        'No podés agregar la misma actividad más de una vez para la misma inscripción.'
+      );
+    }
+    seenSelections.add(selectionKey);
+  }
   const activities = await prisma.activity.findMany({
     where: { id: { in: uniqueIds } },
     include: { participants: { select: { id: true } } },
@@ -119,6 +131,29 @@ export async function buildCartQuote({
         'Uno de los hijos seleccionados no pertenece al usuario.'
       );
     }
+  }
+
+  const participantKeys = items.map((item) =>
+    getActivityParticipantKey(item.activityId, userId, normalizeTarget(item.target))
+  );
+  const existingParticipants = await prisma.activityParticipant.findMany({
+    where: {
+      participantKey: { in: participantKeys },
+    },
+    select: {
+      participantKey: true,
+      activity: { select: { name: true } },
+    },
+  });
+
+  if (existingParticipants.length > 0) {
+    const repeatedActivityName = existingParticipants[0]?.activity.name;
+    throw new CartQuoteError(
+      409,
+      repeatedActivityName
+        ? `Ya existe una inscripción para ${repeatedActivityName}.`
+        : 'Ya existe una inscripción para una de las actividades seleccionadas.'
+    );
   }
 
   const activityLines = items.map((item) => {


### PR DESCRIPTION
- what changed
  - Se agregó en la página de checkout (`/activities/cart`) una sección “Sumar actividades” que muestra cards con actividades disponibles (nombre, fecha/hora, precio) y un botón `Agregar` para incorporarlas al carrito sin romper el flujo de pago.
- files touched
  - `src/app/activities/cart/page.tsx`
  - `src/app/api/activities/cart/available/route.ts`
  - `src/lib/cart-checkout.ts`
- tests or verification run
  - Se intentó ejecutar `pnpm lint`, pero falló por restricciones de red al descargar `pnpm` vía `corepack` (error HTTP tunneling 403), por lo que no se ejecutaron comprobaciones automáticas en el entorno.
- unresolved risks
  - Las actividades agregadas se asignan automáticamente al mismo `target` de la primera inscripción del carrito y no hay selector por card en esta versión; además la verificación automática quedó pendiente por el fallo de `pnpm lint` en el entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d10391a483338cefba22ad583e5d)