### PR TITLE
Filtrar actividades pasadas en home y agregar pestaña «Antiguas» en /activities

### DIFF
--- a/src/app/activities/activities-tabs.tsx
+++ b/src/app/activities/activities-tabs.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import DeleteActivityButton from './delete-activity-button';
+
+type ActivityItem = {
+  id: string;
+  name: string;
+  activityType: 'TEMPORARY' | 'ANNUAL';
+  date: string;
+  endDate: string;
+  price: number;
+  capacity: number | null;
+  participantCount: number;
+};
+
+interface ActivitiesTabsProps {
+  upcomingActivities: ActivityItem[];
+  pastActivities: ActivityItem[];
+}
+
+const activityTypeLabels: Record<'TEMPORARY' | 'ANNUAL', string> = {
+  TEMPORARY: 'Temporal',
+  ANNUAL: 'Anual',
+};
+
+function formatDateRange(startDate: string, endDate: string) {
+  const start = new Date(startDate).toLocaleDateString('es-AR');
+  const end = new Date(endDate).toLocaleDateString('es-AR');
+  return start === end ? start : `${start} al ${end}`;
+}
+
+function ActivitiesList({ activities }: { activities: ActivityItem[] }) {
+  return (
+    <ul className="space-y-3">
+      {activities.map((activity) => (
+        <li
+          key={activity.id}
+          className="rounded-xl border bg-card p-4 shadow-sm flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <Link
+              href={`/activities/${activity.id}`}
+              className="text-base font-semibold hover:text-primary transition-colors"
+            >
+              {activity.name}
+            </Link>
+            <div className="mt-1 flex flex-wrap gap-3 text-sm text-muted-foreground">
+              <span>{activityTypeLabels[activity.activityType]}</span>
+              <span>·</span>
+              <span>{formatDateRange(activity.date, activity.endDate)}</span>
+              <span>·</span>
+              <span>${activity.price}</span>
+              <span>·</span>
+              <span>
+                {activity.capacity
+                  ? `${Math.max(activity.capacity - activity.participantCount, 0)} cupos restantes`
+                  : `${activity.participantCount} suscriptos`}
+              </span>
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-2 sm:justify-end">
+            <Link
+              href={`/activities/${activity.id}`}
+              className="inline-flex items-center justify-center rounded-full border-[1.5px] border-primary px-4 py-2 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
+            >
+              Ver
+            </Link>
+            <Link
+              href={`/activities/${activity.id}/edit`}
+              className="inline-flex items-center justify-center rounded-full border-[1.5px] border-border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
+            >
+              Editar
+            </Link>
+            <DeleteActivityButton
+              activityId={activity.id}
+              activityName={activity.name}
+              hasParticipants={activity.participantCount > 0}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export default function ActivitiesTabs({
+  upcomingActivities,
+  pastActivities,
+}: ActivitiesTabsProps) {
+  const [tab, setTab] = useState<'upcoming' | 'past'>('upcoming');
+
+  const visibleActivities =
+    tab === 'upcoming' ? upcomingActivities : pastActivities;
+
+  return (
+    <div className="space-y-4">
+      <div className="inline-flex rounded-lg border bg-muted p-1">
+        <button
+          type="button"
+          onClick={() => setTab('upcoming')}
+          className={`rounded-md px-3 py-1.5 text-sm ${tab === 'upcoming' ? 'bg-background font-medium shadow-sm' : 'text-muted-foreground'}`}
+        >
+          Activas ({upcomingActivities.length})
+        </button>
+        <button
+          type="button"
+          onClick={() => setTab('past')}
+          className={`rounded-md px-3 py-1.5 text-sm ${tab === 'past' ? 'bg-background font-medium shadow-sm' : 'text-muted-foreground'}`}
+        >
+          Antiguas ({pastActivities.length})
+        </button>
+      </div>
+
+      {visibleActivities.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground">
+          <p>
+            {tab === 'upcoming'
+              ? 'No hay actividades activas.'
+              : 'No hay actividades antiguas.'}
+          </p>
+        </div>
+      ) : (
+        <ActivitiesList activities={visibleActivities} />
+      )}
+    </div>
+  );
+}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -3,9 +3,9 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import ActivitiesHeading from '@/components/activities-heading';
-import DeleteActivityButton from './delete-activity-button';
 import { listActivitiesWithParticipantCount } from '@/lib/activities/activity-records';
 import { authOptions } from '@/lib/auth';
+import ActivitiesTabs from './activities-tabs';
 
 export default async function ActivitiesPage() {
   const session = await getServerSession(authOptions);
@@ -26,16 +26,22 @@ export default async function ActivitiesPage() {
     activities = [];
   }
 
-  const activityTypeLabels: Record<'TEMPORARY' | 'ANNUAL', string> = {
-    TEMPORARY: 'Temporal',
-    ANNUAL: 'Anual',
-  };
+  const now = new Date();
+  const upcomingActivities = activities
+    .filter((activity) => activity.endDate >= now)
+    .map((activity) => ({
+      ...activity,
+      date: activity.date.toISOString(),
+      endDate: activity.endDate.toISOString(),
+    }));
 
-  function formatDateRange(startDate: Date, endDate: Date) {
-    const start = startDate.toLocaleDateString('es-AR');
-    const end = endDate.toLocaleDateString('es-AR');
-    return start === end ? start : `${start} al ${end}`;
-  }
+  const pastActivities = activities
+    .filter((activity) => activity.endDate < now)
+    .map((activity) => ({
+      ...activity,
+      date: activity.date.toISOString(),
+      endDate: activity.endDate.toISOString(),
+    }));
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-6">
@@ -51,63 +57,10 @@ export default async function ActivitiesPage() {
           <p>No hay actividades creadas.</p>
         </div>
       ) : (
-        <ul className="space-y-3">
-          {activities.map((activity) => (
-            <li
-              key={activity.id}
-              className="rounded-xl border bg-card p-4 shadow-sm flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-            >
-              <div>
-                <Link
-                  href={`/activities/${activity.id}`}
-                  className="text-base font-semibold hover:text-primary transition-colors"
-                >
-                  {activity.name}
-                </Link>
-                <div className="mt-1 flex flex-wrap gap-3 text-sm text-muted-foreground">
-                  <span>
-                    {
-                      activityTypeLabels[
-                        activity.activityType as keyof typeof activityTypeLabels
-                      ]
-                    }
-                  </span>
-                  <span>·</span>
-                  <span>
-                    {formatDateRange(activity.date, activity.endDate)}
-                  </span>
-                  <span>·</span>
-                  <span>${activity.price}</span>
-                  <span>·</span>
-                  <span>
-                    {activity.capacity
-                      ? `${Math.max(activity.capacity - activity.participantCount, 0)} cupos restantes`
-                      : `${activity.participantCount} suscriptos`}
-                  </span>
-                </div>
-              </div>
-              <div className="flex flex-wrap gap-2 sm:justify-end">
-                <Link
-                  href={`/activities/${activity.id}`}
-                  className="inline-flex items-center justify-center rounded-full border-[1.5px] border-primary px-4 py-2 text-sm font-medium text-primary hover:bg-primary/5 transition-colors"
-                >
-                  Ver
-                </Link>
-                <Link
-                  href={`/activities/${activity.id}/edit`}
-                  className="inline-flex items-center justify-center rounded-full border-[1.5px] border-border px-4 py-2 text-sm font-medium hover:bg-muted transition-colors"
-                >
-                  Editar
-                </Link>
-                <DeleteActivityButton
-                  activityId={activity.id}
-                  activityName={activity.name}
-                  hasParticipants={activity.participantCount > 0}
-                />
-              </div>
-            </li>
-          ))}
-        </ul>
+        <ActivitiesTabs
+          upcomingActivities={upcomingActivities}
+          pastActivities={pastActivities}
+        />
       )}
     </main>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -30,6 +30,11 @@ export default async function Home() {
     activities = [];
   }
 
+  const now = new Date();
+  const upcomingActivities = activities.filter(
+    (activity) => activity.endDate >= now
+  );
+
   return (
     <>
       {/* Divisor */}
@@ -44,13 +49,13 @@ export default async function Home() {
             </h2>
           </div>
 
-          {activities.length === 0 ? (
+          {upcomingActivities.length === 0 ? (
             <div className="py-16 text-center text-muted-foreground font-body">
               <p>No hay actividades disponibles por el momento.</p>
             </div>
           ) : (
             <div className="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-              {activities.map((activity) => (
+              {upcomingActivities.map((activity) => (
                 <Link
                   key={activity.id}
                   href={`/activities/join/${activity.id}`}


### PR DESCRIPTION
### Motivation
- Mejorar la UX ocultando en la pantalla principal (`/`) las actividades que ya finalizaron para mostrar solo actividades vigentes. 
- Permitir al administrador ver las actividades históricas en `/activities` sin mezclarlas con las activas mediante una pestaña de «Antiguas». 

### Description
- En `src/app/page.tsx` se añadió el filtro `upcomingActivities = activities.filter((activity) => activity.endDate >= now)` y la UI ahora renderiza `upcomingActivities` en lugar de la lista completa. 
- Se creó el componente cliente `src/app/activities/activities-tabs.tsx` que implementa dos tabs (`Activas` / `Antiguas`) y reutiliza la UI de listado con las acciones `Ver`/`Editar`/`Eliminar`. 
- En `src/app/activities/page.tsx` se calcula `upcomingActivities` y `pastActivities` a partir de `activities`, se serializan `date`/`endDate` a ISO para pasar al cliente y se reemplazó el listado inline por el componente `ActivitiesTabs`. 
- Formateo menor con `prettier` aplicado a los archivos modificados. 

### Testing
- Ejecutado `pnpm lint`, que finalizó correctamente; solo aparecieron warnings preexistentes en otros archivos y no hay errores bloqueantes. 
- Ejecutado `pnpm prettier --write` sobre los archivos tocados y aplicado formateo sin conflictos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6960f780483289ebcd7840c0f63cd)