### PR TITLE
[codex] fix push notification VAPID config

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,6 @@ import './globals.css';
 import type { ReactNode } from 'react';
 import type { Viewport } from 'next';
 import { Chivo } from 'next/font/google';
-import Script from 'next/script';
 import Navbar from '@/components/navbar';
 import Footer from '@/components/footer';
 import Providers from '@/components/providers';
@@ -46,16 +45,6 @@ export default async function RootLayout({
 }) {
   return (
     <html lang="es">
-      <head>
-        <Script id="pushalert-unified-code" strategy="beforeInteractive">
-          {`(function(d, t) {
-    var g = d.createElement(t),
-    s = d.getElementsByTagName(t)[0];
-    g.src = "https://cdn.pushalert.co/unified_bb185d3211576a36bc9a0d4726b49fc2.js";
-    s.parentNode.insertBefore(g, s);
-}(document, "script"));`}
-        </Script>
-      </head>
       <body
         className={`${chivo.variable} min-h-screen text-foreground flex flex-col font-body`}
       >

--- a/src/app/profile/notifications/page.tsx
+++ b/src/app/profile/notifications/page.tsx
@@ -137,6 +137,10 @@ export default async function NotificationsPreferencesPage() {
     addedAt: s.createdAt.toISOString(),
     failed: !!s.failedAt,
   }));
+  const vapidConfigured =
+    !!process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY &&
+    !!process.env.VAPID_PRIVATE_KEY &&
+    !!process.env.VAPID_SUBJECT;
 
   return (
     <main className="max-w-3xl mx-auto px-4 py-8">
@@ -146,6 +150,13 @@ export default async function NotificationsPreferencesPage() {
       <p className="text-sm text-gray-600 mb-6">
         Elegí qué notificaciones querés recibir y cómo.
       </p>
+      {!vapidConfigured ? (
+        <div className="mb-6 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          Faltan variables VAPID en el entorno. Sin `NEXT_PUBLIC_VAPID_PUBLIC_KEY`,
+          `VAPID_PRIVATE_KEY` y `VAPID_SUBJECT`, no se pueden suscribir ni enviar
+          push notifications.
+        </div>
+      ) : null}
       <PreferencesForm items={items} devices={devices} />
     </main>
   );

--- a/src/app/profile/notifications/preferences-form.tsx
+++ b/src/app/profile/notifications/preferences-form.tsx
@@ -77,7 +77,12 @@ export default function PreferencesForm({ items: initialItems, devices: initialD
       if (result === 'granted' && 'serviceWorker' in navigator) {
         const reg = await navigator.serviceWorker.ready;
         const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
-        if (!publicKey) return;
+        if (!publicKey) {
+          console.error(
+            '[preferences] NEXT_PUBLIC_VAPID_PUBLIC_KEY is missing. Browser push subscriptions are disabled.',
+          );
+          return;
+        }
         const padding = '='.repeat((4 - (publicKey.length % 4)) % 4);
         const base64 = (publicKey + padding).replace(/-/g, '+').replace(/_/g, '/');
         const raw = atob(base64);

--- a/src/components/notifications/push-manager.tsx
+++ b/src/components/notifications/push-manager.tsx
@@ -92,7 +92,12 @@ export default function PushManager() {
 
   async function ensureSubscription(reg: ServiceWorkerRegistration): Promise<void> {
     const publicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
-    if (!publicKey) return;
+    if (!publicKey) {
+      console.error(
+        '[push-manager] NEXT_PUBLIC_VAPID_PUBLIC_KEY is missing. Browser push subscriptions are disabled.',
+      );
+      return;
+    }
     const existing = await reg.pushManager.getSubscription();
     if (existing) {
       await postSubscription(existing);


### PR DESCRIPTION
## What changed
- Removed the external PushAlert script from the root layout so the app uses its own Web Push/VAPID flow.
- Added a visible warning when the VAPID env vars are missing in the browser push settings page.
- Added explicit client-side errors when `NEXT_PUBLIC_VAPID_PUBLIC_KEY` is missing so the subscription flow does not fail silently.

## Why
- The app already uses self-hosted Web Push with VAPID, so the external PushAlert loader was conflicting with the native push flow.
- We need push subscriptions to fail loudly when the env configuration is incomplete instead of silently doing nothing.

## Validation
- `npm run lint`
- `npm run build`