### PR TITLE
Precargar calendario semanal al editar actividades anuales

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -73,6 +73,7 @@ interface EditActivityFormProps {
     professorIds: string[];
   };
   annualDefaults?: AnnualSharedDraft;
+  initialAnnualSchedules?: Omit<AnnualScheduleDraft, 'tempId'>[];
   professors: ProfessorOption[];
   initialGroups: ExistingGroup[];
   existingDayCount: number;
@@ -91,6 +92,7 @@ function createEmptyScheduleDraft(): AnnualScheduleDraft {
 export default function EditActivityForm({
   activity,
   annualDefaults,
+  initialAnnualSchedules = [],
   professors,
   initialGroups,
   existingDayCount,
@@ -109,7 +111,10 @@ export default function EditActivityForm({
   );
 
   const [annualSchedules, setAnnualSchedules] = useState<AnnualScheduleDraft[]>(
-    []
+    initialAnnualSchedules.map((draft) => ({
+      ...draft,
+      tempId: crypto.randomUUID(),
+    }))
   );
   const [annualShared, setAnnualShared] = useState<AnnualSharedDraft>(
     annualDefaults ?? {

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -28,6 +28,7 @@ export default async function EditActivityPage({
     activityProfessorAssignments,
     existingDayCount,
     firstAnnualDay,
+    annualCalendarSample,
   ] = await Promise.all([
     prisma.user.findMany({
       where: {
@@ -63,7 +64,32 @@ export default async function EditActivityPage({
         description: true,
       },
     }),
+    prisma.activityDay.findMany({
+      where: { activityId: params.id },
+      orderBy: [{ date: 'asc' }, { schedule: 'asc' }],
+      take: 7,
+      select: {
+        id: true,
+        date: true,
+        schedule: true,
+        activityGroupId: true,
+        professors: {
+          select: { userId: true },
+          orderBy: { createdAt: 'asc' },
+        },
+      },
+    }),
   ]);
+
+  const initialAnnualSchedules =
+    activity.activityType === 'ANNUAL'
+      ? annualCalendarSample.map((day) => ({
+          weekday: String(day.date.getUTCDay()),
+          schedule: day.schedule,
+          groupId: day.activityGroupId ?? '',
+          professorIds: day.professors.map((professor) => professor.userId),
+        }))
+      : [];
 
   return (
     <main className="p-4">
@@ -99,6 +125,7 @@ export default async function EditActivityPage({
               }
             : undefined
         }
+        initialAnnualSchedules={initialAnnualSchedules}
         professors={professors}
         initialGroups={groups}
         existingDayCount={existingDayCount}


### PR DESCRIPTION
- what changed: Se precarga un "calendario semanal" de ejemplo al abrir el editor para actividades de tipo `ANNUAL`: la página de edición consulta hasta 7 `ActivityDay` existentes y los mapea a borradores editables con `weekday`, `schedule`, `groupId` y `professorIds`, y el formulario ahora acepta `initialAnnualSchedules` e inicializa `annualSchedules` generando un `tempId` por fila.
- files touched: `src/app/activities/[id]/edit/page.tsx`, `src/app/activities/[id]/edit/form.tsx`.
- tests or verification run: Ejecutado `pnpm -s lint` correctamente; no hubo errores bloqueantes y se observan warnings de Prettier preexistentes en archivos no relacionados.
- unresolved risks: La "semana de ejemplo" se arma con las primeras 7 sesiones cronológicas y puede no representar exactamente una semana calendario completa en actividades con distribución irregular.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e6cbd8448328a77af6068d775c43)