### PR TITLE
Expandir ancho del bloque “Elegí grupo y horarios” en la página pública de inscripción

### DIFF
--- a/src/app/activities/join/[id]/join-enrollment-panel.tsx
+++ b/src/app/activities/join/[id]/join-enrollment-panel.tsx
@@ -26,17 +26,19 @@ export default function JoinEnrollmentPanel({
   const selectedGroup = useMemo(() => groups.find((group) => group.id === selectedGroupId), [groups, selectedGroupId]);
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 lg:grid lg:grid-cols-[1fr_320px] lg:items-start lg:gap-8">
       {groups.length > 0 && (
-        <GroupScheduleCalendar
+        <div className="lg:col-span-2">
+          <GroupScheduleCalendar
           activityType={activity.activityType}
           groups={groups}
           sessions={sessions}
           selectedGroupId={selectedGroupId}
           onGroupChange={setSelectedGroupId}
         />
+        </div>
       )}
-      <div className="space-y-4 rounded-xl border bg-card p-5">
+      <div className="space-y-4 rounded-xl border bg-card p-5 lg:col-start-2 lg:sticky lg:top-6">
         <div className="space-y-1">
           <p className="text-xs uppercase tracking-wide text-muted-foreground font-body">Inscripción</p>
           <p className="font-heading text-2xl font-semibold">${activity.price}</p>

--- a/src/app/activities/join/[id]/page.tsx
+++ b/src/app/activities/join/[id]/page.tsx
@@ -72,7 +72,7 @@ export default async function ActivityJoinPage({
         />
       )}
 
-      <div className="mx-auto grid max-w-5xl gap-8 px-4 py-8 lg:grid-cols-[1fr_320px]">
+      <div className="mx-auto max-w-5xl space-y-8 px-4 py-8">
         <section className="space-y-6">
           <nav className="flex items-center gap-2 text-xs text-muted-foreground font-body">
             <Link href="/" className="hover:text-primary transition-colors">
@@ -153,8 +153,7 @@ export default async function ActivityJoinPage({
           </div>
         </section>
 
-        <aside className="lg:sticky lg:top-6">
-          <JoinEnrollmentPanel
+        <JoinEnrollmentPanel
             activity={{
               id: activity.id,
               name: activity.name,
@@ -172,7 +171,6 @@ export default async function ActivityJoinPage({
             hasCapacity={hasCapacity}
             remainingSpots={remainingSpots}
           />
-        </aside>
       </div>
     </main>
   );


### PR DESCRIPTION
### Motivation
- Hacer que el bloque “Elegí grupo y horarios” ocupe todo el ancho disponible en la página pública de inscripción para mejorar la visibilidad del calendario/horarios. 
- Mantener la tarjeta de inscripción (panel lateral) en una columna derecha pegada (`sticky`) en pantallas grandes para conservar la UX de inscripción.

### Description
- Cambié el contenedor principal de la página de join para eliminar la grilla rígida de dos columnas y usar un contenedor vertical (`space-y-8`) que permite que el bloque de selección crezca en ancho. (`src/app/activities/join/[id]/page.tsx`).
- Reorganicé `JoinEnrollmentPanel` para usar una grilla responsive (`lg:grid lg:grid-cols-[1fr_320px]`) donde el componente `GroupScheduleCalendar` ahora queda dentro de un `lg:col-span-2` para ocupar todo el ancho y la tarjeta de inscripción queda en la segunda columna con `lg:sticky lg:top-6`. (`src/app/activities/join/[id]/join-enrollment-panel.tsx`).
- No se modificó la lógica de selección de grupo ni el flujo de registro; solo se ajustaron clases y estructura DOM/CSS con Tailwind.

### Testing
- Ejecuté el linter con `pnpm lint`, que terminó correctamente; el repositorio muestra warnings preexistentes de `prettier` que no están relacionados con este cambio. 
- No se añadieron tests automatizados; no se ejecutaron pruebas visuales ni capturas de pantalla automatizadas para validar breakpoints.
- Riesgos sin resolver: el ajuste se basa en clases Tailwind y requiere verificación visual en distintos breakpoints para validar layout en pantallas pequeñas/medianas y comprobación de posibles colisiones CSS con componentes adyacentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f90391b42c8328bb33c28c58c146da)