### PR TITLE
Agregar pestaña “Mis grupos” en la vista de alumnos del profesor

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -2,7 +2,42 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import StudentsSearch, { type StudentEntry } from './students-search';
+import StudentsSearch, {
+  type ProfessorGroupEntry,
+  type StudentEntry,
+} from './students-search';
+
+function calculateAge(birthDate: Date | null) {
+  if (!birthDate) return null;
+
+  const today = new Date();
+  let age = today.getFullYear() - birthDate.getFullYear();
+  const monthDifference = today.getMonth() - birthDate.getMonth();
+
+  if (
+    monthDifference < 0 ||
+    (monthDifference === 0 && today.getDate() < birthDate.getDate())
+  ) {
+    age -= 1;
+  }
+
+  return age;
+}
+
+function formatFullName(
+  person: {
+    name: string | null;
+    lastName: string | null;
+    email?: string;
+  } | null
+) {
+  if (!person) return 'Sin nombre';
+  return (
+    [person.name, person.lastName].filter(Boolean).join(' ') ||
+    person.email ||
+    'Sin nombre'
+  );
+}
 
 export default async function ProfessorStudentsPage() {
   const session = await getServerSession(authOptions);
@@ -57,6 +92,47 @@ export default async function ProfessorStudentsPage() {
               lastName: true,
               birthDate: true,
               documentNumber: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const activityGroups = await prisma.activityGroup.findMany({
+    where: { activityId: { in: activityIds } },
+    orderBy: [{ activity: { name: 'asc' } }, { name: 'asc' }],
+    include: {
+      activity: { select: { name: true } },
+      days: {
+        orderBy: { date: 'asc' },
+        select: {
+          id: true,
+          date: true,
+          schedule: true,
+          cancelled: true,
+        },
+      },
+      members: {
+        orderBy: { createdAt: 'asc' },
+        include: {
+          activityParticipant: {
+            include: {
+              user: {
+                select: {
+                  name: true,
+                  lastName: true,
+                  email: true,
+                  birthDate: true,
+                },
+              },
+              child: {
+                select: {
+                  name: true,
+                  lastName: true,
+                  birthDate: true,
+                },
+              },
             },
           },
         },
@@ -225,6 +301,45 @@ export default async function ProfessorStudentsPage() {
     return nameA.localeCompare(nameB, 'es');
   });
 
+  const groups: ProfessorGroupEntry[] = activityGroups.map((group) => ({
+    id: group.id,
+    name: group.name,
+    activityName: group.activity.name,
+    description: group.description,
+    capacity: group.capacity,
+    minAge: group.minAge,
+    maxAge: group.maxAge,
+    schedules: group.days.map((day) => ({
+      id: day.id,
+      date: day.date.toISOString(),
+      schedule: day.schedule,
+      cancelled: day.cancelled,
+    })),
+    participants: group.members
+      .map((member) => {
+        const participant = member.activityParticipant;
+
+        if (participant.child) {
+          return {
+            id: member.id,
+            type: 'child' as const,
+            name: formatFullName(participant.child),
+            age: calculateAge(participant.child.birthDate),
+            responsibleName: formatFullName(participant.user),
+          };
+        }
+
+        return {
+          id: member.id,
+          type: 'adult' as const,
+          name: formatFullName(participant.user),
+          age: calculateAge(participant.user.birthDate),
+          responsibleName: null,
+        };
+      })
+      .sort((a, b) => a.name.localeCompare(b.name, 'es')),
+  }));
+
   return (
     <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">
       <div>
@@ -233,7 +348,7 @@ export default async function ProfessorStudentsPage() {
           Alumnos y padres en grupos de tus actividades.
         </p>
       </div>
-      <StudentsSearch students={students} />
+      <StudentsSearch students={students} groups={groups} />
     </main>
   );
 }

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -10,6 +10,57 @@ type Tutor = {
   relationship: string;
 };
 
+export type ProfessorGroupEntry = {
+  id: string;
+  name: string;
+  activityName: string;
+  description: string | null;
+  capacity: number | null;
+  minAge: number | null;
+  maxAge: number | null;
+  schedules: {
+    id: string;
+    date: string;
+    schedule: string;
+    cancelled: boolean;
+  }[];
+  participants: {
+    id: string;
+    type: 'child' | 'adult';
+    name: string;
+    age: number | null;
+    responsibleName: string | null;
+  }[];
+};
+
+function getParticipantAgeLabel(age: number | null) {
+  if (age === null) return 'Edad no cargada';
+  return `${age} año${age === 1 ? '' : 's'}`;
+}
+
+function formatScheduleDay(date: string) {
+  return new Date(date).toLocaleDateString('es-AR', {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'short',
+  });
+}
+
+function getAgeSummary(participants: ProfessorGroupEntry['participants']) {
+  const ages = participants
+    .map((participant) => participant.age)
+    .filter((age): age is number => age !== null);
+
+  if (participants.length === 0) return 'Sin participantes';
+  if (ages.length === 0) return 'Edades no cargadas';
+
+  const min = Math.min(...ages);
+  const max = Math.max(...ages);
+  if (min === max) return getParticipantAgeLabel(min);
+
+  return `${min} a ${max} años`;
+}
+
 export type StudentEntry =
   | {
       type: 'child';
@@ -74,9 +125,13 @@ function matches(student: StudentEntry, query: string): boolean {
 
 export default function StudentsSearch({
   students,
+  groups,
 }: {
   students: StudentEntry[];
+  groups: ProfessorGroupEntry[];
 }) {
+  const [activeTab, setActiveTab] = useState<'students' | 'groups'>('students');
+  const [selectedGroupId, setSelectedGroupId] = useState(groups[0]?.id ?? '');
   const [query, setQuery] = useState('');
 
   const visible = useMemo(() => {
@@ -85,173 +140,375 @@ export default function StudentsSearch({
     return students.filter((s) => matches(s, q));
   }, [students, query]);
 
+  const selectedGroup =
+    groups.find((group) => group.id === selectedGroupId) ?? groups[0] ?? null;
+
   return (
     <div className="space-y-4">
-      <div className="relative">
-        <svg
-          className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
-          xmlns="http://www.w3.org/2000/svg"
-          fill="none"
-          viewBox="0 0 24 24"
-          strokeWidth={1.5}
-          stroke="currentColor"
+      <div
+        className="flex flex-wrap gap-2 rounded-xl border bg-card p-1"
+        role="tablist"
+        aria-label="Vista de alumnos y grupos"
+      >
+        <button
+          type="button"
+          onClick={() => setActiveTab('students')}
+          className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'students'
+              ? 'bg-primary text-primary-foreground shadow-sm'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          }`}
+          role="tab"
+          aria-selected={activeTab === 'students'}
         >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
-          />
-        </svg>
-        <input
-          type="search"
-          placeholder="Buscar por nombre, apellido, DNI o email…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          className="w-full rounded-lg border bg-background py-2 pl-9 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
-        />
+          Mis alumnos
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('groups')}
+          className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'groups'
+              ? 'bg-primary text-primary-foreground shadow-sm'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          }`}
+          role="tab"
+          aria-selected={activeTab === 'groups'}
+        >
+          Mis grupos
+        </button>
       </div>
 
-      {students.length === 0 ? (
-        <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground">
-          <p>Todavía no hay alumnos asignados a grupos en tus actividades.</p>
-        </div>
-      ) : visible.length === 0 ? (
-        <div className="rounded-xl border bg-card p-6 text-center text-sm text-muted-foreground">
-          Sin resultados para &ldquo;{query}&rdquo;.
-        </div>
-      ) : (
+      {activeTab === 'students' ? (
         <>
-          <p className="text-xs text-muted-foreground">
-            {visible.length} de {students.length} alumno
-            {students.length === 1 ? '' : 's'}
-          </p>
-          <ul className="space-y-3">
-            {visible.map((student) => {
-              const fullName =
-                `${student.name} ${student.lastName ?? ''}`.trim() ||
-                'Sin nombre';
-              const href =
-                student.type === 'child'
-                  ? `/professor/students/child/${student.childId}`
-                  : `/professor/students/parent/${student.userId}`;
+          <div className="relative">
+            <svg
+              className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+              />
+            </svg>
+            <input
+              type="search"
+              placeholder="Buscar por nombre, apellido, DNI o email…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="w-full rounded-lg border bg-background py-2 pl-9 pr-4 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+            />
+          </div>
 
-              return (
-                <li
-                  key={
-                    student.type === 'child' ? student.childId : student.userId
-                  }
-                >
-                  <Link
-                    href={href}
-                    className="flex items-start justify-between gap-4 rounded-xl border bg-card p-4 shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
-                  >
-                    <div className="space-y-1 min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-medium">{fullName}</span>
-                        <span
-                          className={`rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${
-                            student.type === 'child'
-                              ? 'bg-sky-100 text-sky-700'
-                              : 'bg-amber-100 text-amber-700'
-                          }`}
-                        >
-                          {student.type === 'child' ? 'Alumno' : 'Adulto'}
-                        </span>
-                      </div>
+          {students.length === 0 ? (
+            <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground">
+              <p>
+                Todavía no hay alumnos asignados a grupos en tus actividades.
+              </p>
+            </div>
+          ) : visible.length === 0 ? (
+            <div className="rounded-xl border bg-card p-6 text-center text-sm text-muted-foreground">
+              Sin resultados para &ldquo;{query}&rdquo;.
+            </div>
+          ) : (
+            <>
+              <p className="text-xs text-muted-foreground">
+                {visible.length} de {students.length} alumno
+                {students.length === 1 ? '' : 's'}
+              </p>
+              <ul className="space-y-3">
+                {visible.map((student) => {
+                  const fullName =
+                    `${student.name} ${student.lastName ?? ''}`.trim() ||
+                    'Sin nombre';
+                  const href =
+                    student.type === 'child'
+                      ? `/professor/students/child/${student.childId}`
+                      : `/professor/students/parent/${student.userId}`;
 
-                      {student.type === 'child' && (
-                        <div className="space-y-0.5">
-                          <p className="text-sm text-muted-foreground">
-                            <span className="text-xs uppercase tracking-wide mr-1">
-                              Responsable:
+                  return (
+                    <li
+                      key={
+                        student.type === 'child'
+                          ? student.childId
+                          : student.userId
+                      }
+                    >
+                      <Link
+                        href={href}
+                        className="flex items-start justify-between gap-4 rounded-xl border bg-card p-4 shadow-sm hover:border-primary/50 hover:bg-primary/5 transition-colors"
+                      >
+                        <div className="space-y-1 min-w-0">
+                          <div className="flex items-center gap-2 flex-wrap">
+                            <span className="font-medium">{fullName}</span>
+                            <span
+                              className={`rounded-full px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide ${
+                                student.type === 'child'
+                                  ? 'bg-sky-100 text-sky-700'
+                                  : 'bg-amber-100 text-amber-700'
+                              }`}
+                            >
+                              {student.type === 'child' ? 'Alumno' : 'Adulto'}
                             </span>
-                            <span className="font-medium text-foreground">
-                              {student.parentName}
-                            </span>
-                            {student.parentPhone && (
-                              <span> · {student.parentPhone}</span>
-                            )}
-                          </p>
-                          {student.tutors.map((t, i) => {
-                            const relLabel: Record<string, string> = {
-                              PARENT: 'Madre/Padre',
-                              RESPONSIBLE: 'Responsable',
-                              OTHER: 'Tutor/a',
-                            };
-                            return (
-                              <p
-                                key={i}
-                                className="text-sm text-muted-foreground"
-                              >
+                          </div>
+
+                          {student.type === 'child' && (
+                            <div className="space-y-0.5">
+                              <p className="text-sm text-muted-foreground">
                                 <span className="text-xs uppercase tracking-wide mr-1">
-                                  {relLabel[t.relationship] ?? t.relationship}:
+                                  Responsable:
                                 </span>
                                 <span className="font-medium text-foreground">
-                                  {t.name}
+                                  {student.parentName}
                                 </span>
-                                {t.phone && <span> · {t.phone}</span>}
+                                {student.parentPhone && (
+                                  <span> · {student.parentPhone}</span>
+                                )}
                               </p>
-                            );
-                          })}
-                        </div>
-                      )}
-
-                      {student.type === 'adult' && (
-                        <div className="space-y-0.5">
-                          {student.phone && (
-                            <p className="text-sm text-muted-foreground">
-                              {student.phone}
-                            </p>
+                              {student.tutors.map((t, i) => {
+                                const relLabel: Record<string, string> = {
+                                  PARENT: 'Madre/Padre',
+                                  RESPONSIBLE: 'Responsable',
+                                  OTHER: 'Tutor/a',
+                                };
+                                return (
+                                  <p
+                                    key={i}
+                                    className="text-sm text-muted-foreground"
+                                  >
+                                    <span className="text-xs uppercase tracking-wide mr-1">
+                                      {relLabel[t.relationship] ??
+                                        t.relationship}
+                                      :
+                                    </span>
+                                    <span className="font-medium text-foreground">
+                                      {t.name}
+                                    </span>
+                                    {t.phone && <span> · {t.phone}</span>}
+                                  </p>
+                                );
+                              })}
+                            </div>
                           )}
-                          {student.tutors.map((t, i) => {
-                            const relLabel: Record<string, string> = {
-                              PARENT: 'Madre/Padre',
-                              RESPONSIBLE: 'Responsable',
-                              OTHER: 'Tutor/a',
-                            };
-                            return (
-                              <p
-                                key={i}
-                                className="text-sm text-muted-foreground"
-                              >
-                                <span className="text-xs uppercase tracking-wide mr-1">
-                                  {relLabel[t.relationship] ?? t.relationship}:
-                                </span>
-                                <span className="font-medium text-foreground">
-                                  {t.name}
-                                </span>
-                                {t.phone && <span> · {t.phone}</span>}
-                              </p>
-                            );
-                          })}
-                        </div>
-                      )}
 
-                      <div className="flex flex-wrap gap-1 mt-1">
-                        {student.activities.map((act) => (
-                          <span
-                            key={act}
-                            className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
-                          >
-                            {act}
+                          {student.type === 'adult' && (
+                            <div className="space-y-0.5">
+                              {student.phone && (
+                                <p className="text-sm text-muted-foreground">
+                                  {student.phone}
+                                </p>
+                              )}
+                              {student.tutors.map((t, i) => {
+                                const relLabel: Record<string, string> = {
+                                  PARENT: 'Madre/Padre',
+                                  RESPONSIBLE: 'Responsable',
+                                  OTHER: 'Tutor/a',
+                                };
+                                return (
+                                  <p
+                                    key={i}
+                                    className="text-sm text-muted-foreground"
+                                  >
+                                    <span className="text-xs uppercase tracking-wide mr-1">
+                                      {relLabel[t.relationship] ??
+                                        t.relationship}
+                                      :
+                                    </span>
+                                    <span className="font-medium text-foreground">
+                                      {t.name}
+                                    </span>
+                                    {t.phone && <span> · {t.phone}</span>}
+                                  </p>
+                                );
+                              })}
+                            </div>
+                          )}
+
+                          <div className="flex flex-wrap gap-1 mt-1">
+                            {student.activities.map((act) => (
+                              <span
+                                key={act}
+                                className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground"
+                              >
+                                {act}
+                              </span>
+                            ))}
+                          </div>
+                        </div>
+
+                        {student.type === 'child' && student.birthDate && (
+                          <span className="shrink-0 text-xs text-muted-foreground mt-1">
+                            {new Date(student.birthDate).toLocaleDateString(
+                              'es-AR'
+                            )}
                           </span>
-                        ))}
-                      </div>
+                        )}
+                      </Link>
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          )}
+        </>
+      ) : (
+        <div className="space-y-4">
+          {groups.length === 0 ? (
+            <div className="rounded-xl border bg-card p-8 text-center text-muted-foreground">
+              <p>Todavía no tenés grupos asignados en tus actividades.</p>
+            </div>
+          ) : (
+            <>
+              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+                {groups.map((group) => {
+                  const isSelected = selectedGroup?.id === group.id;
+                  return (
+                    <button
+                      key={group.id}
+                      type="button"
+                      onClick={() => setSelectedGroupId(group.id)}
+                      className={`rounded-xl border p-4 text-left shadow-sm transition-colors ${
+                        isSelected
+                          ? 'border-primary bg-primary/10 ring-2 ring-primary/20'
+                          : 'bg-card hover:border-primary/50 hover:bg-primary/5'
+                      }`}
+                    >
+                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {group.activityName}
+                      </p>
+                      <p className="mt-1 font-semibold text-foreground">
+                        {group.name}
+                      </p>
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        {group.participants.length} participante
+                        {group.participants.length === 1 ? '' : 's'} ·{' '}
+                        {getAgeSummary(group.participants)}
+                      </p>
+                    </button>
+                  );
+                })}
+              </div>
+
+              {selectedGroup && (
+                <section className="rounded-2xl border bg-card p-5 shadow-sm space-y-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <p className="text-sm font-medium text-primary">
+                        {selectedGroup.activityName}
+                      </p>
+                      <h2 className="text-xl font-semibold tracking-tight">
+                        {selectedGroup.name}
+                      </h2>
+                      {selectedGroup.description && (
+                        <p className="mt-1 text-sm text-muted-foreground">
+                          {selectedGroup.description}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                      <span className="rounded-full bg-muted px-3 py-1">
+                        {selectedGroup.participants.length} participante
+                        {selectedGroup.participants.length === 1 ? '' : 's'}
+                      </span>
+                      <span className="rounded-full bg-muted px-3 py-1">
+                        Edades: {getAgeSummary(selectedGroup.participants)}
+                      </span>
+                      {selectedGroup.capacity !== null && (
+                        <span className="rounded-full bg-muted px-3 py-1">
+                          Cupo: {selectedGroup.capacity}
+                        </span>
+                      )}
+                      {(selectedGroup.minAge !== null ||
+                        selectedGroup.maxAge !== null) && (
+                        <span className="rounded-full bg-muted px-3 py-1">
+                          Rango: {selectedGroup.minAge ?? 'sin mínimo'} -{' '}
+                          {selectedGroup.maxAge ?? 'sin máximo'} años
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                    <div className="rounded-xl border bg-background p-4">
+                      <h3 className="font-medium">Días y horarios</h3>
+                      {selectedGroup.schedules.length === 0 ? (
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          Este grupo todavía no tiene días cargados.
+                        </p>
+                      ) : (
+                        <ul className="mt-3 space-y-2">
+                          {selectedGroup.schedules.map((day) => (
+                            <li
+                              key={day.id}
+                              className="rounded-lg bg-muted/60 p-3 text-sm"
+                            >
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="font-medium capitalize">
+                                  {formatScheduleDay(day.date)}
+                                </span>
+                                {day.cancelled && (
+                                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                                    Cancelado
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-muted-foreground">
+                                {day.schedule}
+                              </p>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </div>
 
-                    {student.type === 'child' && student.birthDate && (
-                      <span className="shrink-0 text-xs text-muted-foreground mt-1">
-                        {new Date(student.birthDate).toLocaleDateString(
-                          'es-AR'
-                        )}
-                      </span>
-                    )}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </>
+                    <div className="rounded-xl border bg-background p-4">
+                      <h3 className="font-medium">Participantes</h3>
+                      {selectedGroup.participants.length === 0 ? (
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          Este grupo todavía no tiene participantes asignados.
+                        </p>
+                      ) : (
+                        <ul className="mt-3 divide-y rounded-lg border bg-card">
+                          {selectedGroup.participants.map((participant) => (
+                            <li
+                              key={participant.id}
+                              className="flex flex-col gap-1 p-3 text-sm sm:flex-row sm:items-center sm:justify-between"
+                            >
+                              <div>
+                                <p className="font-medium">
+                                  {participant.name}
+                                </p>
+                                {participant.responsibleName && (
+                                  <p className="text-xs text-muted-foreground">
+                                    Responsable: {participant.responsibleName}
+                                  </p>
+                                )}
+                              </div>
+                              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                                <span className="rounded-full bg-muted px-2 py-0.5">
+                                  {participant.type === 'child'
+                                    ? 'Alumno'
+                                    : 'Adulto'}
+                                </span>
+                                <span className="rounded-full bg-muted px-2 py-0.5">
+                                  {getParticipantAgeLabel(participant.age)}
+                                </span>
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                </section>
+              )}
+            </>
+          )}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
### Motivation
- Permitir que un profesor consulte rápidamente todos los grupos en los que está asignado y ver detalles de cada grupo (días, horarios, cupo, edades y participantes) desde la ruta `/professor/students`.

### Description
- Se añadió carga server-side de los `activityGroup` asignados a las actividades del profesor y se mapearon `days`, `members` y datos relevantes a un nuevo tipo `ProfessorGroupEntry` en `src/app/professor/students/page.tsx`.
- Se extendió el componente cliente `StudentsSearch` (`src/app/professor/students/students-search.tsx`) para incluir un control de pestañas (`Mis alumnos` / `Mis grupos`), listado de grupos como botones seleccionables y una vista detallada del grupo seleccionado con días/horarios y lista de participantes.
- Se incorporaron utilidades pequeñas en el servidor para formateo de nombres y cálculo de edad, y helpers en el cliente para resumen de edades y formato de día en `es-AR`.
- Archivos modificados: `src/app/professor/students/page.tsx` y `src/app/professor/students/students-search.tsx`.

### Testing
- Ejecuté `pnpm lint` y la salida fue satisfactoria (advertencias no relacionadas con estos cambios). 
- Ejecuté `pnpm exec eslint src/app/professor/students/page.tsx src/app/professor/students/students-search.tsx` sin errores relevantes sobre los archivos modificados.
- Ejecuté `pnpm exec tsc --noEmit` que falló por errores de tipado existentes en `tests/api/pickup-notices.test.ts` no relacionados con los cambios introducidos aquí, por lo que no bloquea la funcionalidad añadida en los componentes modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa6a0b011883289ced1cb281442094)