### PR TITLE
Add option to hide session details for annual activities

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -85,6 +85,7 @@ interface ActivityDaysPanelProps {
   defaultProfessorIds: string[];
   registrations: Registration[];
   days: ActivityDay[];
+  hideSessionDetails?: boolean;
 }
 
 const statusLabels: Record<AttendanceStatus, string> = {
@@ -101,6 +102,7 @@ export default function ActivityDaysPanel({
   defaultProfessorIds,
   registrations,
   days,
+  hideSessionDetails = false,
 }: ActivityDaysPanelProps) {
   const router = useRouter();
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -242,7 +244,7 @@ export default function ActivityDaysPanel({
         )}
       </div>
 
-      {canManageDays && showCreateForm && (
+      {canManageDays && showCreateForm && !hideSessionDetails && (
         <div className="mt-5">
           <ActivityDayForm
             activityId={activityId}
@@ -263,6 +265,11 @@ export default function ActivityDaysPanel({
       {days.length === 0 ? (
         <p className="mt-6 text-sm text-muted-foreground font-body">
           Aún no hay días cargados para esta actividad.
+        </p>
+      ) : hideSessionDetails ? (
+        <p className="mt-6 text-sm text-muted-foreground font-body">
+          Las sesiones se visualizan desde el calendario. Hacé click en cada una
+          para ver información y editar según permisos.
         </p>
       ) : (
         <div className="mt-6 space-y-4">

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -312,6 +312,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const isParticipantInActivity = registrations.length > 0;
   const canSeeSessions = isAdmin || isProfessor || isParticipantInActivity;
+  const hideSessionDetails = activity.activityType === 'ANNUAL';
   const activityListHref = isParticipantInActivity
     ? '/my-activities'
     : '/activities';
@@ -444,6 +445,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
             groups={activityGroupOptions}
             defaultProfessorIds={activityProfessorIds}
             registrations={registrations}
+            hideSessionDetails={hideSessionDetails}
             days={daysWithAttendance
               .filter((day: any) => {
                 if (isAdmin) return true;


### PR DESCRIPTION
### Motivation
- Annual activities should expose sessions primarily through the calendar and not show editable session details in the panel, so add a switchable UI mode to prevent confusion and editing where not desired. 
- Provide a simple prop to control whether the session creation form and detailed list are shown so the page can decide based on activity type.

### Description
- Added an optional `hideSessionDetails?: boolean` prop to `ActivityDaysPanel` with a default of `false` and used it to conditionally suppress the `ActivityDayForm` and the detailed session list. 
- When `hideSessionDetails` is true the panel shows a short message guiding users to the calendar instead of rendering session details. 
- The activity page now computes `hideSessionDetails` as `activity.activityType === 'ANNUAL'` and passes it into `ActivityDaysPanel`.

### Testing
- Ran TypeScript type checking with `tsc --noEmit`, which completed successfully. 
- Performed a local Next.js build (`next build`) to verify the pages compile, and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e4fefd208328866d9355268f8e65)