### PR TITLE
Ajusta vista compacta de inscriptos en canvas de grupos

### DIFF
--- a/src/app/activities/[id]/inscriptos-panel.tsx
+++ b/src/app/activities/[id]/inscriptos-panel.tsx
@@ -240,22 +240,16 @@ export default function InscriptosPanel({
                         onClick={() =>
                           handleParticipantTapToAssign(participant.id)
                         }
-                        className={`rounded-md border bg-card px-3 py-2 transition-colors ${canAssignGroups && groups.length > 0 ? 'cursor-pointer md:cursor-grab md:active:cursor-grabbing' : ''} ${selectedParticipantIdForAssign === participant.id ? 'border-primary bg-primary/5' : ''}`}
+                        className={`rounded-md border bg-card px-3 py-1.5 transition-colors ${canAssignGroups && groups.length > 0 ? 'cursor-pointer md:cursor-grab md:active:cursor-grabbing' : ''} ${selectedParticipantIdForAssign === participant.id ? 'border-primary bg-primary/5' : ''}`}
                       >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="min-w-0">
-                            <p className="font-medium">{participant.name}</p>
-                            <p className="text-sm text-muted-foreground font-body">
-                              {participant.subtitle}
+                        <div className="min-w-0">
+                          <p className="text-xs font-medium leading-tight">
+                            {participant.name}
+                          </p>
+                          {participant.age != null && (
+                            <p className="text-[11px] text-muted-foreground">
+                              {participant.age} años
                             </p>
-                            {participant.age != null && (
-                              <p className="text-xs text-muted-foreground font-body">
-                                Edad: {participant.age}
-                              </p>
-                            )}
-                          </div>
-                          {participant.whatsappPhone && (
-                            <WhatsAppButton phone={participant.whatsappPhone} />
                           )}
                         </div>
                       </li>


### PR DESCRIPTION
### Motivation
- Hacer que los inscriptos en la sección “Sin grupo” ocupen menos espacio y coincidan visualmente con los miembros ya asignados mostrando solo nombre/apellido y edad.

### Description
- Se actualizó `src/app/activities/[id]/inscriptos-panel.tsx` para reducir el padding vertical de las tarjetas (`py-2` → `py-1.5`), eliminar el subtítulo y quitar el botón de WhatsApp en la lista de inscriptos sin grupo, y ajustar la tipografía a tamaños pequeños (`text-xs` / `text-[11px]`) para un formato compacto.

### Testing
- Ejecutado `pnpm -s lint`, que terminó correctamente; se observaron warnings de formato preexistentes en otros archivos no modificados pero no hay errores bloqueantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ed57d0348328a8e01ae081e99768)