### PR TITLE
feat(activities): mostrar días de actividad en calendario

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -7,6 +7,9 @@ import ActivityDayForm from './activity-day-form';
 import AttendanceList, {
   type ParticipantForAttendance,
 } from './attendance-list';
+import ActivityCalendar, {
+  type CalendarActivityDay,
+} from '@/app/my-activities/activity-calendar';
 
 type AttendanceStatus = 'PENDING' | 'GOING' | 'NOT_GOING';
 
@@ -116,7 +119,9 @@ export default function ActivityDaysPanel({
   const router = useRouter();
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingDayId, setEditingDayId] = useState<string | null>(null);
-  const [editingDescriptionId, setEditingDescriptionId] = useState<string | null>(null);
+  const [editingDescriptionId, setEditingDescriptionId] = useState<
+    string | null
+  >(null);
   const [descriptionDraft, setDescriptionDraft] = useState('');
   const [error, setError] = useState('');
   const [savingKey, setSavingKey] = useState<string | null>(null);
@@ -126,6 +131,15 @@ export default function ActivityDaysPanel({
   const [expandedAttendance, setExpandedAttendance] = useState<
     Record<string, boolean>
   >({});
+  const calendarDays: CalendarActivityDay[] = days.map((day) => ({
+    id: day.id,
+    date: day.date.slice(0, 10),
+    activityId,
+    activityName: 'Actividad',
+    schedule: day.schedule,
+    geoLocation: day.geoLocation,
+    sportIcon: day.sportIcon,
+  }));
 
   async function updateAttendance(
     dayId: string,
@@ -230,6 +244,12 @@ export default function ActivityDaysPanel({
             groups={groups}
             defaultProfessorIds={defaultProfessorIds}
           />
+        </div>
+      )}
+
+      {days.length > 0 && (
+        <div className="mt-6">
+          <ActivityCalendar activityDays={calendarDays} />
         </div>
       )}
 
@@ -367,7 +387,9 @@ export default function ActivityDaysPanel({
                       <Button
                         type="button"
                         disabled={savingKey === `desc:${day.id}`}
-                        onClick={() => saveDescription(day.id, descriptionDraft)}
+                        onClick={() =>
+                          saveDescription(day.id, descriptionDraft)
+                        }
                       >
                         {savingKey === `desc:${day.id}`
                           ? 'Guardando...'


### PR DESCRIPTION
### Motivation
- Mostrar las sesiones de una actividad en un calendario con la misma experiencia visual que `my-activities` para facilitar la navegación por fechas.
- Reutilizar el componente existente `ActivityCalendar` en el panel de `Días de la actividad` para mantener consistencia UI.

### Description
- Se importó y reutilizó `ActivityCalendar` desde `src/app/my-activities/activity-calendar` en `ActivityDaysPanel`.
- Se transformó la prop `days` a `CalendarActivityDay[]` (`calendarDays`) con los campos requeridos (`id`, `date`, `activityId`, `activityName`, `schedule`, `geoLocation`, `sportIcon`).
- Se renderiza el calendario encima del listado detallado de sesiones, manteniendo la funcionalidad de edición, asistencia y avisos intacta.
- Se dejó `activityName` como texto genérico `"Actividad"` porque el nombre de actividad no se recibe actualmente en este panel.

### Testing
- Ejecutado `pnpm lint` y el proceso terminó sin errores bloqueantes, mostrando sólo warnings de estilo ya existentes en el repo. 
- Ejecutado `pnpm prettier --write src/app/activities/[id]/activity-days-panel.tsx` para formatear el archivo modificado y eliminar warnings de `prettier` locales.
- Archivo modificado: `src/app/activities/[id]/activity-days-panel.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6aaf271d8832887f3b0452d90a086)