### PR TITLE
Adjust login redirect for users without activities

### DIFF
--- a/src/app/api/auth/post-login-redirect/route.ts
+++ b/src/app/api/auth/post-login-redirect/route.ts
@@ -1,0 +1,34 @@
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { isCounterRole } from '@/lib/accounting';
+import { prisma } from '@/lib/prisma';
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return NextResponse.json({ redirectUrl: '/login' }, { status: 401 });
+  }
+
+  if (isCounterRole(session.user.role)) {
+    return NextResponse.json({ redirectUrl: '/accounting' });
+  }
+
+  const userId = session.user.id;
+
+  const [participantCount, professorCount] = await Promise.all([
+    prisma.activityParticipant.count({
+      where: {
+        OR: [{ userId }, { child: { userId } }],
+      },
+    }),
+    prisma.activityProfessor.count({ where: { userId } }),
+  ]);
+
+  const hasActivities = participantCount > 0 || professorCount > 0;
+
+  return NextResponse.json({
+    redirectUrl: hasActivities ? '/my-activities' : '/',
+  });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,7 +30,19 @@ export default function LoginPage() {
       setError('invalidCredentials');
     } else {
       setSuccess('Login successful');
-      setTimeout(() => router.push('/my-activities'), 1000);
+
+      try {
+        const redirectResponse = await fetch('/api/auth/post-login-redirect', {
+          method: 'GET',
+        });
+        const data = (await redirectResponse.json()) as {
+          redirectUrl?: string;
+        };
+
+        setTimeout(() => router.push(data.redirectUrl ?? '/'), 1000);
+      } catch {
+        setTimeout(() => router.push('/'), 1000);
+      }
     }
   };
 
@@ -110,7 +122,7 @@ export default function LoginPage() {
 
           <Button
             className="w-full flex items-center justify-center gap-2 bg-white border border-border text-foreground hover:bg-muted"
-            onClick={() => signIn('google', { callbackUrl: '/my-activities' })}
+            onClick={() => signIn('google', { callbackUrl: '/' })}
           >
             <Image src="/google.svg" alt="Google logo" width={18} height={18} />
             {t.signInWithGoogle}


### PR DESCRIPTION
### Motivation
- Avoid sending newly logged-in users who have no activity registrations to `/my-activities`; instead send them to the home page and keep accounting-role users routed to `/accounting`.

### Description
- Added an authenticated endpoint `GET /api/auth/post-login-redirect` at `src/app/api/auth/post-login-redirect/route.ts` that returns `redirectUrl` based on the current user's role and whether they have any `ActivityParticipant` or `ActivityProfessor` records.
- Updated the credentials login flow in `src/app/login/page.tsx` to call the new endpoint after successful sign-in and redirect the user to the `redirectUrl` returned by the server, falling back to `/` on error.
- Changed the Google sign-in button to use `callbackUrl: '/'` to avoid forcing OAuth logins into `/my-activities` when the user has no activities.
- Files touched: `src/app/api/auth/post-login-redirect/route.ts`, `src/app/login/page.tsx`.

### Testing
- Ran `pnpm -s lint` successfully (repository had unrelated Prettier warnings prior to this change). 
- No unit or integration tests were modified or added as part of this change.
- Unresolved risks: the OAuth provider callback currently uses a static `callbackUrl` and does not apply the same conditional post-login routing logic returned by the new endpoint; if the same behavior is desired for provider logins, NextAuth provider callback handling should be extended to consult the same decision logic on sign-in.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5168bd23483289e49526657de1841)