### PR TITLE
Filter My Activities sessions to participant groups for parents

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -249,13 +249,37 @@ export default async function MyActivitiesPage({
     professorAssignments.map((a) => a.activity.id)
   );
 
-  const items = Array.from(grouped.values()).map((entry) => ({
-    activity: entry.activity,
-    labels: Array.from(entry.labels),
-    participants: entry.participants,
-    sessions: sessionsByActivity.get(entry.activity.id) ?? [],
-    isProfessor: professorActivityIds.has(entry.activity.id),
-  }));
+  const items = Array.from(grouped.values()).map((entry) => {
+    const isProfessor = professorActivityIds.has(entry.activity.id);
+    const rawSessions = sessionsByActivity.get(entry.activity.id) ?? [];
+
+    const groupIds = new Set(
+      entry.participants
+        .map((participant) => participant.groupId)
+        .filter((groupId): groupId is string => Boolean(groupId))
+    );
+    const hasUngroupedParticipant = entry.participants.some(
+      (participant) => participant.groupId === null
+    );
+
+    const sessions = isProfessor
+      ? rawSessions
+      : rawSessions.filter((sessionItem) => {
+          if (sessionItem.activityGroupId === null) {
+            return hasUngroupedParticipant;
+          }
+
+          return groupIds.has(sessionItem.activityGroupId);
+        });
+
+    return {
+      activity: entry.activity,
+      labels: Array.from(entry.labels),
+      participants: entry.participants,
+      sessions,
+      isProfessor,
+    };
+  });
 
   const resolvedSearchParams = await searchParams;
   const requestedTab = resolvedSearchParams?.tab;


### PR DESCRIPTION
### Motivation
- Parents were seeing upcoming sessions for activities that did not belong to the group(s) where they or their children are assigned, causing confusion in the “Mis actividades” view. 
- The intent is to restrict the sessions list in member/parent view to only the activity group(s) relevant to that member (professor view should remain unchanged).

### Description
- Updated session selection logic in `src/app/my-activities/page.tsx` so items are built with a filtered `sessions` array instead of showing all sessions; professor-assigned users keep the original unfiltered sessions. 
- The new logic computes `groupIds` from the participant list and a `hasUngroupedParticipant` flag, and then filters `rawSessions` to include only sessions whose `activityGroupId` matches one of the participant `groupIds` or are ungrouped when an ungrouped participant exists. 
- Change is scoped to `src/app/my-activities/page.tsx` and does not modify other routes or APIs.

### Testing
- Ran `pnpm -s lint`, which completed successfully; existing Prettier/ESLint warnings in unrelated files remain as before and are not introduced by this change. 
- No new unit or integration tests were added for this UI filter; manual behavior verified locally by reviewing the generated session filtering logic.
- Unresolved risks: parents with children in multiple groups will see sessions from all their groups (currently expected but should be validated with product), and edge cases around participants without group assignments may need additional UX clarification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d27e78588328905b039f5fe3c62b)