### PR TITLE
Add group selection and schedule UI for activity enrollment and persist group info in cart

### DIFF
--- a/src/app/activities/[id]/register-button.tsx
+++ b/src/app/activities/[id]/register-button.tsx
@@ -12,10 +12,14 @@ export default function ActivityRegisterButton({
   activityId,
   activityName,
   activityPrice,
+  groupId,
+  groupName,
 }: {
   activityId: string;
   activityName: string;
   activityPrice: number;
+  groupId?: string;
+  groupName?: string;
 }) {
   const { data: session } = useSession();
   const isMember = session?.user?.role === 'MEMBER';
@@ -57,12 +61,14 @@ export default function ActivityRegisterButton({
       price: activityPrice,
       target: effectiveTarget,
       targetLabel,
+      groupId,
+      groupName,
     };
     const raw = window.localStorage.getItem(ACTIVITY_CART_STORAGE_KEY);
     const existing = raw ? (JSON.parse(raw) as ActivityCartItem[]) : [];
     const deduped = existing.filter(
       (entry) =>
-        !(entry.activityId === item.activityId && entry.target === item.target)
+        !(entry.activityId === item.activityId && entry.target === item.target && (entry.groupId ?? '') === (item.groupId ?? ''))
     );
     window.localStorage.setItem(
       ACTIVITY_CART_STORAGE_KEY,

--- a/src/app/activities/cart/page.tsx
+++ b/src/app/activities/cart/page.tsx
@@ -201,6 +201,11 @@ export default function ActivitiesCartPage() {
                   <p className="text-sm text-muted-foreground">
                     Inscripción: {item.targetLabel}
                   </p>
+                  {item.groupName && (
+                    <p className="text-sm text-muted-foreground">
+                      Grupo: {item.groupName}
+                    </p>
+                  )}
                 </div>
                 <div className="flex items-center gap-3">
                   <span className="font-semibold">

--- a/src/app/activities/join/[id]/group-schedule-calendar.tsx
+++ b/src/app/activities/join/[id]/group-schedule-calendar.tsx
@@ -1,0 +1,129 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+type Group = { id: string; name: string };
+type Session = { id: string; date: string; schedule: string; activityGroupId: string | null };
+
+type Props = {
+  activityType: 'ANNUAL' | 'TEMPORARY';
+  groups: Group[];
+  sessions: Session[];
+  selectedGroupId: string;
+  onGroupChange: (value: string) => void;
+};
+
+const weekdayLabels = ['Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado', 'Domingo'];
+
+function getWeekStartMonday(date: Date) {
+  const copy = new Date(date);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+export default function GroupScheduleCalendar({ activityType, groups, sessions, selectedGroupId, onGroupChange }: Props) {
+  const [currentDate, setCurrentDate] = useState(() => new Date());
+
+  const selectedGroup = groups.find((group) => group.id === selectedGroupId) ?? null;
+
+  const groupSessions = useMemo(() => {
+    if (!selectedGroupId) return [];
+    return sessions.filter((session) => session.activityGroupId === selectedGroupId);
+  }, [selectedGroupId, sessions]);
+
+  const weeklyDays = useMemo(() => {
+    const start = getWeekStartMonday(currentDate);
+    return Array.from({ length: 7 }, (_, index) => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + index);
+      return date;
+    });
+  }, [currentDate]);
+
+  const monthlyDays = useMemo(() => {
+    const year = currentDate.getFullYear();
+    const month = currentDate.getMonth();
+    const firstDay = new Date(year, month, 1);
+    const start = getWeekStartMonday(firstDay);
+    return Array.from({ length: 42 }, (_, index) => {
+      const date = new Date(start);
+      date.setDate(start.getDate() + index);
+      return date;
+    });
+  }, [currentDate]);
+
+  const title = currentDate.toLocaleDateString('es-AR', { month: 'long', year: 'numeric' });
+
+  const sessionsByDate = useMemo(() => {
+    const map = new Map<string, Session[]>();
+    for (const session of groupSessions) {
+      const key = new Date(session.date).toISOString().slice(0, 10);
+      const list = map.get(key) ?? [];
+      list.push(session);
+      map.set(key, list);
+    }
+    return map;
+  }, [groupSessions]);
+
+  const movePeriod = (delta: number) => {
+    const next = new Date(currentDate);
+    if (activityType === 'ANNUAL') {
+      next.setDate(next.getDate() + delta * 7);
+    } else {
+      next.setMonth(next.getMonth() + delta);
+    }
+    setCurrentDate(next);
+  };
+
+  const daysToRender = activityType === 'ANNUAL' ? weeklyDays : monthlyDays;
+
+  return (
+    <section className="w-full rounded-lg border bg-card p-5 space-y-4">
+      <div className="space-y-3">
+        <h2 className="font-heading text-lg font-semibold">Elegí grupo y horarios</h2>
+        <p className="text-sm text-muted-foreground font-body">Para inscribirte en esta actividad tenés que elegir un grupo.</p>
+        <select
+          className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+          value={selectedGroupId}
+          onChange={(e) => onGroupChange(e.target.value)}
+        >
+          <option value="" disabled>Seleccioná un grupo</option>
+          {groups.map((group) => (
+            <option key={group.id} value={group.id}>{group.name}</option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <button type="button" className="rounded-md border px-3 py-1 text-sm" onClick={() => movePeriod(-1)}>←</button>
+        <p className="text-sm font-medium capitalize">{title}</p>
+        <button type="button" className="rounded-md border px-3 py-1 text-sm" onClick={() => movePeriod(1)}>→</button>
+      </div>
+
+      <div className={`grid gap-2 ${activityType === 'ANNUAL' ? 'grid-cols-1 sm:grid-cols-7' : 'grid-cols-7'}`}>
+        {daysToRender.map((day, index) => {
+          const key = day.toISOString().slice(0, 10);
+          const daySessions = sessionsByDate.get(key) ?? [];
+          const isCurrentMonth = day.getMonth() === currentDate.getMonth();
+          return (
+            <div key={key} className={`rounded-md border p-2 ${activityType === 'TEMPORARY' && !isCurrentMonth ? 'opacity-40' : ''}`}>
+              <p className="text-xs text-muted-foreground">{weekdayLabels[day.getDay() === 0 ? 6 : day.getDay() - 1]}</p>
+              <p className="text-sm font-semibold">{day.getDate()}</p>
+              <div className="mt-1 space-y-1">
+                {daySessions.map((session) => (
+                  <div key={session.id} className="rounded bg-muted px-2 py-1 text-xs">
+                    <p className="font-medium">{selectedGroup?.name ?? 'Grupo'}</p>
+                    <p>{session.schedule}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/app/activities/join/[id]/join-enrollment-panel.tsx
+++ b/src/app/activities/join/[id]/join-enrollment-panel.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import RegisterButton from '@/app/activities/[id]/register-button';
+import GroupScheduleCalendar from './group-schedule-calendar';
+
+type Group = { id: string; name: string };
+type Session = { id: string; date: string; schedule: string; activityGroupId: string | null };
+
+export default function JoinEnrollmentPanel({
+  activity,
+  groups,
+  sessions,
+  isFull,
+  hasCapacity,
+  remainingSpots,
+}: {
+  activity: { id: string; name: string; price: number; activityType: 'ANNUAL' | 'TEMPORARY' };
+  groups: Group[];
+  sessions: Session[];
+  isFull: boolean;
+  hasCapacity: boolean;
+  remainingSpots: number | null;
+}) {
+  const [selectedGroupId, setSelectedGroupId] = useState('');
+  const selectedGroup = useMemo(() => groups.find((group) => group.id === selectedGroupId), [groups, selectedGroupId]);
+
+  return (
+    <div className="w-full space-y-4">
+      {groups.length > 0 && (
+        <GroupScheduleCalendar
+          activityType={activity.activityType}
+          groups={groups}
+          sessions={sessions}
+          selectedGroupId={selectedGroupId}
+          onGroupChange={setSelectedGroupId}
+        />
+      )}
+      <div className="space-y-4 rounded-xl border bg-card p-5">
+        <div className="space-y-1">
+          <p className="text-xs uppercase tracking-wide text-muted-foreground font-body">Inscripción</p>
+          <p className="font-heading text-2xl font-semibold">${activity.price}</p>
+          {hasCapacity && (
+            <p className={`text-xs font-body ${isFull ? 'text-destructive' : 'text-muted-foreground'}`}>
+              {isFull ? 'Cupo completo' : `${remainingSpots} lugares disponibles`}
+            </p>
+          )}
+        </div>
+
+        {isFull ? (
+          <div className="rounded-md border border-dashed border-border px-4 py-3 text-sm text-muted-foreground font-body">
+            No hay cupos disponibles en este momento.
+          </div>
+        ) : groups.length > 0 && !selectedGroupId ? (
+          <div className="rounded-md border border-dashed border-border px-4 py-3 text-sm text-muted-foreground font-body">
+            Seleccioná un grupo para continuar con la inscripción.
+          </div>
+        ) : (
+          <RegisterButton
+            activityId={activity.id}
+            activityName={activity.name}
+            activityPrice={Number(activity.price)}
+            groupId={selectedGroupId || undefined}
+            groupName={selectedGroup?.name}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/activities/join/[id]/page.tsx
+++ b/src/app/activities/join/[id]/page.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 import { notFound } from 'next/navigation';
 import { getActivityBaseRecordById } from '@/lib/activities/activity-records';
 import { prisma } from '@/lib/prisma';
-import RegisterButton from '@/app/activities/[id]/register-button';
+import JoinEnrollmentPanel from './join-enrollment-panel';
 
 interface ActivityJoinPageProps {
   params: { id: string };
@@ -31,9 +31,11 @@ export default async function ActivityJoinPage({
     notFound();
   }
 
-  const participantCount = await prisma.activityParticipant.count({
-    where: { activityId: activity.id },
-  });
+  const [participantCount, groups, sessions] = await Promise.all([
+    prisma.activityParticipant.count({ where: { activityId: activity.id } }),
+    prisma.activityGroup.findMany({ where: { activityId: activity.id }, select: { id: true, name: true }, orderBy: { name: 'asc' } }),
+    prisma.activityDay.findMany({ where: { activityId: activity.id, cancelled: false }, select: { id: true, date: true, schedule: true, activityGroupId: true }, orderBy: { date: 'asc' } }),
+  ]);
 
   const activityTypeLabels: Record<'TEMPORARY' | 'ANNUAL', string> = {
     TEMPORARY: 'Temporal',
@@ -70,7 +72,7 @@ export default async function ActivityJoinPage({
         />
       )}
 
-      <div className="mx-auto grid max-w-5xl gap-8 px-4 py-8 lg:grid-cols-[1fr_320px]">
+      <div className="mx-auto grid w-full max-w-none gap-8 px-4 py-8 lg:grid-cols-1">
         <section className="space-y-6">
           <nav className="flex items-center gap-2 text-xs text-muted-foreground font-body">
             <Link href="/" className="hover:text-primary transition-colors">
@@ -151,41 +153,25 @@ export default async function ActivityJoinPage({
           </div>
         </section>
 
-        <aside className="lg:sticky lg:top-6">
-          <div className="space-y-4 rounded-xl border bg-card p-5">
-            <div className="space-y-1">
-              <p className="text-xs uppercase tracking-wide text-muted-foreground font-body">
-                Inscripción
-              </p>
-              <p className="font-heading text-2xl font-semibold">
-                ${activity.price}
-              </p>
-              {hasCapacity && (
-                <p
-                  className={`text-xs font-body ${
-                    isFull ? 'text-destructive' : 'text-muted-foreground'
-                  }`}
-                >
-                  {isFull
-                    ? 'Cupo completo'
-                    : `${remainingSpots} lugares disponibles`}
-                </p>
-              )}
-            </div>
-
-            {isFull ? (
-              <div className="rounded-md border border-dashed border-border px-4 py-3 text-sm text-muted-foreground font-body">
-                No hay cupos disponibles en este momento.
-              </div>
-            ) : (
-              <RegisterButton
-                activityId={activity.id}
-                activityName={activity.name}
-                activityPrice={Number(activity.price)}
-              />
-            )}
-
-          </div>
+        <aside className="w-full">
+          <JoinEnrollmentPanel
+            activity={{
+              id: activity.id,
+              name: activity.name,
+              price: Number(activity.price),
+              activityType: activity.activityType,
+            }}
+            groups={groups}
+            sessions={sessions.map((session) => ({
+              id: session.id,
+              date: session.date.toISOString(),
+              schedule: session.schedule,
+              activityGroupId: session.activityGroupId,
+            }))}
+            isFull={isFull}
+            hasCapacity={hasCapacity}
+            remainingSpots={remainingSpots}
+          />
         </aside>
       </div>
     </main>

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -6,6 +6,8 @@ export type ActivityCartItem = {
   price: number;
   target: CartItemTarget;
   targetLabel: string;
+  groupId?: string;
+  groupName?: string;
 };
 
 export const ACTIVITY_CART_STORAGE_KEY = 'hualas-activity-cart';


### PR DESCRIPTION
### Motivation

- Enable selecting a group when joining activities and surface group schedules to users so enrollments can be made per-group.

### Description

- Add `groupId` and `groupName` to the `ActivityCartItem` type and persist them to local storage when adding an activity to the cart, updating deduplication to include `groupId` in the comparison.
- Propagate optional `groupId`/`groupName` through the registration flow by extending `ActivityRegisterButton` props and storing those values when creating the cart item.
- Display the chosen group's name in the activities cart UI by rendering `item.groupName` when present.
- Introduce a `GroupScheduleCalendar` client component to render weekly/monthly calendar views and group-specific sessions, and a `JoinEnrollmentPanel` component that exposes the calendar and enrollment controls.
- Update the activity join page to fetch `activityGroup` and `activityDay` records in parallel with participant counts, serialize sessions for the client, and replace the previous sidebar with the new `JoinEnrollmentPanel` component and responsive layout adjustments.

### Testing

- Ran TypeScript type-check and `eslint` across the changed files, both succeeded. 
- Performed a local Next build (`next build`) and verified the app compiles and the modified pages render without type or build errors. 
- Executed the project's automated test suite (`yarn test`), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9009ecfec832880a7ea235d4a2be5)