### PR TITLE
Mostrar edad de inscriptos en el panel de actividad

### DIFF
--- a/src/app/activities/[id]/inscriptos-panel.tsx
+++ b/src/app/activities/[id]/inscriptos-panel.tsx
@@ -14,6 +14,7 @@ type InscriptosParticipant = {
   isChild: boolean;
   groupId: string | null;
   groupName: string | null;
+  age: number | null;
 };
 
 interface InscriptosPanelProps {
@@ -172,6 +173,9 @@ export default function InscriptosPanel({
                   >
                     <p className="font-medium">{participant.name}</p>
                     <p className="text-sm text-muted-foreground font-body">{participant.subtitle}</p>
+                    {participant.age != null && (
+                      <p className="text-xs text-muted-foreground font-body">Edad: {participant.age}</p>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -214,6 +218,9 @@ export default function InscriptosPanel({
                         >
                           <p className="font-medium">{member.name}</p>
                           <p className="text-sm text-muted-foreground font-body">{member.subtitle}</p>
+                          {member.age != null && (
+                            <p className="text-xs text-muted-foreground font-body">Edad: {member.age}</p>
+                          )}
                           {canAssignGroups && (
                             <button
                               type="button"

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -36,6 +36,23 @@ function getParticipantName(participant: ActivityParticipantDetail) {
   return `${participant.user.name ?? 'Sin nombre'}${participant.user.lastName ? ` ${participant.user.lastName}` : ''}`;
 }
 
+
+function getAgeFromBirthDate(birthDate: Date | null) {
+  if (!birthDate) return null;
+
+  const today = new Date();
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const monthDiff = today.getMonth() - birthDate.getMonth();
+
+  if (
+    monthDiff < 0 ||
+    (monthDiff === 0 && today.getDate() < birthDate.getDate())
+  ) {
+    age -= 1;
+  }
+
+  return age >= 0 ? age : null;
+}
 function getParticipantSubtitle(participant: ActivityParticipantDetail) {
   if (participant.child) {
     return `Registrado por ${participant.user.name ?? 'sin nombre'}${participant.user.lastName ? ` ${participant.user.lastName}` : ''}`;
@@ -499,6 +516,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
               id: p.id,
               name: getParticipantName(p),
               subtitle: getParticipantSubtitle(p),
+              age: getAgeFromBirthDate(p.child ? p.child.birthDate : p.user.birthDate),
               receipt: p.receipt ?? null,
               receiptDate: p.receiptDate ? p.receiptDate.toISOString() : null,
               isChild: !!p.child,


### PR DESCRIPTION
- what changed: Se calculó la edad a partir de `birthDate` (usuario o hijo) y se añadió el campo `age` al payload enviado a `InscriptosPanel`, además se renderiza `Edad: X` en las tarjetas de "Sin grupo" y en cada miembro de grupo.
- files touched: `src/app/activities/[id]/page.tsx`, `src/app/activities/[id]/inscriptos-panel.tsx`.
- tests or verification run: Ejecuté `pnpm lint`, que finalizó correctamente y mostró solo warnings de formato (`prettier`) en archivos no relacionados; los cambios aplicados no introdujeron errores de lint blocking.
- unresolved risks: Si un inscripto no tiene `birthDate` cargada la edad no se muestra; el cálculo de edad usa la fecha local y podría tener diferencias en casos límite de cumpleaños o zonas horarias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ff7fe8448328aee01011f24671be)