### PR TITLE
Guardar pagos manuales en centavos ARS y normalizar registros legados

### DIFF
--- a/src/lib/accounting.ts
+++ b/src/lib/accounting.ts
@@ -59,6 +59,12 @@ export function getAccountingManualPaymentAmount(
   const rawAmount =
     payment.amount !== 0 ? payment.amount : (payment.order?.total ?? 0);
 
+  // Legacy manual payments may have been stored in pesos instead of cents.
+  // If amount matches order total exactly, treat it as pesos and normalize.
+  if (payment.order?.total != null && rawAmount === payment.order.total) {
+    return rawAmount * 100;
+  }
+
   return rawAmount;
 }
 

--- a/src/lib/services/manual-payment-service.ts
+++ b/src/lib/services/manual-payment-service.ts
@@ -413,7 +413,7 @@ export async function createManualPaymentCheckout(input: {
           orderId: order.id,
           provider: 'MANUAL_TRANSFER',
           providerPaymentId: null,
-          amount: input.quote.totalAmount,
+          amount: input.quote.totalAmount * 100,
           currency: 'ARS',
           status: 'PENDING',
           payerName:


### PR DESCRIPTION
### Motivation
- Los pagos manuales subidos desde el checkout se registraban en pesos (ARS) mientras que la contaduría y los reportes esperan valores en centavos, lo que provoca importes incorrectos en reportes.
- Necesidad de compatibilidad con filas históricas que pudieron guardarse en pesos en lugar de centavos.

### Description
- Al crear un `Payment` de tipo `MANUAL_TRANSFER` ahora se almacena el `amount` como `input.quote.totalAmount * 100` para persistir centavos en la base (`src/lib/services/manual-payment-service.ts`).
- Se añadió una normalización en `getAccountingManualPaymentAmount` que detecta pagos legados donde `payment.amount === order.total` y los convierte a centavos (`* 100`) antes de usarlos en vistas/exports (`src/lib/accounting.ts`).
- Los cambios preservan la moneda `currency: 'ARS'` y son retrocompatibles para evitar romper reportes existentes.

### Testing
- Ejecuté el chequeo de tipos TypeScript con `pnpm -s exec tsc --noEmit`, que falló por errores de tipado preexistentes en `tests/api/pickup-notices.test.ts` que no están relacionados con este cambio, por lo que no se considera regresión del PR.
- No se añadieron tests automatizados nuevos; la verificación funcional debe realizarse en entorno local revisando un flujo de checkout manual y los listados/reportes de contaduría para confirmar montos correctos en centavos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f520c148648328b1ce7c420b505e4a)