### PR TITLE
Permitir seleccionar grupo por sesión al crear actividades anuales

### DIFF
--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -24,6 +24,7 @@ type AnnualScheduleDraft = {
   weekday: string;
   schedule: string;
   description: string;
+  groupTempId: string;
   geoLocation: string;
   coordinates: Coordinates | null;
 };
@@ -58,6 +59,7 @@ function createEmptyAnnualScheduleDraft(): AnnualScheduleDraft {
     weekday: '1',
     schedule: '',
     description: '',
+    groupTempId: '',
     geoLocation: '',
     coordinates: null,
   };
@@ -181,6 +183,7 @@ export default function CreateActivityForm({
                 weekday: Number(draft.weekday),
                 schedule: draft.schedule.trim(),
                 description: draft.description.trim() || undefined,
+                groupTempId: draft.groupTempId || undefined,
                 geoLocation: draft.geoLocation.trim(),
                 latitude: draft.coordinates.latitude,
                 longitude: draft.coordinates.longitude,
@@ -200,6 +203,11 @@ export default function CreateActivityForm({
           price: Number(price),
           capacity: capacity ? Number(capacity) : undefined,
           professorIds,
+          groups: groups.map((group) => ({
+            tempId: group.tempId,
+            name: group.name,
+            description: group.description || undefined,
+          })),
           annualSchedules: normalizedAnnualSchedules,
         }),
       });
@@ -210,23 +218,6 @@ export default function CreateActivityForm({
       }
 
       const json = await res.json();
-
-      for (const group of groups) {
-        const groupRes = await fetch(`/api/activities/${json.id}/groups`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            name: group.name,
-            description: group.description || undefined,
-          }),
-        });
-
-        if (!groupRes.ok) {
-          throw new Error(
-            'La actividad se creó, pero falló la creación de grupos'
-          );
-        }
-      }
 
       setSuccess('Actividad creada');
       resetForm();
@@ -389,6 +380,26 @@ export default function CreateActivityForm({
                       }
                       className={inputClass}
                     />
+                  </div>
+
+                  <div className="space-y-1">
+                    <label className="text-sm font-medium">Grupo</label>
+                    <select
+                      value={draft.groupTempId}
+                      onChange={(e) =>
+                        updateAnnualScheduleDraft(draft.tempId, {
+                          groupTempId: e.target.value,
+                        })
+                      }
+                      className={inputClass}
+                    >
+                      <option value="">Sin grupo</option>
+                      {groups.map((group) => (
+                        <option key={group.tempId} value={group.tempId}>
+                          {group.name}
+                        </option>
+                      ))}
+                    </select>
                   </div>
 
                   <input

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -74,6 +74,21 @@ export async function POST(req: Request) {
       });
     }
 
+    const groupIdByTempId = new Map<string, string>();
+    if (data.groups.length > 0) {
+      for (const group of data.groups) {
+        const createdGroup = await tx.activityGroup.create({
+          data: {
+            activityId,
+            name: group.name,
+            description: group.description,
+          },
+          select: { id: true },
+        });
+        groupIdByTempId.set(group.tempId, createdGroup.id);
+      }
+    }
+
     if (data.activityType === 'ANNUAL') {
       const annualDays = buildAnnualActivityDays(
         data.date,
@@ -82,6 +97,14 @@ export async function POST(req: Request) {
       );
 
       for (const day of annualDays) {
+        const activityGroupId = day.groupTempId
+          ? groupIdByTempId.get(day.groupTempId)
+          : null;
+
+        if (day.groupTempId && !activityGroupId) {
+          throw new Error('Una sesión anual referencia un grupo inválido');
+        }
+
         const activityDay = await tx.activityDay.create({
           data: {
             activityId,
@@ -89,6 +112,7 @@ export async function POST(req: Request) {
             date: day.date,
             schedule: day.schedule,
             description: day.description,
+            activityGroupId,
             geoLocation: day.geoLocation,
             latitude: day.latitude,
             longitude: day.longitude,

--- a/src/lib/activities/annual-schedule.ts
+++ b/src/lib/activities/annual-schedule.ts
@@ -2,6 +2,7 @@ type AnnualScheduleTemplate = {
   weekday: number;
   schedule: string;
   description?: string;
+  groupTempId?: string;
   geoLocation: string;
   latitude: number;
   longitude: number;

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -25,9 +25,16 @@ const annualScheduleSchema = z.object({
   weekday: z.number().int().min(0).max(6),
   schedule: z.string().min(1),
   description: z.string().optional(),
+  groupTempId: z.string().min(1).optional(),
   geoLocation: z.string().min(1),
   latitude: z.number(),
   longitude: z.number(),
+});
+
+const activityGroupDraftSchema = z.object({
+  tempId: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string().optional(),
 });
 
 const activityBaseSchema = z.object({
@@ -48,6 +55,7 @@ const activityBaseSchema = z.object({
 
 export const activityCreateSchema = activityBaseSchema
   .extend({
+    groups: z.array(activityGroupDraftSchema).optional().default([]),
     annualSchedules: z.array(annualScheduleSchema).optional().default([]),
   })
   .superRefine((data, ctx) => {


### PR DESCRIPTION
### Motivation
- Al crear una actividad de tipo anual, cada sesión (sesión semanal) debe poder asociarse a un grupo específico desde el formulario de creación para mantener la relación sesión→grupo al persistir la actividad.

### Description
- Se agregó `groupTempId` a cada draft de sesión anual y un selector de grupo en el bloque de cada sesión para elegir un grupo (o "Sin grupo").
- El formulario ahora envía `groups` (borradores de grupos) junto con `annualSchedules` en el mismo payload al `POST /api/activities` en vez de crear los grupos en llamadas separadas después de crear la actividad.
- El backend crea los grupos dentro de la misma transacción, mapea `tempId -> activityGroupId` y asigna `activityGroupId` a cada `ActivityDay` generado por `buildAnnualActivityDays` según la selección de la sesión.
- Archivos modificados: `src/app/activities/new/form.tsx`, `src/lib/validations/activity.ts`, `src/app/api/activities/route.ts`, `src/lib/activities/annual-schedule.ts`.

### Testing
- Se ejecutó `pnpm lint` y completó correctamente; el linter reportó warnings preexistentes de formato en archivos no relacionados, sin errores que bloqueen el cambio.
- No se ejecutaron tests unitarios adicionales en esta PR.
- Riesgos no resueltos: si una sesión anual referencia un `groupTempId` inexistente el backend lanza un error genérico (se detecta y aborta la transacción), por lo que la respuesta al cliente depende del manejo global de errores (mensaje no tipado con status 400 en el payload actual).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f52f3fa650832881a0f29482984cbc)