### PR TITLE
Allow adding available activities to cart and enforce duplicate/existing enrollment checks

### DIFF
--- a/src/app/activities/cart/page.tsx
+++ b/src/app/activities/cart/page.tsx
@@ -29,6 +29,19 @@ type QuoteResponse = {
   socialFeeAmount: number;
 };
 
+type AvailableActivity = {
+  id: string;
+  name: string;
+  date: string;
+  price: number;
+};
+
+type ChildOption = {
+  id: string;
+  name: string;
+  lastName?: string | null;
+};
+
 function formatMoney(amount: number) {
   return `$${Number(amount).toLocaleString('es-AR')}`;
 }
@@ -42,6 +55,25 @@ export default function ActivitiesCartPage() {
   const [paymentMethod, setPaymentMethod] =
     useState<PaymentMethod>('MERCADO_PAGO');
   const [error, setError] = useState<string | null>(null);
+  const [availableActivities, setAvailableActivities] = useState<AvailableActivity[]>([]);
+  const [availableLoading, setAvailableLoading] = useState(false);
+  const [children, setChildren] = useState<ChildOption[]>([]);
+  const [selectedTarget, setSelectedTarget] = useState('self');
+
+  useEffect(() => {
+    const fetchChildren = async () => {
+      try {
+        const response = await fetch('/api/children');
+        if (!response.ok) return;
+        const data = (await response.json().catch(() => [])) as ChildOption[];
+        setChildren(Array.isArray(data) ? data : []);
+      } catch {
+        setChildren([]);
+      }
+    };
+
+    fetchChildren();
+  }, []);
 
   useEffect(() => {
     const raw = window.localStorage.getItem(ACTIVITY_CART_STORAGE_KEY);
@@ -115,6 +147,45 @@ export default function ActivitiesCartPage() {
     return () => controller.abort();
   }, [hydrated, items]);
 
+  useEffect(() => {
+    if (!hydrated || items.length === 0) {
+      setAvailableActivities([]);
+      return;
+    }
+
+    const controller = new AbortController();
+    const fetchAvailable = async () => {
+      setAvailableLoading(true);
+      try {
+        const response = await fetch('/api/activities/cart/available', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ items }),
+          signal: controller.signal,
+        });
+
+        const data = (await response.json().catch(() => ({}))) as {
+          activities?: AvailableActivity[];
+        };
+        if (!response.ok) {
+          setAvailableActivities([]);
+          return;
+        }
+
+        setAvailableActivities(Array.isArray(data.activities) ? data.activities : []);
+      } catch (fetchError) {
+        if ((fetchError as { name?: string } | null)?.name !== 'AbortError') {
+          setAvailableActivities([]);
+        }
+      } finally {
+        setAvailableLoading(false);
+      }
+    };
+
+    fetchAvailable();
+    return () => controller.abort();
+  }, [hydrated, items]);
+
   const persist = (next: ActivityCartItem[]) => {
     setItems(next);
     window.localStorage.setItem(
@@ -155,6 +226,11 @@ export default function ActivitiesCartPage() {
   };
 
   const canCheckout = !!quote && !quoteLoading && !submitting;
+  const selectedChild = children.find((child) => child.id === selectedTarget);
+  const selectedTargetLabel =
+    selectedTarget === 'self'
+      ? 'Para mí'
+      : `${selectedChild?.name ?? 'Menor'} ${selectedChild?.lastName ?? ''}`.trim();
   const manualItems = items.map((item) => ({
     activityId: item.activityId,
     target: item.target === 'self' ? 'self' : item.target,
@@ -203,6 +279,70 @@ export default function ActivitiesCartPage() {
             ))}
           </section>
 
+          <section className="rounded-xl border bg-card p-5 shadow-sm space-y-3">
+            <h2 className="text-lg font-semibold">Sumar actividades</h2>
+            <p className="text-sm text-muted-foreground">
+              Podés agregar otras actividades antes de finalizar el pago.
+            </p>
+            <div className="space-y-1">
+              <label htmlFor="additional-target" className="text-sm font-medium">
+                Inscribir a
+              </label>
+              <select
+                id="additional-target"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                value={selectedTarget}
+                onChange={(event) => setSelectedTarget(event.target.value)}
+              >
+                <option value="self">Para mí</option>
+                {children.map((child) => (
+                  <option key={child.id} value={child.id}>
+                    {`${child.name} ${child.lastName ?? ''}`.trim()}
+                  </option>
+                ))}
+              </select>
+            </div>
+            {availableLoading ? (
+              <p className="text-sm text-muted-foreground">Buscando actividades disponibles...</p>
+            ) : availableActivities.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No hay actividades adicionales disponibles.</p>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2">
+                {availableActivities.map((activity) => (
+                  <article key={activity.id} className="rounded-md border p-4 space-y-2">
+                    <p className="font-medium">{activity.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {new Date(activity.date).toLocaleString('es-AR', {
+                        dateStyle: 'medium',
+                        timeStyle: 'short',
+                      })}
+                    </p>
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="font-semibold">{formatMoney(activity.price)}</span>
+                      <Button
+                        variant="outline"
+                        onClick={() =>
+                          persist([
+                            ...items,
+                            {
+                              activityId: activity.id,
+                              activityName: activity.name,
+                              price: activity.price,
+                              target: selectedTarget,
+                              targetLabel: selectedTargetLabel,
+                            },
+                          ])
+                        }
+                      >
+                        Agregar
+                      </Button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+          </section>
+
           <section className="grid gap-4 rounded-xl border bg-card p-5 shadow-sm md:grid-cols-2">
             <div className="space-y-3">
               <h2 className="text-lg font-semibold">Resumen</h2>
@@ -212,6 +352,14 @@ export default function ActivitiesCartPage() {
                 </p>
               ) : quote ? (
                 <div className="space-y-2 text-sm">
+                  <div className="space-y-1">
+                    {quote.activityLines.map((line, index) => (
+                      <div key={`${line.id}-${index}`} className="flex items-center justify-between gap-4">
+                        <span>{line.name} · {line.targetLabel}</span>
+                        <span className="font-medium">{formatMoney(line.amount)}</span>
+                      </div>
+                    ))}
+                  </div>
                   <div className="flex items-center justify-between gap-4">
                     <span>Subtotal actividades</span>
                     <span className="font-medium">

--- a/src/app/api/activities/cart/available/route.ts
+++ b/src/app/api/activities/cart/available/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+type CartItem = {
+  activityId: string;
+};
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid body' }, { status: 400 });
+  }
+
+  const items = Array.isArray((payload as { items?: unknown } | null)?.items)
+    ? ((payload as { items: CartItem[] }).items ?? [])
+    : [];
+
+  const excludedIds = new Set(items.map((item) => item.activityId));
+
+  const activities = await prisma.activity.findMany({
+    where: {
+      id: { notIn: [...excludedIds] },
+      date: { gte: new Date() },
+    },
+    select: {
+      id: true,
+      name: true,
+      date: true,
+      price: true,
+      capacity: true,
+      _count: {
+        select: { participants: true },
+      },
+    },
+    orderBy: { date: 'asc' },
+    take: 20,
+  });
+
+  const available = activities
+    .filter(
+      (activity) =>
+        activity.capacity == null || activity._count.participants < activity.capacity
+    )
+    .map((activity) => ({
+      id: activity.id,
+      name: activity.name,
+      date: activity.date,
+      price: activity.price,
+      hasAvailability:
+        activity.capacity == null || activity._count.participants < activity.capacity,
+    }));
+
+  return NextResponse.json({ activities: available });
+}

--- a/src/lib/cart-checkout.ts
+++ b/src/lib/cart-checkout.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { getActivityParticipantKey } from '@/lib/activity-participants';
 import {
   getSocialFeeAmount,
   hasSocialFeeForCurrentMonth,
@@ -64,6 +65,17 @@ export async function buildCartQuote({
   }
 
   const uniqueIds = [...new Set(items.map((item) => item.activityId))];
+  const seenSelections = new Set<string>();
+  for (const item of items) {
+    const selectionKey = `${item.activityId}:${normalizeTarget(item.target) ?? 'self'}`;
+    if (seenSelections.has(selectionKey)) {
+      throw new CartQuoteError(
+        409,
+        'No podés agregar la misma actividad más de una vez para la misma inscripción.'
+      );
+    }
+    seenSelections.add(selectionKey);
+  }
   const activities = await prisma.activity.findMany({
     where: { id: { in: uniqueIds } },
     include: { participants: { select: { id: true } } },
@@ -119,6 +131,29 @@ export async function buildCartQuote({
         'Uno de los hijos seleccionados no pertenece al usuario.'
       );
     }
+  }
+
+  const participantKeys = items.map((item) =>
+    getActivityParticipantKey(item.activityId, userId, normalizeTarget(item.target))
+  );
+  const existingParticipants = await prisma.activityParticipant.findMany({
+    where: {
+      participantKey: { in: participantKeys },
+    },
+    select: {
+      participantKey: true,
+      activity: { select: { name: true } },
+    },
+  });
+
+  if (existingParticipants.length > 0) {
+    const repeatedActivityName = existingParticipants[0]?.activity.name;
+    throw new CartQuoteError(
+      409,
+      repeatedActivityName
+        ? `Ya existe una inscripción para ${repeatedActivityName}.`
+        : 'Ya existe una inscripción para una de las actividades seleccionadas.'
+    );
   }
 
   const activityLines = items.map((item) => {


### PR DESCRIPTION
### Motivation
- Provide a way for users to discover and add other upcoming activities to the current cart before checkout. 
- Ensure the cart quote prevents adding the same activity multiple times for the same target. 
- Prevent checkout attempts when the user (or child) is already enrolled in any of the selected activities.

### Description
- Added a new API route `POST /api/activities/cart/available` which returns up to 20 upcoming activities with remaining capacity excluding items already in the cart. 
- Extended the cart UI to fetch children (`/api/children`), fetch available activities for the current cart, show a selector for `Para mí` or a child, and allow adding an available activity into local storage-backed cart; also display activity lines in the summary. 
- Hardened the server-side quote builder in `buildCartQuote` to reject duplicate selections of the same activity+target and to detect existing `activityParticipant` records using `getActivityParticipantKey`, returning `409` with descriptive messages when conflicts are found.

### Testing
- Ran TypeScript type-checking with `tsc --noEmit` and it completed successfully. 
- Executed the existing automated test suite with `pnpm test` and all tests passed. 
- Exercised the new API route via the added flows in the application during automated request tests and received expected JSON responses (no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d10391a483338cefba22ad583e5d)