### PR TITLE
feat(my-activities): ocultar sesiones pasadas en pestaña «Antiguas»

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -26,7 +26,11 @@ type ActivityParticipantSummary = {
   groupId: string | null;
 };
 
-export default async function MyActivitiesPage() {
+export default async function MyActivitiesPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ tab?: string }>;
+}) {
   const session = await getServerSession(authOptions);
   if (!session) {
     redirect('/login');
@@ -245,6 +249,19 @@ export default async function MyActivitiesPage() {
     isProfessor: professorActivityIds.has(entry.activity.id),
   }));
 
+  const resolvedSearchParams = await searchParams;
+  const requestedTab = resolvedSearchParams?.tab;
+  const selectedTab = requestedTab === 'old' ? 'old' : 'current';
+  const today = new Date(new Date().setHours(0, 0, 0, 0));
+
+  const currentItems = items.filter(({ sessions }) =>
+    sessions.some((sessionItem) => new Date(sessionItem.date) >= today)
+  );
+  const oldItems = items.filter(
+    ({ sessions }) => !sessions.some((sessionItem) => new Date(sessionItem.date) >= today)
+  );
+  const visibleItems = selectedTab === 'old' ? oldItems : currentItems;
+
   return (
     <main className="mx-auto max-w-5xl px-4 py-6">
       <div className="mb-6">
@@ -259,14 +276,41 @@ export default async function MyActivitiesPage() {
 
       <ActivityCalendar activityDays={calendarDays} />
 
-      <div className="mt-6">
-        {items.length === 0 ? (
+      <div className="mt-6 space-y-4">
+        <div className="inline-flex rounded-lg border bg-muted/30 p-1">
+          <Link
+            href="/my-activities"
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              selectedTab === 'current'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Actuales ({currentItems.length})
+          </Link>
+          <Link
+            href="/my-activities?tab=old"
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              selectedTab === 'old'
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            Antiguas ({oldItems.length})
+          </Link>
+        </div>
+
+        {visibleItems.length === 0 ? (
           <div className="py-16 text-center text-muted-foreground">
-            <p>Todavía no tenés actividades asociadas.</p>
+            <p>
+              {selectedTab === 'old'
+                ? 'No tenés actividades antiguas.'
+                : 'Todavía no tenés actividades actuales.'}
+            </p>
           </div>
         ) : (
           <ul className="space-y-4">
-            {items.map(({ activity, labels, participants, sessions, isProfessor }) => (
+            {visibleItems.map(({ activity, labels, participants, sessions, isProfessor }) => (
               <li
                 key={activity.id}
                 className="rounded-xl border bg-card p-5 shadow-sm space-y-4"


### PR DESCRIPTION
### Motivation
- Evitar mostrar por defecto sesiones pasadas en la vista «Mis actividades» para reducir ruido en la lista principal. 
- Permitir a los usuarios acceder a las sesiones históricas desde una pestaña separada llamada "Antiguas".
- Mantener el calendario visible y agregar una navegación simple por pestañas para alternar entre actuales y antiguas.

### Description
- Se actualizó el componente servidor `MyActivitiesPage` para aceptar `searchParams` y resolver la pestaña activa vía query param (`/my-activities` y `/my-activities?tab=old`).
- Se clasifican las actividades en `currentItems` (tienen sesiones desde hoy en adelante) y `oldItems` (no tienen sesiones futuras) y se renderiza solo la lista correspondiente a la pestaña seleccionada.
- Se añadió la UI de pestañas con conteos (`Actuales (N)` y `Antiguas (M)`) y mensajes vacíos específicos por pestaña.
- Archivo modificado: `src/app/my-activities/page.tsx`.

### Testing
- Se ejecutó `pnpm exec tsc --noEmit` para verificación de tipos y el comando falló con errores de TypeScript preexistentes en otros módulos (no relacionados con este cambio), por lo que la verificación global no quedó verde.
- Resultado de la verificación: fallida debido a errores en rutas/tests ajenos a `my-activities` (ej. páginas de observaciones y tests de `pickup-notices`).
- Unresolved risks: la clasificación actual vs antigua depende de la existencia de `activityDay` con fechas; actividades sin `activityDay` cargadas se mostrarán en "Antiguas" aunque aún deban considerarse vigentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a63af35c832893c120f1246957e6)