### PR TITLE
Summarize annual schedules in professor group view

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
+import { summarizeActivitySchedules } from '@/lib/activities/schedule-summary';
 import { prisma } from '@/lib/prisma';
 import StudentsSearch, {
   type ProfessorGroupEntry,
@@ -117,7 +118,7 @@ export default async function ProfessorStudentsPage() {
     where: { id: { in: assignedGroupIds } },
     orderBy: [{ activity: { name: 'asc' } }, { name: 'asc' }],
     include: {
-      activity: { select: { name: true } },
+      activity: { select: { name: true, activityType: true } },
       days: {
         orderBy: { date: 'asc' },
         select: {
@@ -323,11 +324,16 @@ export default async function ProfessorStudentsPage() {
     capacity: group.capacity,
     minAge: group.minAge,
     maxAge: group.maxAge,
-    schedules: group.days.map((day) => ({
+    schedules: summarizeActivitySchedules(
+      group.activity.activityType,
+      group.days
+    ).map((day) => ({
       id: day.id,
       date: day.date.toISOString(),
+      weekday: day.weekday,
       schedule: day.schedule,
       cancelled: day.cancelled,
+      repeatsWeekly: day.repeatsWeekly,
     })),
     participants: group.members
       .map((member) => {

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -21,8 +21,10 @@ export type ProfessorGroupEntry = {
   schedules: {
     id: string;
     date: string;
+    weekday?: number;
     schedule: string;
     cancelled: boolean;
+    repeatsWeekly: boolean;
   }[];
   participants: {
     id: string;
@@ -38,7 +40,29 @@ function getParticipantAgeLabel(age: number | null) {
   return `${age} año${age === 1 ? '' : 's'}`;
 }
 
-function formatScheduleDay(date: string) {
+const weeklyScheduleLabels = [
+  'domingo',
+  'lunes',
+  'martes',
+  'miércoles',
+  'jueves',
+  'viernes',
+  'sábado',
+];
+
+function formatScheduleDay({
+  date,
+  weekday,
+  repeatsWeekly,
+}: {
+  date: string;
+  weekday?: number;
+  repeatsWeekly: boolean;
+}) {
+  if (repeatsWeekly && weekday !== undefined) {
+    return weeklyScheduleLabels[weekday] ?? 'Día semanal';
+  }
+
   return new Date(date).toLocaleDateString('es-AR', {
     weekday: 'long',
     day: 'numeric',
@@ -448,7 +472,7 @@ export default function StudentsSearch({
                             >
                               <div className="flex items-center justify-between gap-3">
                                 <span className="font-medium capitalize">
-                                  {formatScheduleDay(day.date)}
+                                  {formatScheduleDay(day)}
                                 </span>
                                 {day.cancelled && (
                                   <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">

--- a/src/lib/__tests__/schedule-summary.test.ts
+++ b/src/lib/__tests__/schedule-summary.test.ts
@@ -1,0 +1,70 @@
+import { summarizeActivitySchedules } from '../activities/schedule-summary';
+
+describe('summarizeActivitySchedules', () => {
+  it('agrupa sesiones anuales repetidas por día semanal y horario', () => {
+    const summaries = summarizeActivitySchedules('ANNUAL', [
+      {
+        id: 'thu-1',
+        date: new Date('2026-01-01T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+      {
+        id: 'tue-1',
+        date: new Date('2026-01-06T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+      {
+        id: 'thu-2',
+        date: new Date('2026-01-08T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+      {
+        id: 'tue-2',
+        date: new Date('2026-01-13T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+    ]);
+
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        id: 'tue-1',
+        weekday: 2,
+        schedule: '17.30 a 18.30',
+        repeatsWeekly: true,
+      }),
+      expect.objectContaining({
+        id: 'thu-1',
+        weekday: 4,
+        schedule: '17.30 a 18.30',
+        repeatsWeekly: true,
+      }),
+    ]);
+  });
+
+  it('mantiene cada sesión para actividades temporarias', () => {
+    const summaries = summarizeActivitySchedules('TEMPORARY', [
+      {
+        id: 'session-1',
+        date: new Date('2026-01-01T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+      {
+        id: 'session-2',
+        date: new Date('2026-01-08T12:00:00.000Z'),
+        schedule: '17.30 a 18.30',
+        cancelled: false,
+      },
+    ]);
+
+    expect(summaries).toHaveLength(2);
+    expect(summaries.map((summary) => summary.repeatsWeekly)).toEqual([
+      false,
+      false,
+    ]);
+  });
+});

--- a/src/lib/activities/schedule-summary.ts
+++ b/src/lib/activities/schedule-summary.ts
@@ -1,0 +1,74 @@
+export type ActivityScheduleSummaryType = 'TEMPORARY' | 'ANNUAL';
+
+export type ActivityScheduleDay = {
+  id: string;
+  date: Date;
+  schedule: string;
+  cancelled: boolean;
+};
+
+export type ActivityScheduleSummary = ActivityScheduleDay & {
+  weekday?: number;
+  repeatsWeekly: boolean;
+};
+
+function getUtcWeekday(date: Date) {
+  return date.getUTCDay();
+}
+
+function getWeekdaySortValue(weekday: number) {
+  return weekday === 0 ? 7 : weekday;
+}
+
+export function summarizeActivitySchedules(
+  activityType: ActivityScheduleSummaryType,
+  days: ActivityScheduleDay[]
+): ActivityScheduleSummary[] {
+  if (activityType !== 'ANNUAL') {
+    return days.map((day) => ({ ...day, repeatsWeekly: false }));
+  }
+
+  const summaries = new Map<
+    string,
+    ActivityScheduleSummary & {
+      totalSessions: number;
+      cancelledSessions: number;
+    }
+  >();
+
+  for (const day of days) {
+    const weekday = getUtcWeekday(day.date);
+    const key = `${weekday}:${day.schedule.trim().toLowerCase()}`;
+    const existing = summaries.get(key);
+
+    if (existing) {
+      existing.totalSessions += 1;
+      if (day.cancelled) existing.cancelledSessions += 1;
+      if (day.date < existing.date) {
+        existing.date = day.date;
+        existing.id = day.id;
+      }
+      continue;
+    }
+
+    summaries.set(key, {
+      ...day,
+      weekday,
+      repeatsWeekly: true,
+      totalSessions: 1,
+      cancelledSessions: day.cancelled ? 1 : 0,
+    });
+  }
+
+  return Array.from(summaries.values())
+    .map(({ totalSessions, cancelledSessions, ...summary }) => ({
+      ...summary,
+      cancelled: totalSessions > 0 && cancelledSessions === totalSessions,
+    }))
+    .sort((a, b) => {
+      const weekdayA = getWeekdaySortValue(a.weekday ?? getUtcWeekday(a.date));
+      const weekdayB = getWeekdaySortValue(b.weekday ?? getUtcWeekday(b.date));
+      if (weekdayA !== weekdayB) return weekdayA - weekdayB;
+      return a.schedule.localeCompare(b.schedule, 'es');
+    });
+}


### PR DESCRIPTION
### Motivation
- Evitar que en la vista de profesor (/professor/students) se liste sesión por sesión actividades anuales y mostrar en su lugar el día semanal + horario (p. ej. “martes y jueves 17:30–18:30”).

### Description
- Añadí un helper reutilizable `summarizeActivitySchedules` en `src/lib/activities/schedule-summary.ts` que agrupa sesiones anuales por `weekday` y `schedule` y preserva sesiones individuales para actividades `TEMPORARY`.
- Modifiqué la consulta en `src/app/professor/students/page.tsx` para traer `activity.activityType` y pasar las sesiones por el resumidor antes de enviarlas al cliente.
- Actualicé la UI en `src/app/professor/students/students-search.tsx` para renderizar etiquetas semanales (`lunes`, `martes`, ...) cuando la entrada proviene de una actividad `ANNUAL` (usa `repeatsWeekly`/`weekday`).
- Agregué tests unitarios en `src/lib/__tests__/schedule-summary.test.ts` que cubren el agrupamiento para `ANNUAL` y la preservación para `TEMPORARY`.

### Testing
- Ejecuté el test unitario específico: `pnpm test -- schedule-summary.test.ts --runInBand` y pasó (2 tests ✅).
- Formateé con Prettier: `pnpm exec prettier --write ...` y verifiqué lint: `pnpm lint` (lint pasó; quedó una advertencia preexistente de Prettier en `src/app/api/users/[id]/children/[childId]/route.ts`).
- Intenté `pnpm exec tsc --noEmit` pero falló por errores de tipado en tests no relacionados (`tests/api/pickup-notices.test.ts`), por lo que el chequeo de TypeScript completo no pudo finalizar; los cambios propios no dependen de esos errores.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa79a381f483288ac39d9657eee3b0)