### PR TITLE
Hide session details for annual activities; show calendar and group members

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -80,6 +80,7 @@ type ActivityDay = {
 interface ActivityDaysPanelProps {
   activityId: string;
   canManageDays: boolean;
+  hideSessionDetails?: boolean;
   professors: ProfessorOption[];
   groups: GroupOption[];
   defaultProfessorIds: string[];
@@ -96,6 +97,7 @@ const statusLabels: Record<AttendanceStatus, string> = {
 export default function ActivityDaysPanel({
   activityId,
   canManageDays,
+  hideSessionDetails = false,
   professors,
   groups,
   defaultProfessorIds,
@@ -222,11 +224,12 @@ export default function ActivityDaysPanel({
             Días de la actividad
           </h2>
           <p className="text-sm text-muted-foreground font-body mt-1">
-            El profesor puede programar días y los inscriptos confirman si van a
-            asistir.
+            {hideSessionDetails
+              ? 'En actividades anuales, las sesiones se visualizan desde el calendario. Al hacer click en una sesión se abre su detalle para ver o editar según permisos.'
+              : 'El profesor puede programar días y los inscriptos confirman si van a asistir.'}
           </p>
         </div>
-        {canManageDays && (
+        {canManageDays && !hideSessionDetails && (
           <div className="flex flex-col items-start gap-2 sm:items-end">
             <div className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground">
               Administración de días
@@ -242,7 +245,7 @@ export default function ActivityDaysPanel({
         )}
       </div>
 
-      {canManageDays && showCreateForm && (
+      {canManageDays && !hideSessionDetails && showCreateForm && (
         <div className="mt-5">
           <ActivityDayForm
             activityId={activityId}
@@ -264,7 +267,7 @@ export default function ActivityDaysPanel({
         <p className="mt-6 text-sm text-muted-foreground font-body">
           Aún no hay días cargados para esta actividad.
         </p>
-      ) : (
+      ) : !hideSessionDetails ? (
         <div className="mt-6 space-y-4">
           {visibleDays.map((day) => {
             const goingCount = day.attendances.filter(
@@ -283,6 +286,11 @@ export default function ActivityDaysPanel({
                   `${professor.name ?? 'Sin nombre'}${professor.lastName ? ` ${professor.lastName}` : ''}`
               )
               .join(', ');
+            const groupMembers = day.activityGroupId
+              ? registrations.filter(
+                  (registration) => registration.groupId === day.activityGroupId
+                )
+              : [];
             const isEditing = editingDayId === day.id;
 
             return (
@@ -311,6 +319,14 @@ export default function ActivityDaysPanel({
                     {day.activityGroup && (
                       <p className="mt-1 text-xs text-muted-foreground">
                         Restringida al grupo {day.activityGroup.name}
+                      </p>
+                    )}
+                    {day.activityGroup && (
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        Integrantes asignados:{' '}
+                        {groupMembers.length > 0
+                          ? groupMembers.map((member) => member.label).join(', ')
+                          : 'Sin integrantes asignados.'}
                       </p>
                     )}
                     {mapHref && (
@@ -602,7 +618,7 @@ export default function ActivityDaysPanel({
             );
           })}
         </div>
-      )}
+      ) : null}
 
       {pastDays.length > 0 && (
         <details className="mt-6 rounded-lg border bg-background p-4">

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -312,7 +312,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
 
   const isParticipantInActivity = registrations.length > 0;
   const canSeeSessions = isAdmin || isProfessor || isParticipantInActivity;
-  const showSessionsPanel = activity.activityType !== 'ANNUAL';
+  const hideSessionDetails = activity.activityType === 'ANNUAL';
   const activityListHref = isParticipantInActivity
     ? '/my-activities'
     : '/activities';
@@ -437,10 +437,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
-        {canSeeSessions && showSessionsPanel && (
+        {canSeeSessions && (
           <ActivityDaysPanel
             activityId={activity.id}
             canManageDays={canManageDays}
+            hideSessionDetails={hideSessionDetails}
             professors={professorOptions}
             groups={activityGroupOptions}
             defaultProfessorIds={activityProfessorIds}


### PR DESCRIPTION
### Motivation
- Annual activities should not expose per-session editable details in the activity page and should be managed via the calendar view instead.
- Creation and day-management controls must be suppressed for activities that are annual to avoid confusion.
- It is useful to surface which registered participants belong to a restricted activity group on each session.

### Description
- Added a `hideSessionDetails?: boolean` prop to `ActivityDaysPanel` with default `false` and used it to change the header text when session details are hidden.
- When `hideSessionDetails` is true the panel hides the day-management area and the create-session form and it suppresses the detailed session list while still rendering the calendar.
- Added computation and rendering of group members for days restricted to an activity group by deriving `groupMembers` from `registrations` and showing their labels or a fallback when empty.
- Computed `hideSessionDetails` in the activity page as `activity.activityType === 'ANNUAL'` and passed it into `ActivityDaysPanel`, removing the previous `showSessionsPanel` usage.

### Testing
- Ran TypeScript type-check (`yarn tsc`) and the project build checks which passed without type errors.
- Ran the repository linting (`yarn lint`) which completed successfully.
- Executed the unit test suite (`yarn test`) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ec7600448328abdb3b5756e1eb84)