### PR TITLE
Fix manual payment unit in accounting summaries

### DIFF
--- a/src/lib/__tests__/accounting.test.ts
+++ b/src/lib/__tests__/accounting.test.ts
@@ -4,13 +4,13 @@ import {
 } from '../accounting';
 
 describe('accounting helpers', () => {
-  it('normalizes manual payments from pesos to accounting cents', () => {
+  it('returns manual payment amount as stored for accounting summaries', () => {
     expect(
       getAccountingManualPaymentAmount({
         amount: 18,
         order: { total: 18 },
       })
-    ).toBe(1800);
+    ).toBe(18);
   });
 
   it('falls back to order total when the payment amount is zero', () => {
@@ -19,7 +19,7 @@ describe('accounting helpers', () => {
         amount: 0,
         order: { total: 9 },
       })
-    ).toBe(900);
+    ).toBe(9);
   });
 
   it('falls back to updatedAt or createdAt for manual payment dates', () => {

--- a/src/lib/accounting.ts
+++ b/src/lib/accounting.ts
@@ -59,7 +59,7 @@ export function getAccountingManualPaymentAmount(
   const rawAmount =
     payment.amount !== 0 ? payment.amount : (payment.order?.total ?? 0);
 
-  return rawAmount * 100;
+  return rawAmount;
 }
 
 export function formatPersonName(


### PR DESCRIPTION
### Motivation
- The accounting summary treated manual transfer amounts as centavos by multiplying stored values again, causing manual payments to appear 100x smaller; this change ensures manual payments are interpreted in the same unit they are stored.

### Description
- Adjusted `getAccountingManualPaymentAmount` to return the stored `rawAmount` directly instead of multiplying by 100, and updated the helper unit test to reflect this behavior; files changed: `src/lib/accounting.ts`, `src/lib/__tests__/accounting.test.ts`.

### Testing
- Ran unit tests for the accounting helper: `pnpm test src/lib/__tests__/accounting.test.ts` and all tests passed (3 tests).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51c10b0f8832899221804da82dc85)