### PR TITLE
Add public image icons to activity day action cards

### DIFF
--- a/src/app/activities/[id]/days/[dayId]/page.tsx
+++ b/src/app/activities/[id]/days/[dayId]/page.tsx
@@ -3,6 +3,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import Link from 'next/link';
+import Image from 'next/image';
 
 export default async function ActivityDayPage({
   params,
@@ -83,8 +84,15 @@ export default async function ActivityDayPage({
       <div className="grid gap-3 sm:grid-cols-3">
         <Link
           href={`${base}/descripcion`}
-          className="flex flex-col gap-1 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
+          className="flex flex-col gap-3 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
         >
+          <Image
+            src="/1_Informacion.png"
+            alt="Información"
+            width={52}
+            height={52}
+            className="h-10 w-10 object-contain"
+          />
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Descripción
           </span>
@@ -97,8 +105,15 @@ export default async function ActivityDayPage({
 
         <Link
           href={`${base}/observaciones`}
-          className="flex flex-col gap-1 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
+          className="flex flex-col gap-3 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
         >
+          <Image
+            src="/1_Observacion.png"
+            alt="Observación"
+            width={52}
+            height={52}
+            className="h-10 w-10 object-contain"
+          />
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Observaciones
           </span>
@@ -111,8 +126,15 @@ export default async function ActivityDayPage({
 
         <Link
           href={`${base}/attendance`}
-          className="flex flex-col gap-1 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
+          className="flex flex-col gap-3 rounded-xl border bg-card p-5 hover:border-primary transition-colors"
         >
+          <Image
+            src="/1_asistencia.png"
+            alt="Asistencia"
+            width={52}
+            height={52}
+            className="h-10 w-10 object-contain"
+          />
           <span className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
             Asistencia
           </span>


### PR DESCRIPTION
### Motivation
- Improve the visual affordance of the activity day overview by placing the provided public icons above each action card so users can more quickly identify `Descripción`, `Observaciones`, and `Asistencia`.

### Description
- Import `next/image` and render `/1_Informacion.png`, `/1_Observacion.png`, and `/1_asistencia.png` inside the three action cards on the day landing page at `src/app/activities/[id]/days/[dayId]/page.tsx`.
- Increase the card vertical gap from `gap-1` to `gap-3` to accommodate the new icon row while keeping existing texts and links intact.
- This is a UI-only change and does not alter routes, API logic, or database interactions.

### Testing
- Ran `pnpm lint` which completed successfully; the run shows pre-existing Prettier warnings in unrelated files but no errors from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b1b095fc832886ae3ea6d1e7906f)