### PR TITLE
Agregar acceso al grupo familiar desde Inscriptos de actividad

### DIFF
--- a/src/app/activities/[id]/inscriptos-panel.tsx
+++ b/src/app/activities/[id]/inscriptos-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 type Group = { id: string; name: string };
@@ -16,6 +17,7 @@ type InscriptosParticipant = {
   groupName: string | null;
   age: number | null;
   whatsappPhone?: string | null;
+  detailHref: string;
 };
 
 function getWhatsAppUrl(phone: string) {
@@ -243,9 +245,9 @@ export default function InscriptosPanel({
                         className={`rounded-md border bg-card px-3 py-1.5 transition-colors ${canAssignGroups && groups.length > 0 ? 'cursor-pointer md:cursor-grab md:active:cursor-grabbing' : ''} ${selectedParticipantIdForAssign === participant.id ? 'border-primary bg-primary/5' : ''}`}
                       >
                         <div className="min-w-0">
-                          <p className="text-xs font-medium leading-tight">
+                          <Link href={participant.detailHref} className="text-xs font-medium leading-tight text-link hover:underline" onClick={(event) => event.stopPropagation()}>
                             {participant.name}
-                          </p>
+                          </Link>
                           {participant.age != null && (
                             <p className="text-[11px] text-muted-foreground">
                               {participant.age} años
@@ -309,9 +311,9 @@ export default function InscriptosPanel({
                               )}
                               <div className="flex items-start justify-between gap-1">
                                 <div className="min-w-0">
-                                  <p className="text-xs font-medium leading-tight">
+                                  <Link href={member.detailHref} className="text-xs font-medium leading-tight text-link hover:underline" onClick={(event) => event.stopPropagation()}>
                                     {member.name}
-                                  </p>
+                                  </Link>
                                   {member.age != null && (
                                     <p className="text-[11px] text-muted-foreground">
                                       {member.age} años

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -542,6 +542,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                   null)
                 : null,
               whatsappPhone: p.user.phone ?? null,
+              detailHref: `/activities/${activity.id}/participants/${p.id}`,
             }))}
             groups={activityGroupOptions}
             canAssignGroups={isAdmin}

--- a/src/app/activities/[id]/participants/[participantId]/page.tsx
+++ b/src/app/activities/[id]/participants/[participantId]/page.tsx
@@ -1,0 +1,107 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+export default async function ActivityParticipantFamilyPage({
+  params,
+}: {
+  params: { id: string; participantId: string };
+}) {
+  const session = await getServerSession(authOptions);
+  const role = session?.user?.role;
+  const canAccess = role === 'ADMIN' || role === 'SUPER_ADMIN' || role === 'PROFESSOR';
+
+  if (!session?.user?.id || !canAccess) {
+    redirect('/login');
+  }
+
+  const participant = await prisma.activityParticipant.findUnique({
+    where: { id: params.participantId },
+    include: {
+      activity: { select: { id: true, name: true } },
+      user: {
+        include: {
+          children: {
+            orderBy: [{ name: 'asc' }, { lastName: 'asc' }],
+            select: {
+              id: true,
+              name: true,
+              lastName: true,
+              birthDate: true,
+              phone: true,
+            },
+          },
+        },
+      },
+      child: {
+        select: {
+          id: true,
+          name: true,
+          lastName: true,
+          birthDate: true,
+          phone: true,
+        },
+      },
+    },
+  });
+
+  if (!participant || participant.activityId !== params.id) {
+    redirect(`/activities/${params.id}`);
+  }
+
+  if (role === 'PROFESSOR') {
+    const assignment = await prisma.activityProfessor.findFirst({
+      where: { activityId: params.id, userId: session.user.id },
+      select: { id: true },
+    });
+
+    if (!assignment) redirect('/');
+  }
+
+  const fullName = `${participant.user.name ?? ''} ${participant.user.lastName ?? ''}`.trim() || 'Sin nombre';
+  const participantName = participant.child
+    ? `${participant.child.name}${participant.child.lastName ? ` ${participant.child.lastName}` : ''}`
+    : fullName;
+
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-8 space-y-6">
+      <nav className="text-xs text-muted-foreground font-body flex items-center gap-1">
+        <Link href="/my-activities" className="hover:text-primary transition-colors">Mis actividades</Link>
+        <span>→</span>
+        <Link href={`/activities/${params.id}`} className="hover:text-primary transition-colors">{participant.activity.name}</Link>
+        <span>→</span>
+        <span className="text-foreground">Grupo familiar</span>
+      </nav>
+
+      <section className="rounded-xl border bg-card p-6 shadow-sm space-y-3">
+        <h1 className="text-2xl font-semibold">Grupo familiar de {participantName}</h1>
+        <p className="text-sm text-muted-foreground">Información de contacto del responsable y de las infancias asociadas.</p>
+      </section>
+
+      <section className="rounded-xl border bg-card p-6 shadow-sm space-y-2 text-sm">
+        <h2 className="text-lg font-semibold">Responsable</h2>
+        <p><span className="text-muted-foreground">Nombre:</span> {fullName}</p>
+        <p><span className="text-muted-foreground">Email:</span> {participant.user.email}</p>
+        <p><span className="text-muted-foreground">Teléfono:</span> {participant.user.phone || 'Sin teléfono'}</p>
+      </section>
+
+      <section className="rounded-xl border bg-card p-6 shadow-sm">
+        <h2 className="text-lg font-semibold">Infancias del grupo familiar</h2>
+        {participant.user.children.length === 0 ? (
+          <p className="mt-2 text-sm text-muted-foreground">No hay infancias asociadas a este grupo familiar.</p>
+        ) : (
+          <ul className="mt-3 space-y-2">
+            {participant.user.children.map((child) => (
+              <li key={child.id} className="rounded-lg border p-3 text-sm">
+                <p className="font-medium">{child.name} {child.lastName ?? ''}</p>
+                <p className="text-muted-foreground">Teléfono: {child.phone || 'Sin teléfono'}</p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Permitir que profesores y admins vean y contacten al responsable familiar desde la vista de inscriptos, facilitando la comunicación desde la página de la actividad.
- Proveer una página de detalle que muestre la información del responsable y las infancias asociadas para cada inscripción.

### Description
- Convierto los nombres mostrados en `Inscriptos` en enlaces hacia una nueva ruta de detalle familiar agregando `detailHref` al objeto participante y usando `Link` en `src/app/activities/[id]/inscriptos-panel.tsx`.
- Paso el `detailHref` por cada participante en `src/app/activities/[id]/page.tsx` para construir la URL `/activities/[id]/participants/[participantId]`.
- Agrego la nueva página servidor `src/app/activities/[id]/participants/[participantId]/page.tsx` que carga el `activityParticipant` y muestra nombre/email/teléfono del responsable y la lista de niños vinculados.
- Implemento controles de acceso en la nueva página para permitir sólo a `ADMIN`, `SUPER_ADMIN` y `PROFESSOR`, y verifico que un `PROFESSOR` sólo vea participantes de actividades donde está asignado.
- Files touched: `src/app/activities/[id]/inscriptos-panel.tsx`, `src/app/activities/[id]/page.tsx`, `src/app/activities/[id]/participants/[participantId]/page.tsx`.

### Testing
- Ejecuté `pnpm -s lint` y la tarea finalizó correctamente sin errores (se reportaron warnings de Prettier ya existentes en varios archivos del repositorio). 
- No se agregaron tests automatizados nuevos en esta PR; los cambios son UI/route y la verificación principal fue linting del código.
- Unresolved risks: quedan warnings de formato en el repo que no se corrigen aquí, la nueva vista muestra datos de contacto pero no incluye acciones directas como “abrir chat”, y la política de acceso para profesores depende de que la asignación `activityProfessor` esté correctamente poblada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8ef6335bc83288cc1d1c47e0c4688)