### PR TITLE
Arregla desbordamiento de texto en tarjetas Monto/Fecha de Pagos Manuales

### DIFF
--- a/src/components/accounting/manual-payment-detail.tsx
+++ b/src/components/accounting/manual-payment-detail.tsx
@@ -135,19 +135,19 @@ export default function ManualPaymentDetail({
           </div>
 
           <div className="grid gap-3 sm:grid-cols-2">
-            <article className="rounded-xl border bg-muted/20 p-4">
+            <article className="min-w-0 rounded-xl border bg-muted/20 p-4">
               <p className="text-xs uppercase tracking-wide text-muted-foreground">
                 Monto
               </p>
-              <p className="mt-1 text-lg font-semibold">
+              <p className="mt-1 break-words text-lg font-semibold leading-tight">
                 {formatPesos(payment.amount / 100, payment.currency)}
               </p>
             </article>
-            <article className="rounded-xl border bg-muted/20 p-4">
+            <article className="min-w-0 rounded-xl border bg-muted/20 p-4">
               <p className="text-xs uppercase tracking-wide text-muted-foreground">
                 Fecha de pago
               </p>
-              <p className="mt-1 text-lg font-semibold">
+              <p className="mt-1 break-words text-lg font-semibold leading-tight">
                 {(payment.paidAt ?? payment.createdAt).toLocaleDateString(
                   'es-AR'
                 )}


### PR DESCRIPTION
### Motivation
- Evitar que valores largos en las tarjetas "Monto" y "Fecha de pago" se desborden fuera de sus recuadros en la vista de revisión de pagos manuales en layouts estrechos.

### Description
- Añadí `min-w-0` a los contenedores de ambas tarjetas y `break-words` + `leading-tight` al texto de los valores en `src/components/accounting/manual-payment-detail.tsx` para que el contenido se ajuste correctamente dentro del recuadro.

### Testing
- Ejecuté `pnpm lint`; finalizó correctamente (reportó warnings preexistentes no relacionados con este cambio). El cambio es únicamente de estilos/UI y no modifica lógica ni APIs.
- Riesgo pendiente: se recomienda una verificación visual rápida en mobile/tablet ya que no se pudo validar en navegador desde este entorno.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69afcd1388328a88eef7585e998e9)