### PR TITLE
Require per-session professor assignment for annual activity sessions

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -32,6 +32,7 @@ type AnnualScheduleDraft = {
   weekday: string;
   schedule: string;
   groupId: string;
+  professorIds: string[];
 };
 
 type AnnualSharedDraft = {
@@ -83,6 +84,7 @@ function createEmptyScheduleDraft(): AnnualScheduleDraft {
     weekday: '1',
     schedule: '',
     groupId: '',
+    professorIds: [],
   };
 }
 
@@ -250,6 +252,10 @@ export default function EditActivityForm({
           setError(`Completá el horario de la sesión ${i + 1}`);
           return;
         }
+        if (draft.professorIds.length === 0) {
+          setError(`Asigná al menos un profesor en la sesión ${i + 1}`);
+          return;
+        }
       }
     }
 
@@ -274,6 +280,7 @@ export default function EditActivityForm({
               weekday: Number(d.weekday),
               schedule: d.schedule.trim(),
               groupId: d.groupId || undefined,
+              professorIds: d.professorIds,
             }))
           : [];
 
@@ -666,6 +673,15 @@ export default function EditActivityForm({
                         ))}
                       </select>
                     </div>
+                    <ProfessorPicker
+                      professors={professors}
+                      value={draft.professorIds}
+                      onChange={(value) =>
+                        updateScheduleDraft(draft.tempId, {
+                          professorIds: value,
+                        })
+                      }
+                    />
                   </div>
                 ))}
               </div>

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -26,6 +26,7 @@ type AnnualScheduleDraft = {
   weekday: string;
   schedule: string;
   groupTempId: string;
+  professorIds: string[];
 };
 
 type AnnualSharedDraft = {
@@ -64,6 +65,7 @@ function createEmptyAnnualScheduleDraft(): AnnualScheduleDraft {
     weekday: '1',
     schedule: '',
     groupTempId: '',
+    professorIds: [],
   };
 }
 
@@ -180,12 +182,18 @@ export default function CreateActivityForm({
                   `Completá el horario de la sesión ${index + 1}`
                 );
               }
+              if (draft.professorIds.length === 0) {
+                throw new Error(
+                  `Asigná al menos un profesor en la sesión ${index + 1}`
+                );
+              }
 
               return {
                 tempId: draft.tempId,
                 weekday: Number(draft.weekday),
                 schedule: draft.schedule.trim(),
                 groupTempId: draft.groupTempId || undefined,
+                professorIds: draft.professorIds,
               };
             })
           : [];
@@ -557,6 +565,15 @@ export default function CreateActivityForm({
                       ))}
                     </select>
                   </div>
+                  <ProfessorPicker
+                    professors={professors}
+                    value={draft.professorIds}
+                    onChange={(value) =>
+                      updateAnnualScheduleDraft(draft.tempId, {
+                        professorIds: value,
+                      })
+                    }
+                  />
                 </div>
               ))}
             </div>

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -119,8 +119,11 @@ export async function PUT(
               select: { id: true },
             });
             await tx.activityDayProfessor.createMany({
-              data: createdDays.flatMap(({ id: activityDayId }) =>
-                professorIds.map((userId) => ({ activityDayId, userId }))
+              data: createdDays.flatMap(({ id: activityDayId }, index) =>
+                annualDays[index].professorIds.map((userId) => ({
+                  activityDayId,
+                  userId,
+                }))
               ),
             });
           } else {

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -119,8 +119,11 @@ export async function POST(req: Request) {
             select: { id: true },
           });
           await tx.activityDayProfessor.createMany({
-            data: createdDays.flatMap(({ id: activityDayId }) =>
-              professorIds.map((userId) => ({ activityDayId, userId }))
+            data: createdDays.flatMap(({ id: activityDayId }, index) =>
+              annualDays[index].professorIds.map((userId) => ({
+                activityDayId,
+                userId,
+              }))
             ),
           });
         } else {

--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -120,6 +120,9 @@ export default async function MyActivitiesPage({
       const raw = await prisma.activityDay.findMany({
         where: {
           activityId: { in: activityIds },
+          ...(isProfessorView
+            ? { professors: { some: { userId } } }
+            : {}),
           date: {
             gte: new Date(new Date().setHours(0, 0, 0, 0)),
             lte: sixMonthsLater,
@@ -158,6 +161,9 @@ export default async function MyActivitiesPage({
       const rawSessions = await prisma.activityDay.findMany({
         where: {
           activityId: { in: activityIds },
+          ...(isProfessorView
+            ? { professors: { some: { userId } } }
+            : {}),
           date: { gte: new Date(new Date().setHours(0, 0, 0, 0)) },
         },
         select: {

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -26,6 +26,7 @@ const annualScheduleSchema = z.object({
   weekday: z.number().int().min(0).max(6),
   schedule: z.string().min(1),
   groupTempId: z.string().min(1).optional(),
+  professorIds: z.array(z.string().min(1)).min(1),
 });
 
 const annualScheduleEditSchema = z.object({
@@ -33,6 +34,7 @@ const annualScheduleEditSchema = z.object({
   weekday: z.number().int().min(0).max(6),
   schedule: z.string().min(1),
   groupId: z.string().min(1).optional(),
+  professorIds: z.array(z.string().min(1)).min(1),
 });
 
 const activityGroupDraftSchema = z.object({


### PR DESCRIPTION
### Motivation
- Enforce that each weekly session of an annual activity has one or more assigned professors so sessions are properly staffed and validated.
- Ensure professors can only see the specific sessions they are assigned to, not all activity sessions.
- Keep UI, client validation and backend persistence aligned so per-session professor assignments are stored and honored.

### Description
- Updated validation schemas to require per-session `professorIds` by adding `professorIds` to `annualScheduleSchema` and `annualScheduleEditSchema` in `src/lib/validations/activity.ts`.
- Added per-session professor picker UI and client-side validation in the create form at `src/app/activities/new/form.tsx` so each `annualSchedule` draft includes `professorIds` and blocks submit if any session has none.
- Added per-session professor picker UI and client-side validation in the edit form at `src/app/activities/[id]/edit/form.tsx` and included `professorIds` in the payload sent to the update API.
- Persist per-session assignments in the APIs by using each schedule's `professorIds` when creating `ActivityDay` and `ActivityDayProfessor` records in `src/app/api/activities/route.ts` and `src/app/api/activities/[id]/route.ts`.
- Limited the professor view in `src/app/my-activities/page.tsx` to only load and show `ActivityDay` rows where the logged-in professor is explicitly assigned.

### Testing
- Ran `pnpm lint` which completed successfully (existing unrelated Prettier warnings remain in other files).
- No new automated unit/integration tests were added for this change.
- Unresolved risks: the edit form does not prepopulate existing per-session assignments for previously generated days, so regenerating sessions requires reassigning professors in the UI which may be a UX gap to address later.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d4bcc2e88328bd788343aea3a89c)