### PR TITLE
Fix annual activity session panel behavior and messaging

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -80,6 +80,7 @@ type ActivityDay = {
 interface ActivityDaysPanelProps {
   activityId: string;
   canManageDays: boolean;
+  hideSessionDetails?: boolean;
   professors: ProfessorOption[];
   groups: GroupOption[];
   defaultProfessorIds: string[];
@@ -96,6 +97,7 @@ const statusLabels: Record<AttendanceStatus, string> = {
 export default function ActivityDaysPanel({
   activityId,
   canManageDays,
+  hideSessionDetails = false,
   professors,
   groups,
   defaultProfessorIds,
@@ -222,11 +224,12 @@ export default function ActivityDaysPanel({
             Días de la actividad
           </h2>
           <p className="text-sm text-muted-foreground font-body mt-1">
-            El profesor puede programar días y los inscriptos confirman si van a
-            asistir.
+            {hideSessionDetails
+              ? 'En actividades anuales, las sesiones se visualizan desde el calendario. Al hacer click en una sesión se abre su detalle para ver o editar según permisos.'
+              : 'El profesor puede programar días y los inscriptos confirman si van a asistir.'}
           </p>
         </div>
-        {canManageDays && (
+        {canManageDays && !hideSessionDetails && (
           <div className="flex flex-col items-start gap-2 sm:items-end">
             <div className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
               Administración de días
@@ -242,7 +245,7 @@ export default function ActivityDaysPanel({
         )}
       </div>
 
-      {canManageDays && showCreateForm && (
+      {canManageDays && !hideSessionDetails && showCreateForm && (
         <div className="mt-5">
           <ActivityDayForm
             activityId={activityId}
@@ -264,7 +267,7 @@ export default function ActivityDaysPanel({
         <p className="mt-6 text-sm text-muted-foreground font-body">
           Aún no hay días cargados para esta actividad.
         </p>
-      ) : (
+      ) : !hideSessionDetails ? (
         <div className="mt-6 space-y-4">
           {visibleDays.map((day) => {
             const goingCount = day.attendances.filter(
@@ -602,7 +605,7 @@ export default function ActivityDaysPanel({
             );
           })}
         </div>
-      )}
+      ) : null}
 
       {pastDays.length > 0 && (
         <details className="mt-6 rounded-lg border bg-background p-4">

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -312,7 +312,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const isParticipantInActivity = registrations.length > 0;
   const canSeeSessions = isAdmin || isProfessor || isParticipantInActivity;
-  const showSessionsPanel = activity.activityType !== 'ANNUAL';
+  const hideSessionDetails = activity.activityType === 'ANNUAL';
   const activityListHref = isParticipantInActivity
     ? '/my-activities'
     : '/activities';
@@ -437,10 +437,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
-        {canSeeSessions && showSessionsPanel && (
+        {canSeeSessions && (
           <ActivityDaysPanel
             activityId={activity.id}
             canManageDays={canManageDays}
+            hideSessionDetails={hideSessionDetails}
             professors={professorOptions}
             groups={activityGroupOptions}
             defaultProfessorIds={activityProfessorIds}


### PR DESCRIPTION
### Motivation
- Evitar que las actividades anuales oculten por completo el panel de sesiones y devolver la posibilidad de ver el calendario cuando el usuario tiene permisos (`canSeeSessions`).
- Mantener la UI limpia para actividades anuales mostrando el calendario pero ocultando el listado detallado y el formulario inline cuando corresponde, y aclarar al usuario dónde ver y cómo abrir los detalles de una sesión.

### Description
- Restablece el renderizado del panel de días en la vista de actividad cuando `canSeeSessions` es verdadero y calcula `hideSessionDetails` para actividades anuales (`activity.activityType === 'ANNUAL'`).
- Añade la prop opcional `hideSessionDetails?: boolean` a `ActivityDaysPanel` y propaga `hideSessionDetails={hideSessionDetails}` desde la página de actividad.
- En `ActivityDaysPanel` se oculta el formulario inline de creación/edición y el listado detallado de sesiones cuando `hideSessionDetails` es `true`, pero el componente `ActivityCalendar` sigue renderizándose.
- Agrega copy explicativo para actividades anuales: "En actividades anuales, las sesiones se visualizan desde el calendario. Al hacer click en una sesión se abre su detalle para ver o editar según permisos." para clarificar el comportamiento.
- Archivos modificados: `src/app/activities/[id]/page.tsx`, `src/app/activities/[id]/activity-days-panel.tsx`.

### Testing
- Ejecuté `pnpm -s eslint src/app/activities/[id]/page.tsx src/app/activities/[id]/activity-days-panel.tsx` y pasó correctamente contra las reglas aplicadas a esos archivos.
- Ejecuté `pnpm -s lint` a nivel de repo y falló por múltiples warnings/estilos preexistentes y por un parse error que se corrigió durante el trabajo, por lo que la verificación completa de lint sigue mostrando issues no relacionados con este cambio.
- No se añadieron tests automatizados unitarios en esta PR; la verificación se limitó a lint/ESLint sobre los archivos tocados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ec7600448328abdb3b5756e1eb84)