### PR TITLE
Rediseña sesiones anuales: calendario semanal y profesores por sesión

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -32,6 +32,7 @@ type AnnualScheduleDraft = {
   weekday: string;
   schedule: string;
   groupId: string;
+  professorIds: string[];
 };
 
 type AnnualSharedDraft = {
@@ -83,6 +84,7 @@ function createEmptyScheduleDraft(): AnnualScheduleDraft {
     weekday: '1',
     schedule: '',
     groupId: '',
+    professorIds: [],
   };
 }
 
@@ -250,6 +252,10 @@ export default function EditActivityForm({
           setError(`Completá el horario de la sesión ${i + 1}`);
           return;
         }
+        if (draft.professorIds.length === 0) {
+          setError(`Seleccioná al menos un profesor en la sesión ${i + 1}`);
+          return;
+        }
       }
     }
 
@@ -274,6 +280,7 @@ export default function EditActivityForm({
               weekday: Number(d.weekday),
               schedule: d.schedule.trim(),
               groupId: d.groupId || undefined,
+              professorIds: d.professorIds,
             }))
           : [];
 
@@ -665,6 +672,38 @@ export default function EditActivityForm({
                           </option>
                         ))}
                       </select>
+                    </div>
+
+                    <div className="space-y-1">
+                      <label className="text-sm font-medium">
+                        Profesores de esta sesión
+                      </label>
+                      <div className="max-h-28 space-y-1 overflow-auto rounded border p-2">
+                        {professors.map((professor) => (
+                          <label
+                            key={professor.id}
+                            className="flex items-center gap-2 text-xs"
+                          >
+                            <input
+                              type="checkbox"
+                              checked={draft.professorIds.includes(
+                                professor.id
+                              )}
+                              onChange={(e) =>
+                                updateScheduleDraft(draft.tempId, {
+                                  professorIds: e.target.checked
+                                    ? [...draft.professorIds, professor.id]
+                                    : draft.professorIds.filter(
+                                        (id) => id !== professor.id
+                                      ),
+                                })
+                              }
+                            />
+                            {professor.name ?? 'Sin nombre'}{' '}
+                            {professor.lastName ?? ''}
+                          </label>
+                        ))}
+                      </div>
                     </div>
                   </div>
                 ))}

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -26,6 +26,7 @@ type AnnualScheduleDraft = {
   weekday: string;
   schedule: string;
   groupTempId: string;
+  professorIds: string[];
 };
 
 type AnnualSharedDraft = {
@@ -64,6 +65,7 @@ function createEmptyAnnualScheduleDraft(): AnnualScheduleDraft {
     weekday: '1',
     schedule: '',
     groupTempId: '',
+    professorIds: [],
   };
 }
 
@@ -117,10 +119,10 @@ export default function CreateActivityForm({
     setGroups((current) => current.filter((group) => group.tempId !== tempId));
   }
 
-  function addAnnualScheduleDraft() {
+  function addAnnualScheduleDraft(weekday = '1') {
     setAnnualSchedules((current) => [
       ...current,
-      createEmptyAnnualScheduleDraft(),
+      { ...createEmptyAnnualScheduleDraft(), weekday },
     ]);
   }
 
@@ -180,12 +182,18 @@ export default function CreateActivityForm({
                   `Completá el horario de la sesión ${index + 1}`
                 );
               }
+              if (draft.professorIds.length === 0) {
+                throw new Error(
+                  `Seleccioná al menos un profesor en la sesión ${index + 1}`
+                );
+              }
 
               return {
                 tempId: draft.tempId,
                 weekday: Number(draft.weekday),
                 schedule: draft.schedule.trim(),
                 groupTempId: draft.groupTempId || undefined,
+                professorIds: draft.professorIds,
               };
             })
           : [];
@@ -469,98 +477,111 @@ export default function CreateActivityForm({
             </div>
           </div>
 
-          <div className="flex items-start justify-between gap-4">
-            <div>
-              <p className="text-sm font-semibold">Sesiones semanales</p>
-              <p className="text-xs text-muted-foreground">
-                Cada bloque define un día fijo de la semana, un horario y un
-                grupo. La ubicación, el deporte y la descripción son comunes a
-                todas las sesiones.
-              </p>
-            </div>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={addAnnualScheduleDraft}
-            >
-              Agregar sesión
-            </Button>
+          <p className="text-sm font-semibold">Calendario semanal</p>
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {WEEKDAY_OPTIONS.slice(1)
+              .concat(WEEKDAY_OPTIONS[0])
+              .map((day) => {
+                const daySessions = annualSchedules.filter(
+                  (draft) => draft.weekday === day.value
+                );
+                return (
+                  <div
+                    key={day.value}
+                    className="space-y-2 rounded-lg border p-3"
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium">{day.label}</p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="h-7 px-2 text-xs"
+                        onClick={() => addAnnualScheduleDraft(day.value)}
+                      >
+                        + Sesión
+                      </Button>
+                    </div>
+                    {daySessions.length === 0 ? (
+                      <p className="text-xs text-muted-foreground">
+                        Sin sesiones.
+                      </p>
+                    ) : (
+                      daySessions.map((draft) => (
+                        <div
+                          key={draft.tempId}
+                          className="space-y-2 rounded-md border p-2"
+                        >
+                          <div className="flex justify-end">
+                            <button
+                              type="button"
+                              onClick={() =>
+                                removeAnnualScheduleDraft(draft.tempId)
+                              }
+                              className="text-xs text-destructive"
+                            >
+                              Quitar
+                            </button>
+                          </div>
+                          <input
+                            type="text"
+                            placeholder="Horario"
+                            value={draft.schedule}
+                            onChange={(e) =>
+                              updateAnnualScheduleDraft(draft.tempId, {
+                                schedule: e.target.value,
+                              })
+                            }
+                            className={inputClass}
+                          />
+                          <select
+                            value={draft.groupTempId}
+                            onChange={(e) =>
+                              updateAnnualScheduleDraft(draft.tempId, {
+                                groupTempId: e.target.value,
+                              })
+                            }
+                            className={inputClass}
+                          >
+                            <option value="">Sin grupo</option>
+                            {groups.map((group) => (
+                              <option key={group.tempId} value={group.tempId}>
+                                {group.name}
+                              </option>
+                            ))}
+                          </select>
+                          <div className="max-h-28 space-y-1 overflow-auto rounded border p-2">
+                            {professors.map((professor) => (
+                              <label
+                                key={professor.id}
+                                className="flex items-center gap-2 text-xs"
+                              >
+                                <input
+                                  type="checkbox"
+                                  checked={draft.professorIds.includes(
+                                    professor.id
+                                  )}
+                                  onChange={(e) =>
+                                    updateAnnualScheduleDraft(draft.tempId, {
+                                      professorIds: e.target.checked
+                                        ? [...draft.professorIds, professor.id]
+                                        : draft.professorIds.filter(
+                                            (id) => id !== professor.id
+                                          ),
+                                    })
+                                  }
+                                />
+                                {professor.name ?? 'Sin nombre'}{' '}
+                                {professor.lastName ?? ''}
+                              </label>
+                            ))}
+                          </div>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                );
+              })}
           </div>
-
-          {annualSchedules.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No hay sesiones cargadas todavía.
-            </p>
-          ) : (
-            <div className="space-y-4">
-              {annualSchedules.map((draft, index) => (
-                <div
-                  key={draft.tempId}
-                  className="space-y-3 rounded-lg border p-4"
-                >
-                  <div className="flex items-center justify-between gap-4">
-                    <p className="text-sm font-medium">Sesión {index + 1}</p>
-                    <button
-                      type="button"
-                      onClick={() => removeAnnualScheduleDraft(draft.tempId)}
-                      className="text-xs text-destructive hover:text-destructive/80"
-                    >
-                      Quitar
-                    </button>
-                  </div>
-
-                  <div className="grid gap-3 sm:grid-cols-2">
-                    <select
-                      value={draft.weekday}
-                      onChange={(e) =>
-                        updateAnnualScheduleDraft(draft.tempId, {
-                          weekday: e.target.value,
-                        })
-                      }
-                      className={inputClass}
-                    >
-                      {WEEKDAY_OPTIONS.map((option) => (
-                        <option key={option.value} value={option.value}>
-                          {option.label}
-                        </option>
-                      ))}
-                    </select>
-                    <input
-                      type="text"
-                      placeholder="Horario"
-                      value={draft.schedule}
-                      onChange={(e) =>
-                        updateAnnualScheduleDraft(draft.tempId, {
-                          schedule: e.target.value,
-                        })
-                      }
-                      className={inputClass}
-                    />
-                  </div>
-
-                  <div className="space-y-1">
-                    <label className="text-sm font-medium">Grupo</label>
-                    <select
-                      value={draft.groupTempId}
-                      onChange={(e) =>
-                        updateAnnualScheduleDraft(draft.tempId, {
-                          groupTempId: e.target.value,
-                        })
-                      }
-                      className={inputClass}
-                    >
-                      <option value="">Sin grupo</option>
-                      {groups.map((group) => (
-                        <option key={group.tempId} value={group.tempId}>
-                          {group.name}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
         </div>
       )}
 

--- a/src/app/api/activities/[id]/route.ts
+++ b/src/app/api/activities/[id]/route.ts
@@ -19,16 +19,22 @@ export async function PUT(
   }
   const data = activityUpdateSchema.parse(await req.json());
   const professorIds = Array.from(new Set(data.professorIds ?? []));
-  if (data.professorIds !== undefined && professorIds.length > 0) {
+  const annualProfessorIds = Array.from(
+    new Set(data.annualSchedules.flatMap((schedule) => schedule.professorIds))
+  );
+  const professorIdsToValidate = Array.from(
+    new Set([...professorIds, ...annualProfessorIds])
+  );
+  if (professorIdsToValidate.length > 0) {
     const validProfessors = await prisma.user.findMany({
       where: {
-        id: { in: professorIds },
+        id: { in: professorIdsToValidate },
         roleAssignments: { some: { role: 'PROFESSOR' } },
         isActive: true,
       },
       select: { id: true },
     });
-    if (validProfessors.length !== professorIds.length) {
+    if (validProfessors.length !== professorIdsToValidate.length) {
       return NextResponse.json(
         { error: 'Uno o más profesores no son válidos' },
         { status: 400 }
@@ -113,15 +119,26 @@ export async function PUT(
             };
           });
 
-          if (professorIds.length > 0) {
+          const professorIdsForDays = annualProfessorIds.length
+            ? annualProfessorIds
+            : professorIds;
+
+          if (professorIdsForDays.length > 0) {
             const createdDays = await tx.activityDay.createManyAndReturn({
               data: dayData,
               select: { id: true },
             });
             await tx.activityDayProfessor.createMany({
-              data: createdDays.flatMap(({ id: activityDayId }) =>
-                professorIds.map((userId) => ({ activityDayId, userId }))
-              ),
+              data: createdDays.flatMap(({ id: activityDayId }, index) => {
+                const sessionProfessorIds = annualDays[index]?.professorIds
+                  ?.length
+                  ? annualDays[index].professorIds
+                  : professorIdsForDays;
+                return sessionProfessorIds.map((userId) => ({
+                  activityDayId,
+                  userId,
+                }));
+              }),
             });
           } else {
             await tx.activityDay.createMany({ data: dayData });

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -15,16 +15,22 @@ export async function POST(req: Request) {
   }
   const data = activityCreateSchema.parse(await req.json());
   const professorIds = Array.from(new Set(data.professorIds ?? []));
-  if (professorIds.length > 0) {
+  const annualProfessorIds = Array.from(
+    new Set(data.annualSchedules.flatMap((schedule) => schedule.professorIds))
+  );
+  const professorIdsToValidate = Array.from(
+    new Set([...professorIds, ...annualProfessorIds])
+  );
+  if (professorIdsToValidate.length > 0) {
     const validProfessors = await prisma.user.findMany({
       where: {
-        id: { in: professorIds },
+        id: { in: professorIdsToValidate },
         roleAssignments: { some: { role: 'PROFESSOR' } },
         isActive: true,
       },
       select: { id: true },
     });
-    if (validProfessors.length !== professorIds.length) {
+    if (validProfessors.length !== professorIdsToValidate.length) {
       return NextResponse.json(
         { error: 'Uno o más profesores no son válidos' },
         { status: 400 }
@@ -76,6 +82,16 @@ export async function POST(req: Request) {
       }
 
       if (data.activityType === 'ANNUAL') {
+        const annualScheduleProfessorIds = Array.from(
+          new Set(
+            data.annualSchedules.flatMap((schedule) => schedule.professorIds)
+          )
+        );
+        const professorIdsForDays =
+          annualScheduleProfessorIds.length > 0
+            ? annualScheduleProfessorIds
+            : professorIds;
+
         const annualDays = buildAnnualActivityDays(
           data.date,
           data.endDate,
@@ -113,15 +129,22 @@ export async function POST(req: Request) {
           };
         });
 
-        if (professorIds.length > 0) {
+        if (professorIdsForDays.length > 0) {
           const createdDays = await tx.activityDay.createManyAndReturn({
             data: dayData,
             select: { id: true },
           });
           await tx.activityDayProfessor.createMany({
-            data: createdDays.flatMap(({ id: activityDayId }) =>
-              professorIds.map((userId) => ({ activityDayId, userId }))
-            ),
+            data: createdDays.flatMap(({ id: activityDayId }, index) => {
+              const sessionProfessorIds = annualDays[index]?.professorIds
+                ?.length
+                ? annualDays[index].professorIds
+                : professorIdsForDays;
+              return sessionProfessorIds.map((userId) => ({
+                activityDayId,
+                userId,
+              }));
+            }),
           });
         } else {
           await tx.activityDay.createMany({ data: dayData });

--- a/src/lib/activities/annual-schedule.ts
+++ b/src/lib/activities/annual-schedule.ts
@@ -4,6 +4,7 @@ type AnnualScheduleTemplate = {
   schedule: string;
   groupTempId?: string;
   groupId?: string;
+  professorIds?: string[];
 };
 
 type AnnualSharedFields = {

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -26,6 +26,7 @@ const annualScheduleSchema = z.object({
   weekday: z.number().int().min(0).max(6),
   schedule: z.string().min(1),
   groupTempId: z.string().min(1).optional(),
+  professorIds: z.array(z.string().min(1)).min(1),
 });
 
 const annualScheduleEditSchema = z.object({
@@ -33,6 +34,7 @@ const annualScheduleEditSchema = z.object({
   weekday: z.number().int().min(0).max(6),
   schedule: z.string().min(1),
   groupId: z.string().min(1).optional(),
+  professorIds: z.array(z.string().min(1)).min(1),
 });
 
 const activityGroupDraftSchema = z.object({


### PR DESCRIPTION
### Motivation
- Implementar una UI de creación de sesiones anual tipo calendario (lunes a domingo) donde cada sesión pueda definirse con horario, grupo y uno o más profesores, y propagar esa información al backend para crear/asignar profesores por cada día generado.

### Description
- Reemplacé la UI de sesiones en la creación por un calendario semanal que permite agregar sesiones por día y, en cada sesión, definir `horario`, `grupo` y `profesores` (checkboxes por profesor). La edición ahora almacena también `professorIds` por sesión para paridad de datos.
- Extendí las validaciones frontend/backend para exigir al menos un profesor por sesión anual y añadí el campo `professorIds` en los payloads de sesiones anuales (`zod` schemas actualizados).  
- Ajusté la lógica de creación/edición en los endpoints para validar profesores globales y por sesión, generar los `ActivityDay` a partir del calendario anual y crear registros `ActivityDayProfessor` por cada día usando los profesores definidos en la sesión correspondiente.
- Añadí soporte a `buildAnnualActivityDays` para transportar `professorIds` desde las plantillas hasta los días generados.
- Files touched: `src/app/activities/new/form.tsx`, `src/app/activities/[id]/edit/form.tsx`, `src/lib/validations/activity.ts`, `src/app/api/activities/route.ts`, `src/app/api/activities/[id]/route.ts`, `src/lib/activities/annual-schedule.ts`.

### Testing
- Ejecuté `pnpm lint`; la tarea se completó (hay warnings de formato preexistentes en el repo pero no errores nuevos).  
- Ejecuté `pnpm prettier --write` sobre los archivos modificados para normalizar formato; completó correctamente.  
- Unresolved risks: la UI de edición mantiene el layout listado (no está aún visualmente en formato calendario como la creación), por lo que puede existir desajuste UX si se requiere paridad inmediata; además la API ahora combina profesores “globales” y profesores “por sesión”, conviene validar con QA/UX si se desea mantener ambos conceptos o privilegiar solo el listado por sesión.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7db3993048328b4ab8012665ed003)