### PR TITLE
Fix same-day activity session creation date handling

### DIFF
--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -123,7 +123,18 @@ export const activityGroupCreateSchema = z.object({
 });
 
 export const activityDayCreateSchema = z.object({
-  date: z.string().transform((d) => new Date(d)),
+  date: z.string().min(1).transform((value, ctx) => {
+    const parsed = parseDateInput(value);
+    if (Number.isNaN(parsed.getTime())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Fecha inválida',
+      });
+      return z.NEVER;
+    }
+
+    return parsed;
+  }),
   schedule: z.string().min(1),
   description: z.string().optional(),
   geoLocation: z.string().min(1),


### PR DESCRIPTION
### Motivation
- Fix a bug that blocked or mis-handled creating activity sessions for the same day by avoiding naive `new Date(...)` parsing that caused timezone shifts on `YYYY-MM-DD` inputs.

### Description
- Replaced the `date` transform in `activityDayCreateSchema` to use the existing `parseDateInput` UTC-safe parser and added explicit invalid-date validation, in `src/lib/validations/activity.ts`.

### Testing
- Ran `pnpm -s lint` which completed successfully (the repo still contains pre-existing prettier/lint warnings unrelated to this change, which remain as a residual risk).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53626ce90832897c7cc5ffe5751fc)