### PR TITLE
Restringir calendario de socios en My Activities a sesiones asignadas

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -133,19 +133,54 @@ export default async function MyActivitiesPage({
           sportIcon: true,
           latitude: true,
           longitude: true,
+          activityGroupId: true,
           activity: { select: { id: true, name: true } },
         },
         orderBy: { date: 'asc' },
       });
-      calendarDays = raw.map((d) => ({
-        id: d.id,
-        date: d.date.toISOString().slice(0, 10),
-        activityId: d.activity.id,
-        activityName: d.activity.name,
-        schedule: d.schedule,
-        geoLocation: d.geoLocation,
-        sportIcon: d.sportIcon,
-      }));
+      const participantScopeByActivity = new Map<
+        string,
+        { groupIds: Set<string>; hasUngroupedParticipant: boolean }
+      >();
+
+      for (const participation of participations) {
+        const current = participantScopeByActivity.get(participation.activity.id) ?? {
+          groupIds: new Set<string>(),
+          hasUngroupedParticipant: false,
+        };
+
+        const groupId = participation.groupMembership?.activityGroupId ?? null;
+        if (groupId) {
+          current.groupIds.add(groupId);
+        } else {
+          current.hasUngroupedParticipant = true;
+        }
+
+        participantScopeByActivity.set(participation.activity.id, current);
+      }
+
+      calendarDays = raw
+        .filter((d) => {
+          if (isProfessorView) return true;
+
+          const scope = participantScopeByActivity.get(d.activity.id);
+          if (!scope) return false;
+
+          if (d.activityGroupId === null) {
+            return scope.hasUngroupedParticipant;
+          }
+
+          return scope.groupIds.has(d.activityGroupId);
+        })
+        .map((d) => ({
+          id: d.id,
+          date: d.date.toISOString().slice(0, 10),
+          activityId: d.activity.id,
+          activityName: d.activity.name,
+          schedule: d.schedule,
+          geoLocation: d.geoLocation,
+          sportIcon: d.sportIcon,
+        }));
     } catch {
       calendarDays = [];
     }


### PR DESCRIPTION
### Motivation
- Evitar que en la vista de socios el calendario muestre todas las sesiones de una actividad cuando el socio solo debe ver las sesiones en las que está asignado (él o sus hijos).
- Mantener el comportamiento actual para profesores, que deben seguir viendo todas las sesiones de las actividades donde están asignados.
- Reducir ruido en la lista de sesiones y mejorar la relevancia del calendario para usuarios `MEMBER`.

### Description
- Añadí `activityGroupId` al `select` de `activityDay` y construí un mapa `participantScopeByActivity` que agrupa los `groupIds` y marca si existen participantes sin grupo para cada actividad.
- Apliqué un filtro sobre los días recuperados para que en vista de socio solo se incluyan sesiones cuyo `activityGroupId` coincida con las asignaciones del socio/hijos, y sesiones sin grupo solo si hay participantes sin grupo; en vista de profesor la lista permanece sin filtrar.
- Archivo modificado: `src/app/my-activities/page.tsx`.

### Testing
- Ejecuté el linter con `pnpm -s lint`, el comando finalizó correctamente y reportó advertencias de Prettier en archivos no modificados por este cambio.
- No se añadieron tests automáticos específicos para el nuevo filtro en este PR.
- Riesgos / notas pendientes: falta cobertura automatizada que verifique el comportamiento del filtro con combinaciones de grupos y participaciones (recomendar agregar pruebas de integración/unitarias para `my-activities`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7d6ab5054832893baee4cf53566fd)