### PR TITLE
Add unified search across accounting finance lists

### DIFF
--- a/src/app/accounting/manual-payments/page.tsx
+++ b/src/app/accounting/manual-payments/page.tsx
@@ -7,6 +7,7 @@ import ManualPaymentsDashboard from '@/components/accounting/manual-payments-das
 
 type SearchParams = {
   status?: string;
+  q?: string;
   page?: string;
   limit?: string;
 };
@@ -33,9 +34,11 @@ export default async function ManualPaymentsPage({
     searchParams.status === 'REJECTED'
       ? searchParams.status
       : null;
+  const q = searchParams.q?.trim() ?? '';
 
   const result = await listManualPayments({
     status,
+    q,
     limit,
     offset,
   });
@@ -62,6 +65,16 @@ export default async function ManualPaymentsPage({
             <option value="APPROVED">Aprobados</option>
             <option value="REJECTED">Rechazados</option>
           </select>
+        </label>
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Buscar</span>
+          <input
+            type="text"
+            name="q"
+            defaultValue={q}
+            placeholder="Nombre, apellido, actividad o mail"
+            className="h-10 rounded-md border border-input bg-background px-3 py-2 text-sm"
+          />
         </label>
         <label className="space-y-1 text-sm">
           <span className="font-medium">Cantidad por página</span>

--- a/src/app/accounting/movements/movements-table.tsx
+++ b/src/app/accounting/movements/movements-table.tsx
@@ -35,12 +35,13 @@ export default function MovementsTable({
   initialFilters,
 }: {
   movements: Movement[];
-  initialFilters: { type: string; from: string; to: string };
+  initialFilters: { type: string; from: string; to: string; q: string };
 }) {
   const router = useRouter();
   const [type, setType] = useState(initialFilters.type);
   const [from, setFrom] = useState(initialFilters.from);
   const [to, setTo] = useState(initialFilters.to);
+  const [q, setQ] = useState(initialFilters.q);
   const [deletingId, setDeletingId] = useState('');
 
   const applyFilters = () => {
@@ -48,6 +49,7 @@ export default function MovementsTable({
     if (type) params.set('type', type);
     if (from) params.set('from', from);
     if (to) params.set('to', to);
+    if (q.trim()) params.set('q', q.trim());
     const query = params.toString();
     router.push(
       query ? `/accounting/movements?${query}` : '/accounting/movements'
@@ -59,6 +61,7 @@ export default function MovementsTable({
     setType('');
     setFrom('');
     setTo('');
+    setQ('');
     router.push('/accounting/movements');
     router.refresh();
   };
@@ -80,7 +83,7 @@ export default function MovementsTable({
     <div className="space-y-4">
       <div className="rounded-2xl border bg-card p-4 shadow-sm">
         <div className="flex flex-col gap-3 lg:flex-row lg:items-end">
-          <div className="grid flex-1 gap-3 sm:grid-cols-3">
+          <div className="grid flex-1 gap-3 sm:grid-cols-4">
             <label className="space-y-1 text-sm">
               <span className="font-medium">Tipo</span>
               <select
@@ -108,6 +111,16 @@ export default function MovementsTable({
                 type="date"
                 value={to}
                 onChange={(e) => setTo(e.target.value)}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </label>
+            <label className="space-y-1 text-sm">
+              <span className="font-medium">Buscar</span>
+              <input
+                type="text"
+                value={q}
+                onChange={(e) => setQ(e.target.value)}
+                placeholder="Nombre, apellido, actividad o mail"
                 className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
               />
             </label>

--- a/src/app/accounting/movements/page.tsx
+++ b/src/app/accounting/movements/page.tsx
@@ -13,6 +13,7 @@ type SearchParams = {
   type?: string;
   from?: string;
   to?: string;
+  q?: string;
 };
 
 export default async function MovementsPage({
@@ -31,6 +32,7 @@ export default async function MovementsPage({
       : '';
   const from = searchParams.from ?? '';
   const to = searchParams.to ?? '';
+  const q = searchParams.q?.trim() ?? '';
 
   const where: Prisma.AccountingMovementWhereInput = {};
   if (type) where.type = type;
@@ -39,6 +41,15 @@ export default async function MovementsPage({
     if (from) dateFilter.gte = new Date(from);
     if (to) dateFilter.lte = new Date(to);
     where.date = dateFilter;
+  }
+  if (q) {
+    where.OR = [
+      { category: { contains: q, mode: 'insensitive' } },
+      { description: { contains: q, mode: 'insensitive' } },
+      { createdBy: { name: { contains: q, mode: 'insensitive' } } },
+      { createdBy: { lastName: { contains: q, mode: 'insensitive' } } },
+      { createdBy: { email: { contains: q, mode: 'insensitive' } } },
+    ];
   }
 
   const movements = await prisma.accountingMovement.findMany({
@@ -83,7 +94,7 @@ export default async function MovementsPage({
             name: `${movement.createdBy.name ?? ''} ${movement.createdBy.lastName ?? ''}`.trim(),
           },
         }))}
-        initialFilters={{ type, from, to }}
+        initialFilters={{ type, from, to, q }}
       />
     </div>
   );

--- a/src/app/accounting/page.tsx
+++ b/src/app/accounting/page.tsx
@@ -43,7 +43,11 @@ type RecentAccountingEntry = {
   personHref?: string | null;
 };
 
-export default async function AccountingDashboardPage() {
+export default async function AccountingDashboardPage({
+  searchParams,
+}: {
+  searchParams?: { q?: string };
+}) {
   const session = await getServerSession(authOptions);
   if (!isAccountingRole(session?.user?.role)) {
     redirect('/');
@@ -190,13 +194,35 @@ export default async function AccountingDashboardPage() {
 
     return entries;
   }, []);
+  const searchTerm = searchParams?.q?.trim().toLowerCase() ?? '';
   const recentAccountingEntries: RecentAccountingEntry[] = [
     ...recentMovementEntries,
     ...recentManualPaymentEntries,
   ]
     .sort((a, b) => b.date.getTime() - a.date.getTime())
+    .filter((entry) =>
+      searchTerm
+        ? [entry.description, entry.category]
+            .join(' ')
+            .toLowerCase()
+            .includes(searchTerm)
+        : true
+    )
     .slice(0, 10);
-  const recentPayments = monthPayments.slice(0, 5);
+  const recentPayments = monthPayments
+    .filter((payment) =>
+      searchTerm
+        ? [
+            payment.activity.name,
+            formatPersonName(payment.child ?? payment.user),
+            '',
+          ]
+            .join(' ')
+            .toLowerCase()
+            .includes(searchTerm)
+        : true
+    )
+    .slice(0, 5);
 
   return (
     <div className="space-y-6">
@@ -247,6 +273,15 @@ export default async function AccountingDashboardPage() {
       </section>
 
       <section className="grid gap-6 xl:grid-cols-[1.5fr_1fr]">
+        <form className="xl:col-span-2 rounded-2xl border bg-card p-4 shadow-sm">
+          <input
+            type="text"
+            name="q"
+            defaultValue={searchParams?.q ?? ''}
+            placeholder="Buscar por nombre, apellido, actividad o mail"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+          />
+        </form>
         <article className="rounded-2xl border bg-card p-5 shadow-sm">
           <div className="mb-4 flex items-center justify-between gap-3">
             <div>

--- a/src/app/accounting/payments/page.tsx
+++ b/src/app/accounting/payments/page.tsx
@@ -22,6 +22,7 @@ type SearchParams = {
   from?: string;
   to?: string;
   activity?: string;
+  q?: string;
   page?: string;
 };
 
@@ -38,6 +39,7 @@ export default async function PaymentsPage({
   const from = searchParams.from ?? '';
   const to = searchParams.to ?? '';
   const activity = searchParams.activity ?? '';
+  const q = searchParams.q?.trim() ?? '';
   const page = Math.max(1, parseInt(searchParams.page ?? '1', 10));
 
   const where: Prisma.ActivityParticipantWhereInput = {
@@ -57,6 +59,16 @@ export default async function PaymentsPage({
       },
     };
   }
+  if (q) {
+    where.OR = [
+      { activity: { name: { contains: q, mode: 'insensitive' } } },
+      { user: { name: { contains: q, mode: 'insensitive' } } },
+      { user: { lastName: { contains: q, mode: 'insensitive' } } },
+      { child: { name: { contains: q, mode: 'insensitive' } } },
+      { child: { lastName: { contains: q, mode: 'insensitive' } } },
+      { user: { email: { contains: q, mode: 'insensitive' } } },
+    ];
+  }
 
   const [payments, total] = await Promise.all([
     prisma.activityParticipant.findMany({
@@ -67,7 +79,9 @@ export default async function PaymentsPage({
       include: {
         activity: { select: { name: true, price: true } },
         user: { select: { id: true, name: true, lastName: true } },
-        child: { select: { id: true, userId: true, name: true, lastName: true } },
+        child: {
+          select: { id: true, userId: true, name: true, lastName: true },
+        },
       },
     }),
     prisma.activityParticipant.count({ where }),
@@ -80,6 +94,7 @@ export default async function PaymentsPage({
     if (from) params.set('from', from);
     if (to) params.set('to', to);
     if (activity) params.set('activity', activity);
+    if (q) params.set('q', q);
     params.set('page', String(p));
     return `/accounting/payments?${params.toString()}`;
   }
@@ -102,7 +117,7 @@ export default async function PaymentsPage({
       </div>
 
       <form className="rounded-2xl border bg-card p-4 shadow-sm">
-        <div className="grid gap-3 md:grid-cols-4">
+        <div className="grid gap-3 md:grid-cols-5">
           <label className="space-y-1 text-sm">
             <span className="font-medium">Desde</span>
             <input
@@ -128,6 +143,16 @@ export default async function PaymentsPage({
               name="activity"
               defaultValue={activity}
               placeholder="Nombre de actividad"
+              className="w-full rounded-md border bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </label>
+          <label className="space-y-1 text-sm md:col-span-2">
+            <span className="font-medium">Buscar</span>
+            <input
+              type="text"
+              name="q"
+              defaultValue={q}
+              placeholder="Nombre, apellido, actividad o mail"
               className="w-full rounded-md border bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
             />
           </label>
@@ -218,14 +243,18 @@ export default async function PaymentsPage({
                 <Link href={pageHref(page - 1)}>Anterior</Link>
               </Button>
             ) : (
-              <Button variant="outline" disabled>Anterior</Button>
+              <Button variant="outline" disabled>
+                Anterior
+              </Button>
             )}
             {page < totalPages ? (
               <Button asChild variant="outline">
                 <Link href={pageHref(page + 1)}>Siguiente</Link>
               </Button>
             ) : (
-              <Button variant="outline" disabled>Siguiente</Button>
+              <Button variant="outline" disabled>
+                Siguiente
+              </Button>
             )}
           </div>
         </div>

--- a/src/app/accounting/professors/page.tsx
+++ b/src/app/accounting/professors/page.tsx
@@ -12,12 +12,33 @@ import {
 import { Button } from '@/components/ui/button';
 import PersonLink from '@/components/accounting/person-link';
 
-export default async function ProfessorsAccountingPage() {
+type SearchParams = {
+  q?: string;
+};
+
+export default async function ProfessorsAccountingPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
   const session = await getServerSession(authOptions);
   if (!isAccountingRole((session?.user as any)?.role)) redirect('/');
 
+  const q = searchParams.q?.trim() ?? '';
   const professors = await prisma.user.findMany({
-    where: { role: 'PROFESSOR', isActive: true },
+    where: {
+      role: 'PROFESSOR',
+      isActive: true,
+      ...(q
+        ? {
+            OR: [
+              { name: { contains: q, mode: 'insensitive' } },
+              { lastName: { contains: q, mode: 'insensitive' } },
+              { email: { contains: q, mode: 'insensitive' } },
+            ],
+          }
+        : {}),
+    },
     orderBy: [{ lastName: 'asc' }, { name: 'asc' }],
     select: {
       id: true,
@@ -55,6 +76,23 @@ export default async function ProfessorsAccountingPage() {
           </p>
         </div>
       </div>
+      <form className="rounded-2xl border bg-card p-4 shadow-sm">
+        <label className="space-y-1 text-sm">
+          <span className="font-medium">Buscar</span>
+          <div className="flex gap-2">
+            <input
+              type="text"
+              name="q"
+              defaultValue={q}
+              placeholder="Nombre, apellido, actividad o mail"
+              className="w-full rounded-md border bg-background px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+            <Button type="submit" variant="outline">
+              Buscar
+            </Button>
+          </div>
+        </label>
+      </form>
 
       <div className="overflow-x-auto rounded-xl border">
         <table className="w-full text-sm">

--- a/src/app/accounting/social-fee/page.tsx
+++ b/src/app/accounting/social-fee/page.tsx
@@ -15,6 +15,7 @@ import SocialFeePeriodFilter from './social-fee-period-filter';
 type SearchParams = {
   month?: string;
   year?: string;
+  q?: string;
 };
 
 type PersonRecord = {
@@ -86,6 +87,7 @@ export default async function SocialFeePage({
   const defaultYear = now.getUTCFullYear();
   const month = parsePeriod(searchParams.month, defaultMonth, 1, 12);
   const year = parsePeriod(searchParams.year, defaultYear, 2020, 2100);
+  const q = searchParams.q?.trim().toLowerCase() ?? '';
 
   const [concept, members, payments] = await Promise.all([
     prisma.billableConcept.findUnique({
@@ -188,8 +190,24 @@ export default async function SocialFeePage({
     }
   }
 
-  const paidPeople = people.filter((person) => person.status === 'PAID');
-  const pendingPeople = people.filter((person) => person.status === 'PENDING');
+  const filteredPeople = q
+    ? people.filter((person) => {
+        const searchable = [
+          person.name,
+          person.email ?? '',
+          person.payerLabel ?? '',
+        ]
+          .join(' ')
+          .toLowerCase();
+        return searchable.includes(q);
+      })
+    : people;
+  const paidPeople = filteredPeople.filter(
+    (person) => person.status === 'PAID'
+  );
+  const pendingPeople = filteredPeople.filter(
+    (person) => person.status === 'PENDING'
+  );
   const collectedAmount = paidPeople.reduce(
     (sum, person) => sum + person.amount,
     0
@@ -246,7 +264,20 @@ export default async function SocialFeePage({
               </p>
             </div>
 
-            <SocialFeePeriodFilter initialMonth={month} initialYear={year} />
+            <div className="space-y-2">
+              <SocialFeePeriodFilter initialMonth={month} initialYear={year} />
+              <form>
+                <input type="hidden" name="month" value={String(month)} />
+                <input type="hidden" name="year" value={String(year)} />
+                <input
+                  type="text"
+                  name="q"
+                  defaultValue={searchParams.q ?? ''}
+                  placeholder="Nombre, apellido, actividad o mail"
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                />
+              </form>
+            </div>
           </div>
 
           <div className="space-y-6">

--- a/src/lib/services/manual-payment-service.ts
+++ b/src/lib/services/manual-payment-service.ts
@@ -25,6 +25,7 @@ type CurrentUser = {
 
 type ManualPaymentListQuery = {
   status?: PaymentStatus | null;
+  q?: string;
   limit: number;
   offset: number;
 };
@@ -209,12 +210,36 @@ function mapPaymentToReview(payment: {
 
 export async function listManualPayments({
   status,
+  q,
   limit,
   offset,
 }: ManualPaymentListQuery): Promise<ManualPaymentListResponse> {
   const where: Prisma.PaymentWhereInput = {
     provider: 'MANUAL_TRANSFER',
     ...(status ? { status } : {}),
+    ...(q
+      ? {
+          OR: [
+            { payerName: { contains: q, mode: 'insensitive' } },
+            { payerEmail: { contains: q, mode: 'insensitive' } },
+            {
+              order: { responsibleName: { contains: q, mode: 'insensitive' } },
+            },
+            {
+              order: { responsibleEmail: { contains: q, mode: 'insensitive' } },
+            },
+            {
+              order: {
+                items: {
+                  some: {
+                    activity: { name: { contains: q, mode: 'insensitive' } },
+                  },
+                },
+              },
+            },
+          ],
+        }
+      : {}),
   };
 
   const [total, payments] = await Promise.all([


### PR DESCRIPTION
### Motivation
- Provide a unified text search across accounting sections so staff can quickly find records by name, last name, activity or email in the finance views (Resumen, Cuota social, Movimientos, Pagos MP, Pagos manuales, Profesores).
- Keep search behavior lightweight and consistent by using a `q` query parameter and server-side Prisma filters where lists are loaded, and client-side filtering where pages already build aggregated collections.

### Description
- Added a `q` search param and UI inputs to the accounting dashboard (`/accounting`), social fee (`/accounting/social-fee`), movements (`/accounting/movements`), MP payments (`/accounting/payments`), manual payments (`/accounting/manual-payments`), and professors list (`/accounting/professors`), supporting search by name, last name, activity and email where applicable.
- Implemented Prisma `WHERE`/`OR` filters for server-side lists (`activityParticipant`, `accountingMovement`, `payment`, and `user` queries) and wired the `q` param into client components and forms so filters persist in page URLs and forms.
- Updated the manual payments service (`src/lib/services/manual-payment-service.ts`) to include search over payer/responsible person and activity names in order items, and added in-memory filtering for the dashboard and social-fee pages where data is composed on the server.
- Files touched: `src/app/accounting/page.tsx`, `src/app/accounting/social-fee/page.tsx`, `src/app/accounting/movements/page.tsx`, `src/app/accounting/movements/movements-table.tsx`, `src/app/accounting/payments/page.tsx`, `src/app/accounting/manual-payments/page.tsx`, `src/app/accounting/professors/page.tsx`, and `src/lib/services/manual-payment-service.ts`.

### Testing
- Ran the repository linter with `pnpm -s lint` and it completed successfully (exit code 0) with preexisting unrelated warnings reported elsewhere in the codebase.
- Ran formatter `pnpm -s prettier --write` on touched files to apply formatting changes and ensure lint/prettier consistency.
- Unresolved risks: the social-fee KPIs are computed from the full dataset but the list UI applies search filtering in-memory which may cause the summary cards to not reflect the filtered subset (adjust behavior if you want KPIs to respect the search); there are other unrelated lint warnings in the repo that were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f688b179988328be17fe47b601bfa0)