### PR TITLE
Hide sessions panel for admins on annual activities

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -312,7 +312,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const isParticipantInActivity = registrations.length > 0;
   const canSeeSessions = isAdmin || isProfessor || isParticipantInActivity;
-  const showSessionsPanel = !(isAdmin && activity.activityType === 'ANNUAL');
+  const showSessionsPanel = activity.activityType !== 'ANNUAL';
   const activityListHref = isParticipantInActivity
     ? '/my-activities'
     : '/activities';

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -312,6 +312,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const isParticipantInActivity = registrations.length > 0;
   const canSeeSessions = isAdmin || isProfessor || isParticipantInActivity;
+  const showSessionsPanel = !(isAdmin && activity.activityType === 'ANNUAL');
   const activityListHref = isParticipantInActivity
     ? '/my-activities'
     : '/activities';
@@ -436,7 +437,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
-        {canSeeSessions && (
+        {canSeeSessions && showSessionsPanel && (
           <ActivityDaysPanel
             activityId={activity.id}
             canManageDays={canManageDays}


### PR DESCRIPTION
### Motivation
- Admin users should not see the activity sessions (days) inline when viewing an activity that is `ANNUAL`, because those sessions are managed and visible via the calendar and can still be opened individually to view/edit.
- This change reduces clutter on annual activity detail pages and aligns the UI with the requested admin workflow.

### Description
- Added a `showSessionsPanel` flag computed as `!(isAdmin && activity.activityType === 'ANNUAL')` to the activity detail logic.
- Conditioned the render of `ActivityDaysPanel` behind `canSeeSessions && showSessionsPanel` in `src/app/activities/[id]/page.tsx` so admins do not see sessions for annual activities while professors and enrolled participants keep the previous behavior.

### Testing
- Ran `pnpm lint`, which completed successfully; the repo still contains pre-existing Prettier/ESLint warnings unrelated to this change.
- No automated unit or integration tests were added or modified for this small UI visibility change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e4fefd208328866d9355268f8e65)