### PR TITLE
Fix mobile group assignment in inscritos drag-and-drop

### DIFF
--- a/src/app/activities/[id]/inscriptos-panel.tsx
+++ b/src/app/activities/[id]/inscriptos-panel.tsx
@@ -47,6 +47,8 @@ export default function InscriptosPanel({
   const [dropTargetGroupId, setDropTargetGroupId] = useState<string | null>(
     null
   );
+  const [selectedParticipantIdForAssign, setSelectedParticipantIdForAssign] =
+    useState<string | null>(null);
 
   useEffect(() => {
     setSelectedGroups(
@@ -121,11 +123,14 @@ export default function InscriptosPanel({
   );
 
   async function handleDropInGroup(targetGroupId: string) {
-    if (!draggingParticipantId || savingId) return;
+    const participantId =
+      draggingParticipantId ?? selectedParticipantIdForAssign;
+    if (!participantId || savingId) return;
 
     setDropTargetGroupId(null);
-    await saveGroup(draggingParticipantId, targetGroupId);
+    await saveGroup(participantId, targetGroupId);
     setDraggingParticipantId(null);
+    setSelectedParticipantIdForAssign(null);
   }
 
   function handleDragStart(participantId: string) {
@@ -136,6 +141,14 @@ export default function InscriptosPanel({
   function handleDragEnd() {
     setDraggingParticipantId(null);
     setDropTargetGroupId(null);
+  }
+
+  function handleParticipantTapToAssign(participantId: string) {
+    if (!canAssignGroups || savingId) return;
+    setError('');
+    setSelectedParticipantIdForAssign((current) =>
+      current === participantId ? null : participantId
+    );
   }
 
   return (
@@ -296,7 +309,8 @@ export default function InscriptosPanel({
                   <div className="rounded-lg border border-dashed bg-muted/20 p-4">
                     <p className="text-sm font-medium">Sin grupo</p>
                     <p className="mt-1 text-xs text-muted-foreground font-body">
-                      Arrastrá un inscripto hacia un grupo para asignarlo.
+                      Arrastrá y soltá (desktop) o tocá participante y luego
+                      grupo (móvil).
                     </p>
                     <ul className="mt-3 space-y-2">
                       {unassignedParticipants.map((participant) => (
@@ -305,7 +319,10 @@ export default function InscriptosPanel({
                           draggable={canAssignGroups && groups.length > 0}
                           onDragStart={() => handleDragStart(participant.id)}
                           onDragEnd={handleDragEnd}
-                          className="cursor-grab rounded-md border bg-background px-3 py-2 active:cursor-grabbing"
+                          onClick={() =>
+                            handleParticipantTapToAssign(participant.id)
+                          }
+                          className={`rounded-md border bg-background px-3 py-2 transition-colors ${canAssignGroups && groups.length > 0 ? 'cursor-pointer md:cursor-grab md:active:cursor-grabbing' : ''} ${selectedParticipantIdForAssign === participant.id ? 'border-primary bg-primary/5' : ''}`}
                         >
                           <p className="font-medium">{participant.name}</p>
                           <p className="text-sm text-muted-foreground font-body">
@@ -332,6 +349,9 @@ export default function InscriptosPanel({
                         }}
                         onDrop={(event) => {
                           event.preventDefault();
+                          void handleDropInGroup(group.id);
+                        }}
+                        onClick={() => {
                           void handleDropInGroup(group.id);
                         }}
                         className={`rounded-lg border p-4 transition-colors ${dropTargetGroupId === group.id ? 'border-primary bg-primary/5' : 'border-border bg-card'}`}


### PR DESCRIPTION
### Motivation
- Mobile browsers often have unreliable or missing HTML5 drag-and-drop support, so admins could not assign ungrouped inscritos to groups from touch devices.

### Description
- Added a touch-friendly assignment flow by introducing `selectedParticipantIdForAssign` state and `handleParticipantTapToAssign` to let admins tap a participant and then tap a group to assign them, while preserving desktop drag-and-drop behavior via `handleDropInGroup` in `src/app/activities/[id]/inscriptos-panel.tsx`.
- Reused `handleDropInGroup` to perform the actual API call (`saveGroup`) for both drag and tap flows to keep logic centralized.
- Updated UI helper text and added visual highlighting for the selected participant to make the mobile flow clear to users.
- Files touched: `src/app/activities/[id]/inscriptos-panel.tsx`.

### Testing
- Ran `pnpm -s eslint src/app/activities/[id]/inscriptos-panel.tsx` and resolved lint/format warnings successfully.
- Ran `pnpm -s prettier --write src/app/activities/[id]/inscriptos-panel.tsx` to apply formatting, which completed successfully.
- Automated checks: linting and formatting passed for the modified file.
- Unresolved risks: no E2E or manual touch-device tests were executed; recommend validating the UX on iOS Safari and Android Chrome to confirm tap/tap interaction and visual feedback behave as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7f9a254008328a5d8bbfea492183b)