### PR TITLE
Limit professor students page to assigned groups

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -66,9 +66,23 @@ export default async function ProfessorStudentsPage() {
     );
   }
 
+  const assignedGroupDays = await prisma.activityDay.findMany({
+    where: {
+      activityId: { in: activityIds },
+      activityGroupId: { not: null },
+      professors: { some: { userId: professorId } },
+    },
+    select: { activityGroupId: true },
+    distinct: ['activityGroupId'],
+  });
+
+  const assignedGroupIds = assignedGroupDays
+    .map((day) => day.activityGroupId)
+    .filter((groupId): groupId is string => Boolean(groupId));
+
   const groupMembers = await prisma.activityGroupMember.findMany({
     where: {
-      activityGroup: { activityId: { in: activityIds } },
+      activityGroupId: { in: assignedGroupIds },
     },
     include: {
       activityGroup: { select: { name: true } },
@@ -100,7 +114,7 @@ export default async function ProfessorStudentsPage() {
   });
 
   const activityGroups = await prisma.activityGroup.findMany({
-    where: { activityId: { in: activityIds } },
+    where: { id: { in: assignedGroupIds } },
     orderBy: [{ activity: { name: 'asc' } }, { name: 'asc' }],
     include: {
       activity: { select: { name: true } },
@@ -345,7 +359,7 @@ export default async function ProfessorStudentsPage() {
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">Mis alumnos</h1>
         <p className="text-sm text-muted-foreground mt-1">
-          Alumnos y padres en grupos de tus actividades.
+          Alumnos y padres en los grupos que tenés asignados.
         </p>
       </div>
       <StudentsSearch students={students} groups={groups} />


### PR DESCRIPTION
### Motivation
- Professors should only see members of groups they are actually assigned to, not all groups of an activity where they appear as a professor. 
- The change enforces that group visibility is driven by group sessions (where the professor is assigned) so the professor view matches the intended privacy/assignment rules.

### Description
- Added a query to collect group IDs from `ActivityDay` entries where `professors` include the current professor and `activityGroupId` is set, producing `assignedGroupIds` in `src/app/professor/students/page.tsx`.
- Restricted the `activityGroupMember` and `activityGroup` queries to `assignedGroupIds` so students and groups come only from groups assigned to the professor.
- Updated the page copy to clarify that the page shows students and parents for the groups the professor is assigned to.
- File changed: `src/app/professor/students/page.tsx`.

### Testing
- Ran `pnpm lint`, which completed (there is an existing Prettier warning unrelated to this change in `src/app/api/users/[id]/children/[childId]/route.ts`).
- Ran `pnpm exec tsc --noEmit`, which failed due to existing type/test issues in `tests/api/pickup-notices.test.ts` unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa74681a048328acd26db64a5987a1)