### PR TITLE
Add tabbed admin views for activity participants

### DIFF
--- a/src/app/activities/[id]/inscriptos-panel.tsx
+++ b/src/app/activities/[id]/inscriptos-panel.tsx
@@ -37,6 +37,9 @@ export default function InscriptosPanel({
   );
   const [savingId, setSavingId] = useState<string | null>(null);
   const [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState<'all' | 'groups' | 'unassigned'>(
+    'all'
+  );
 
   useEffect(() => {
     setSelectedGroups(
@@ -95,6 +98,16 @@ export default function InscriptosPanel({
     }
   }
 
+  const unassignedParticipants = participants.filter((p) => !p.groupId);
+  const groupsWithMembers = groups
+    .map((group) => ({
+      ...group,
+      members: participants.filter(
+        (participant) => participant.groupId === group.id
+      ),
+    }))
+    .filter((group) => group.members.length > 0);
+
   return (
     <section className="mt-8 rounded-xl border bg-card p-6 shadow-sm">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -116,84 +129,151 @@ export default function InscriptosPanel({
           Aún no hay inscriptos en esta actividad.
         </p>
       ) : (
-        <ul className="mt-6 divide-y divide-border">
-          {participants.map((participant) => {
-            const selectedGroupId = selectedGroups[participant.id] ?? '';
-            const currentGroupId = participant.groupId ?? '';
-            const isSaving = savingId === participant.id;
+        <>
+          <div className="mt-6 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => setActiveTab('all')}
+              className={`rounded-full border px-3 py-1.5 text-sm font-body transition-colors ${activeTab === 'all' ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-muted-foreground hover:text-foreground'}`}
+            >
+              Todos ({participants.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('groups')}
+              className={`rounded-full border px-3 py-1.5 text-sm font-body transition-colors ${activeTab === 'groups' ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-muted-foreground hover:text-foreground'}`}
+            >
+              Grupos asignados ({groupsWithMembers.length})
+            </button>
+            <button
+              type="button"
+              onClick={() => setActiveTab('unassigned')}
+              className={`rounded-full border px-3 py-1.5 text-sm font-body transition-colors ${activeTab === 'unassigned' ? 'border-primary bg-primary text-primary-foreground' : 'border-border text-muted-foreground hover:text-foreground'}`}
+            >
+              Sin grupo ({unassignedParticipants.length})
+            </button>
+          </div>
 
-            return (
-              <li
-                key={participant.id}
-                className="py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-              >
-                <div className="flex-1 min-w-0">
-                  <p className="font-medium">{participant.name}</p>
-                  <p className="text-sm text-muted-foreground font-body">
-                    {participant.subtitle}
-                  </p>
-                  <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground font-body">
-                    {participant.receipt && (
-                      <span>Comprobante {participant.receipt}</span>
-                    )}
-                    {participant.receiptDate && (
-                      <span>
-                        {participant.receipt ? '· ' : ''}
-                        Pago aprobado el{' '}
-                        {new Date(participant.receiptDate).toLocaleDateString(
-                          'es-AR',
-                          {
-                            day: 'numeric',
-                            month: 'long',
-                            year: 'numeric',
-                          }
+          {activeTab === 'all' && (
+            <ul className="mt-4 divide-y divide-border">
+              {participants.map((participant) => {
+                const selectedGroupId = selectedGroups[participant.id] ?? '';
+                const currentGroupId = participant.groupId ?? '';
+                const isSaving = savingId === participant.id;
+
+                return (
+                  <li
+                    key={participant.id}
+                    className="py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium">{participant.name}</p>
+                      <p className="text-sm text-muted-foreground font-body">
+                        {participant.subtitle}
+                      </p>
+                      <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground font-body">
+                        {participant.receipt && (
+                          <span>Comprobante {participant.receipt}</span>
                         )}
-                      </span>
-                    )}
-                  </div>
-                </div>
-
-                <div className="flex items-center gap-3 shrink-0">
-                  <span className="text-sm text-muted-foreground font-body">
-                    {participant.isChild ? 'Hijo/a' : 'Titular'}
-                  </span>
-
-                  {canAssignGroups && groups.length > 0 && (
-                    <div className="flex items-center gap-2">
-                      <select
-                        className="rounded-md border bg-background px-2 py-1.5 text-sm"
-                        value={selectedGroupId}
-                        onChange={(e) =>
-                          setSelectedGroups((current) => ({
-                            ...current,
-                            [participant.id]: e.target.value,
-                          }))
-                        }
-                      >
-                        <option value="">Sin grupo</option>
-                        {groups.map((group) => (
-                          <option key={group.id} value={group.id}>
-                            {group.name}
-                          </option>
-                        ))}
-                      </select>
-                      <button
-                        type="button"
-                        disabled={
-                          isSaving || selectedGroupId === currentGroupId
-                        }
-                        onClick={() => saveGroup(participant.id)}
-                        className="rounded-md border border-border bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                      >
-                        {isSaving ? '...' : 'Guardar'}
-                      </button>
+                        {participant.receiptDate && (
+                          <span>
+                            {participant.receipt ? '· ' : ''}
+                            Pago aprobado el{' '}
+                            {new Date(
+                              participant.receiptDate
+                            ).toLocaleDateString('es-AR', {
+                              day: 'numeric',
+                              month: 'long',
+                              year: 'numeric',
+                            })}
+                          </span>
+                        )}
+                      </div>
                     </div>
-                  )}
-                </div>
-              </li>
-            );
-          })}
-        </ul>
+
+                    <div className="flex items-center gap-3 shrink-0">
+                      <span className="text-sm text-muted-foreground font-body">
+                        {participant.isChild ? 'Hijo/a' : 'Titular'}
+                      </span>
+
+                      {canAssignGroups && groups.length > 0 && (
+                        <div className="flex items-center gap-2">
+                          <select
+                            className="rounded-md border bg-background px-2 py-1.5 text-sm"
+                            value={selectedGroupId}
+                            onChange={(e) =>
+                              setSelectedGroups((current) => ({
+                                ...current,
+                                [participant.id]: e.target.value,
+                              }))
+                            }
+                          >
+                            <option value="">Sin grupo</option>
+                            {groups.map((group) => (
+                              <option key={group.id} value={group.id}>
+                                {group.name}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            type="button"
+                            disabled={
+                              isSaving || selectedGroupId === currentGroupId
+                            }
+                            onClick={() => saveGroup(participant.id)}
+                            className="rounded-md border border-border bg-primary px-2.5 py-1.5 text-xs font-medium text-primary-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            {isSaving ? '...' : 'Guardar'}
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {activeTab === 'groups' && (
+            <div className="mt-4 space-y-4">
+              {groupsWithMembers.length === 0 ? (
+                <p className="text-sm text-muted-foreground font-body">
+                  Todavía no hay inscriptos asignados a grupos.
+                </p>
+              ) : (
+                groupsWithMembers.map((group) => (
+                  <div key={group.id} className="rounded-lg border p-4">
+                    <p className="font-medium">{group.name}</p>
+                    <ul className="mt-2 space-y-1 text-sm text-muted-foreground font-body">
+                      {group.members.map((member) => (
+                        <li key={member.id}>{member.name}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))
+              )}
+            </div>
+          )}
+
+          {activeTab === 'unassigned' && (
+            <ul className="mt-4 divide-y divide-border">
+              {unassignedParticipants.length === 0 ? (
+                <li className="py-4 text-sm text-muted-foreground font-body">
+                  Todos los inscriptos ya tienen grupo asignado.
+                </li>
+              ) : (
+                unassignedParticipants.map((participant) => (
+                  <li key={participant.id} className="py-4">
+                    <p className="font-medium">{participant.name}</p>
+                    <p className="text-sm text-muted-foreground font-body">
+                      {participant.subtitle}
+                    </p>
+                  </li>
+                ))
+              )}
+            </ul>
+          )}
+        </>
       )}
 
       {error && <p className="mt-4 text-sm text-destructive">{error}</p>}


### PR DESCRIPTION
### Motivation
- Provide administrators a clearer way to browse activity registrations by showing all participants, groups with their members, and participants without a group in separate tabs.

### Description
- Added an `activeTab` state and tab buttons to `src/app/activities/[id]/inscriptos-panel.tsx` to switch between **Todos**, **Grupos asignados**, and **Sin grupo** views.
- Added derived lists `unassignedParticipants` and `groupsWithMembers` and rendered each tab's content while preserving the existing group assignment/unassignment UI and `saveGroup` flow.
- Kept the original participant list and group assignment behavior under the **Todos** tab and left group editing disabled in the group-only and unassigned-only views.

### Testing
- Ran `pnpm prettier --write src/app/activities/[id]/inscriptos-panel.tsx` which formatted the modified file successfully.
- Ran `pnpm lint` which completed successfully (exit code 0) and reported unrelated existing Prettier warnings in other files; no lint errors introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f00631348328aa7a4be03643f46f)