### PR TITLE
Agregar buscador por nombre/apellido al alta de miembros de grupo

### DIFF
--- a/src/app/activities/[id]/groups/[groupId]/group-members-manager.tsx
+++ b/src/app/activities/[id]/groups/[groupId]/group-members-manager.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
@@ -35,20 +35,36 @@ export default function ActivityGroupMembersManager({
   );
   const [error, setError] = useState('');
 
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filteredAvailableParticipants = useMemo(() => {
+    const normalized = searchTerm.trim().toLowerCase();
+
+    if (!normalized) {
+      return availableParticipants;
+    }
+
+    return availableParticipants.filter((participant) =>
+      participant.label.toLowerCase().includes(normalized)
+    );
+  }, [availableParticipants, searchTerm]);
+
   useEffect(() => {
-    if (availableParticipants.length === 0) {
+    if (filteredAvailableParticipants.length === 0) {
       setSelectedParticipantId('');
       return;
     }
 
-    const selectedExists = availableParticipants.some(
+    const selectedExists = filteredAvailableParticipants.some(
       (participant) => participant.participantId === selectedParticipantId
     );
 
     if (!selectedExists) {
-      setSelectedParticipantId(availableParticipants[0]?.participantId ?? '');
+      setSelectedParticipantId(
+        filteredAvailableParticipants[0]?.participantId ?? ''
+      );
     }
-  }, [availableParticipants, selectedParticipantId]);
+  }, [filteredAvailableParticipants, selectedParticipantId]);
 
   async function mutateMembership(
     participantId: string,
@@ -198,12 +214,19 @@ export default function ActivityGroupMembersManager({
               onSubmit={handleAddParticipant}
               className="space-y-3 rounded-lg border bg-background p-4"
             >
+              <input
+                type="text"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                placeholder="Buscar por nombre y apellido"
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+              />
               <select
                 className="w-full rounded-md border bg-background px-3 py-2 text-sm"
                 value={selectedParticipantId}
                 onChange={(e) => setSelectedParticipantId(e.target.value)}
               >
-                {availableParticipants.map((participant) => (
+                {filteredAvailableParticipants.map((participant) => (
                   <option
                     key={participant.participantId}
                     value={participant.participantId}
@@ -215,12 +238,23 @@ export default function ActivityGroupMembersManager({
                   </option>
                 ))}
               </select>
+              {filteredAvailableParticipants.length === 0 && (
+                <p className="text-xs text-muted-foreground">
+                  No se encontraron participantes con esa búsqueda.
+                </p>
+              )}
               <div className="space-y-2">
                 <p className="text-xs text-muted-foreground">
                   Si el participante ya pertenece a otro grupo, se moverá a
                   {` ${groupName}.`}
                 </p>
-                <Button type="submit" disabled={!selectedParticipantId}>
+                <Button
+                  type="submit"
+                  disabled={
+                    !selectedParticipantId ||
+                    filteredAvailableParticipants.length === 0
+                  }
+                >
                   Agregar al grupo
                 </Button>
               </div>


### PR DESCRIPTION
### Motivation
- Facilitar la búsqueda de participantes al agregar usuarios a un grupo mostrando un buscador por nombre y apellido y filtrando el listado en tiempo real.

### Description
- Añadí un `searchTerm` y un `filteredAvailableParticipants` memoizado, ajusté el `useEffect` para respetar la lista filtrada, reemplacé el `<select>` para renderizar sólo los elementos filtrados y mostré un mensaje cuando no hay coincidencias; la UI también deshabilita el botón de alta si no hay resultados.
- Archivo modificado: `src/app/activities/[id]/groups/[groupId]/group-members-manager.tsx`; riesgo no resuelto: el filtrado usa `participant.label`, por lo que la búsqueda depende del formato de ese `label` y puede no cubrir todos los casos de nombre/apellido.

### Testing
- Ejecuté `pnpm -s lint` (completó correctamente con warnings preexistentes en otros archivos) y `pnpm -s prettier --write src/app/activities/[id]/groups/[groupId]/group-members-manager.tsx` (formateó el archivo); ambos pasos terminaron sin errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69bb8e3b483289b74c6d42feb9543)