### PR TITLE
Filter activity join groups by participant age and persist group selection through checkout

### DIFF
--- a/src/app/activities/cart/page.tsx
+++ b/src/app/activities/cart/page.tsx
@@ -189,6 +189,7 @@ export default function ActivitiesCartPage() {
     activityId: item.activityId,
     target: item.target === 'self' ? 'self' : item.target,
     targetLabel: item.targetLabel,
+    groupId: item.groupId,
   }));
 
   return (

--- a/src/app/activities/join/[id]/group-schedule-calendar.tsx
+++ b/src/app/activities/join/[id]/group-schedule-calendar.tsx
@@ -25,6 +25,8 @@ type Props = {
   selectedGroupId: string;
   onGroupChange: (value: string) => void;
   selectedPersonBirthDate?: string | null;
+  selectedPersonAge?: number | null;
+  isPersonSelected?: boolean;
   activityStartDate?: string | null;
 };
 
@@ -88,6 +90,8 @@ export default function GroupScheduleCalendar({
   selectedGroupId,
   onGroupChange,
   selectedPersonBirthDate,
+  selectedPersonAge,
+  isPersonSelected = false,
   activityStartDate,
 }: Props) {
   const [currentDate, setCurrentDate] = useState(() => new Date());
@@ -175,39 +179,55 @@ export default function GroupScheduleCalendar({
         </h2>
         <p className="text-sm text-muted-foreground font-body">
           Hacé clic en un horario del calendario para elegir el grupo al que
-          querés inscribirte.
+          querés inscribirte. Las opciones se filtran por la edad de la persona
+          seleccionada.
         </p>
 
-        <div className="flex flex-wrap gap-2">
-          {groups.map((group) => {
-            const colors = groupColorMap.get(group.id)!;
-            const isSelected = group.id === selectedGroupId;
-            return (
-              <button
-                key={group.id}
-                type="button"
-                onClick={() => onGroupChange(group.id)}
-                className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer text-left ${
-                  isSelected ? colors.pillSelected : colors.pill
-                }`}
-              >
-                <span className="block leading-tight">
-                  {group.name}
-                  {(group.minAge !== null || group.maxAge !== null) && (
-                    <span className="ml-1 opacity-70">
-                      ({group.minAge ?? '0'}-{group.maxAge ?? '∞'} años)
+        {isPersonSelected &&
+          selectedPersonAge !== null &&
+          selectedPersonAge !== undefined && (
+            <p className="rounded-md border border-border bg-muted/30 px-3 py-2 text-sm text-muted-foreground font-body">
+              Mostrando grupos disponibles para {selectedPersonAge} año
+              {selectedPersonAge === 1 ? '' : 's'}.
+            </p>
+          )}
+
+        {groups.length === 0 ? (
+          <div className="rounded-md border border-dashed border-border px-3 py-3 text-sm text-muted-foreground font-body">
+            No hay grupos disponibles para la persona seleccionada.
+          </div>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {groups.map((group) => {
+              const colors = groupColorMap.get(group.id)!;
+              const isSelected = group.id === selectedGroupId;
+              return (
+                <button
+                  key={group.id}
+                  type="button"
+                  onClick={() => onGroupChange(group.id)}
+                  className={`rounded-full border px-3 py-1.5 text-xs font-medium transition-colors cursor-pointer text-left ${
+                    isSelected ? colors.pillSelected : colors.pill
+                  }`}
+                >
+                  <span className="block leading-tight">
+                    {group.name}
+                    {(group.minAge !== null || group.maxAge !== null) && (
+                      <span className="ml-1 opacity-70">
+                        ({group.minAge ?? '0'}-{group.maxAge ?? '∞'} años)
+                      </span>
+                    )}
+                  </span>
+                  {group.professors.length > 0 && (
+                    <span className="block leading-tight opacity-75 font-normal mt-0.5">
+                      {group.professors.join(', ')}
                     </span>
                   )}
-                </span>
-                {group.professors.length > 0 && (
-                  <span className="block leading-tight opacity-75 font-normal mt-0.5">
-                    {group.professors.join(', ')}
-                  </span>
-                )}
-              </button>
-            );
-          })}
-        </div>
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         {ageWarning && (
           <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 font-body">

--- a/src/app/activities/join/[id]/join-enrollment-panel.tsx
+++ b/src/app/activities/join/[id]/join-enrollment-panel.tsx
@@ -60,6 +60,38 @@ function calculateAge(birthDate: Date, referenceDate: Date): number {
   return age;
 }
 
+function getReferenceDate(activityStartDate?: string | null) {
+  const today = new Date();
+  const parsedActivityDate = activityStartDate
+    ? new Date(activityStartDate)
+    : null;
+
+  return parsedActivityDate &&
+    !Number.isNaN(parsedActivityDate.getTime()) &&
+    parsedActivityDate > today
+    ? parsedActivityDate
+    : today;
+}
+
+function getPersonAge(
+  birthDate: string | null | undefined,
+  activityStartDate?: string | null
+) {
+  if (!birthDate) return null;
+
+  const parsedBirthDate = new Date(birthDate);
+  if (Number.isNaN(parsedBirthDate.getTime())) return null;
+
+  return calculateAge(parsedBirthDate, getReferenceDate(activityStartDate));
+}
+
+function isGroupEligibleForAge(group: Group, age: number | null) {
+  if (age === null) return true;
+  if (group.minAge !== null && age < group.minAge) return false;
+  if (group.maxAge !== null && age > group.maxAge) return false;
+  return true;
+}
+
 function getGroupAgeError(
   group: Group | undefined,
   birthDate: string | null | undefined,
@@ -68,20 +100,8 @@ function getGroupAgeError(
   if (!group || (group.minAge === null && group.maxAge === null)) return null;
   if (!birthDate) return null;
 
-  const parsedBirthDate = new Date(birthDate);
-  if (Number.isNaN(parsedBirthDate.getTime())) return null;
-
-  const today = new Date();
-  const parsedActivityDate = activityStartDate
-    ? new Date(activityStartDate)
-    : null;
-  const referenceDate =
-    parsedActivityDate &&
-    !Number.isNaN(parsedActivityDate.getTime()) &&
-    parsedActivityDate > today
-      ? parsedActivityDate
-      : today;
-  const age = calculateAge(parsedBirthDate, referenceDate);
+  const age = getPersonAge(birthDate, activityStartDate);
+  if (age === null) return null;
 
   if (group.minAge !== null && age < group.minAge) {
     return `La persona seleccionada tiene ${age} año${age === 1 ? '' : 's'} y este grupo requiere al menos ${group.minAge}.`;
@@ -173,6 +193,28 @@ export default function JoinEnrollmentPanel({
   const effectivePersonId =
     people.length === 1 ? people[0].id : selectedPersonId;
   const selectedPerson = people.find((p) => p.id === effectivePersonId) ?? null;
+  const selectedPersonAge = useMemo(
+    () => getPersonAge(selectedPerson?.birthDate ?? null, activityStartDate),
+    [selectedPerson?.birthDate, activityStartDate]
+  );
+  const eligibleGroups = useMemo(
+    () =>
+      groups.filter((group) => isGroupEligibleForAge(group, selectedPersonAge)),
+    [groups, selectedPersonAge]
+  );
+  const eligibleGroupIds = useMemo(
+    () => new Set(eligibleGroups.map((group) => group.id)),
+    [eligibleGroups]
+  );
+  const eligibleSessions = useMemo(
+    () =>
+      sessions.filter(
+        (activitySession) =>
+          activitySession.activityGroupId &&
+          eligibleGroupIds.has(activitySession.activityGroupId)
+      ),
+    [sessions, eligibleGroupIds]
+  );
   const selectedGroup = groups.find((g) => g.id === selectedGroupId);
 
   const missingFields = useMemo(() => {
@@ -182,6 +224,12 @@ export default function JoinEnrollmentPanel({
     if (!child) return [];
     return getMissingChildFields(child, userPhone ?? null);
   }, [effectivePersonId, selfMissingFields, children, userPhone]);
+
+  useEffect(() => {
+    if (selectedGroupId && !eligibleGroupIds.has(selectedGroupId)) {
+      setSelectedGroupId('');
+    }
+  }, [selectedGroupId, eligibleGroupIds]);
 
   const groupAgeError = useMemo(
     () =>
@@ -197,11 +245,13 @@ export default function JoinEnrollmentPanel({
   const needsPersonSelection = Boolean(
     session && people.length > 1 && !selectedPersonId
   );
-  const needsGroupSelection = groups.length > 0 && !selectedGroupId;
+  const needsGroupSelection = eligibleGroups.length > 0 && !selectedGroupId;
+  const hasNoEligibleGroups = groups.length > 0 && eligibleGroups.length === 0;
   const canRegister =
     !isFull &&
     !needsPersonSelection &&
     !needsGroupSelection &&
+    !hasNoEligibleGroups &&
     !profileIncomplete &&
     !groupAgeError;
 
@@ -225,11 +275,7 @@ export default function JoinEnrollmentPanel({
     const existing = raw ? (JSON.parse(raw) as ActivityCartItem[]) : [];
     const deduped = existing.filter(
       (entry) =>
-        !(
-          entry.activityId === item.activityId &&
-          entry.target === item.target &&
-          (entry.groupId ?? '') === (item.groupId ?? '')
-        )
+        !(entry.activityId === item.activityId && entry.target === item.target)
     );
     window.localStorage.setItem(
       ACTIVITY_CART_STORAGE_KEY,
@@ -244,11 +290,13 @@ export default function JoinEnrollmentPanel({
         <div className="lg:col-span-2">
           <GroupScheduleCalendar
             activityType={activity.activityType}
-            groups={groups}
-            sessions={sessions}
+            groups={eligibleGroups}
+            sessions={eligibleSessions}
             selectedGroupId={selectedGroupId}
             onGroupChange={setSelectedGroupId}
             selectedPersonBirthDate={selectedPerson?.birthDate}
+            selectedPersonAge={selectedPersonAge}
+            isPersonSelected={Boolean(effectivePersonId)}
             activityStartDate={activityStartDate}
           />
         </div>
@@ -301,6 +349,16 @@ export default function JoinEnrollmentPanel({
         ) : needsGroupSelection ? (
           <div className="rounded-md border border-dashed border-border px-4 py-3 text-sm text-muted-foreground font-body">
             Seleccioná un grupo en el calendario para continuar.
+          </div>
+        ) : hasNoEligibleGroups ? (
+          <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 font-body space-y-2">
+            <p className="font-medium">
+              No hay grupos disponibles para esta edad
+            </p>
+            <p>
+              Seleccioná otra persona del grupo familiar o consultá con
+              administración.
+            </p>
           </div>
         ) : profileIncomplete ? (
           <div className="rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800 font-body space-y-2">

--- a/src/app/api/activities/cart/checkout/route.ts
+++ b/src/app/api/activities/cart/checkout/route.ts
@@ -34,6 +34,7 @@ type CartItem = {
   activityId: string;
   target?: string;
   targetLabel?: string;
+  groupId?: string;
 };
 
 function isManualPaymentMethod(value: unknown) {
@@ -235,9 +236,11 @@ export async function POST(req: Request) {
   const checkoutSettings = getMercadoPagoCheckoutSettings();
   const appUrl = getAppUrl(req);
   const base = `${appUrl}/activities/cart`;
-  const refs = items.map(
+  const refs = quote.validatedItems.map(
     (item) =>
-      `${item.activityId}:${(session.user as { id: string }).id}:${item.target && item.target !== 'self' ? item.target : ''}`
+      `${item.activityId}:${(session.user as { id: string }).id}:${
+        item.target && item.target !== 'self' ? item.target : ''
+      }:${item.groupId ?? ''}`
   );
 
   const result = await new Preference(client).create({

--- a/src/app/api/activities/cart/quote/route.ts
+++ b/src/app/api/activities/cart/quote/route.ts
@@ -10,6 +10,7 @@ type CartItem = {
   activityId: string;
   target?: string;
   targetLabel?: string;
+  groupId?: string;
 };
 
 export async function POST(req: Request) {

--- a/src/app/api/mercadopago/notifications/route.ts
+++ b/src/app/api/mercadopago/notifications/route.ts
@@ -68,7 +68,7 @@ export async function POST(req: NextRequest) {
       : [payment.external_reference];
 
     for (const reference of references) {
-      const [activityId, userId, childId] = reference.split(':');
+      const [activityId, userId, childId, groupId] = reference.split(':');
 
       const user = await prisma.user.findUnique({
         where: { id: userId },
@@ -85,7 +85,13 @@ export async function POST(req: NextRequest) {
       const activity = await prisma.activity.findUnique({
         where: { id: activityId },
         select: {
-          groups: { select: { capacity: true } },
+          groups: {
+            select: {
+              id: true,
+              capacity: true,
+              _count: { select: { members: true } },
+            },
+          },
           participants: {
             select: {
               id: true,
@@ -97,6 +103,10 @@ export async function POST(req: NextRequest) {
       if (!activity) {
         continue;
       }
+
+      const selectedGroup = groupId
+        ? activity.groups.find((group) => group.id === groupId)
+        : null;
 
       const participantChildId = childId || null;
       const participantKey = getActivityParticipantKey(
@@ -130,6 +140,17 @@ export async function POST(req: NextRequest) {
         continue;
       }
 
+      if (
+        selectedGroup?.capacity != null &&
+        !existingParticipant &&
+        selectedGroup._count.members >= selectedGroup.capacity
+      ) {
+        console.warn(
+          `[mercadopago] Group ${selectedGroup.id} reached capacity, skipping participant upsert`
+        );
+        continue;
+      }
+
       const receipt = payment.id?.toString();
       const date = payment.date_approved || payment.date_created || new Date();
       const participantData = {
@@ -151,6 +172,17 @@ export async function POST(req: NextRequest) {
         update: participantData,
         select: { id: true },
       });
+
+      if (selectedGroup) {
+        await prisma.activityGroupMember.upsert({
+          where: { activityParticipantId: participant.id },
+          create: {
+            activityGroupId: selectedGroup.id,
+            activityParticipantId: participant.id,
+          },
+          update: { activityGroupId: selectedGroup.id },
+        });
+      }
 
       if (!existingParticipant) {
         notifyActivityPaymentApproved(participant.id).catch((err) =>

--- a/src/lib/cart-checkout.ts
+++ b/src/lib/cart-checkout.ts
@@ -13,6 +13,7 @@ export type CartCheckoutItem = {
   activityId: string;
   target?: string;
   targetLabel?: string;
+  groupId?: string;
 };
 
 type ActivitySummary = {
@@ -68,6 +69,25 @@ class CartQuoteError extends Error {
   }
 }
 
+function calculateAge(birthDate: Date, referenceDate: Date) {
+  let age = referenceDate.getFullYear() - birthDate.getFullYear();
+  const monthDiff = referenceDate.getMonth() - birthDate.getMonth();
+
+  if (
+    monthDiff < 0 ||
+    (monthDiff === 0 && referenceDate.getDate() < birthDate.getDate())
+  ) {
+    age -= 1;
+  }
+
+  return age;
+}
+
+function getActivityReferenceDate(activityDate: Date) {
+  const today = new Date();
+  return activityDate > today ? activityDate : today;
+}
+
 function normalizeTarget(target?: string) {
   return !target || target === 'self' ? null : target;
 }
@@ -96,17 +116,61 @@ export async function buildCartQuote({
     where: { id: { in: uniqueIds } },
     include: {
       participants: { select: { id: true } },
-      groups: { select: { capacity: true } },
+      groups: {
+        select: {
+          id: true,
+          name: true,
+          capacity: true,
+          minAge: true,
+          maxAge: true,
+          _count: { select: { members: true } },
+        },
+      },
     },
   });
   const activityById = new Map(
     activities.map((activity) => [activity.id, activity])
   );
 
+  const userProfile = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { birthDate: true },
+  });
+
+  const selectedCountByGroupId = items.reduce((counts, item) => {
+    if (item.groupId) {
+      counts.set(item.groupId, (counts.get(item.groupId) ?? 0) + 1);
+    }
+    return counts;
+  }, new Map<string, number>());
+
   for (const item of items) {
     const activity = activityById.get(item.activityId);
     if (!activity) {
       throw new CartQuoteError(404, 'Una actividad no existe.');
+    }
+
+    const selectedGroup = item.groupId
+      ? activity.groups.find((group) => group.id === item.groupId)
+      : null;
+
+    if (activity.groups.length > 0 && !selectedGroup) {
+      throw new CartQuoteError(
+        400,
+        `Seleccioná un grupo válido para ${activity.name}.`
+      );
+    }
+
+    if (
+      selectedGroup?.capacity != null &&
+      selectedGroup._count.members +
+        (selectedCountByGroupId.get(selectedGroup.id) ?? 0) >
+        selectedGroup.capacity
+    ) {
+      throw new CartQuoteError(
+        409,
+        `El grupo ${selectedGroup.name} no tiene cupo.`
+      );
     }
 
     const activityCapacity =
@@ -144,6 +208,7 @@ export async function buildCartQuote({
           id: true,
           name: true,
           lastName: true,
+          birthDate: true,
         },
       })
     : [];
@@ -154,6 +219,46 @@ export async function buildCartQuote({
       throw new CartQuoteError(
         403,
         'Una de las personas seleccionadas no pertenece a tu familia.'
+      );
+    }
+  }
+
+  for (const item of items) {
+    const activity = activityById.get(item.activityId)!;
+    const selectedGroup = item.groupId
+      ? activity.groups.find((group) => group.id === item.groupId)
+      : null;
+
+    if (!selectedGroup) continue;
+
+    const childId = normalizeTarget(item.target);
+    const birthDate = childId
+      ? (childById.get(childId)?.birthDate ?? null)
+      : (userProfile?.birthDate ?? null);
+
+    if (!birthDate) {
+      throw new CartQuoteError(
+        422,
+        'La persona seleccionada no tiene fecha de nacimiento cargada.'
+      );
+    }
+
+    const age = calculateAge(
+      birthDate,
+      getActivityReferenceDate(activity.date)
+    );
+
+    if (selectedGroup.minAge != null && age < selectedGroup.minAge) {
+      throw new CartQuoteError(
+        400,
+        `${item.targetLabel ?? 'La persona seleccionada'} no alcanza la edad mínima del grupo ${selectedGroup.name}.`
+      );
+    }
+
+    if (selectedGroup.maxAge != null && age > selectedGroup.maxAge) {
+      throw new CartQuoteError(
+        400,
+        `${item.targetLabel ?? 'La persona seleccionada'} supera la edad máxima del grupo ${selectedGroup.name}.`
       );
     }
   }

--- a/src/lib/services/manual-payment-service.ts
+++ b/src/lib/services/manual-payment-service.ts
@@ -427,7 +427,7 @@ export async function createManualPaymentCheckout(input: {
           source?.target && source.target !== 'self' ? source.target : null
         );
 
-        await tx.activityParticipant.upsert({
+        const participant = await tx.activityParticipant.upsert({
           where: { participantKey },
           create: {
             activityId: item.id,
@@ -437,7 +437,19 @@ export async function createManualPaymentCheckout(input: {
             participantKey,
           },
           update: {},
+          select: { id: true },
         });
+
+        if (source?.groupId) {
+          await tx.activityGroupMember.upsert({
+            where: { activityParticipantId: participant.id },
+            create: {
+              activityGroupId: source.groupId,
+              activityParticipantId: participant.id,
+            },
+            update: { activityGroupId: source.groupId },
+          });
+        }
       }
 
       if (input.quote.totalDiscountAmount > 0) {


### PR DESCRIPTION
### Motivation
- Show only the group options that are appropriate for the selected family member’s age on the public activity join flow and prevent invalid selections when switching persons. 
- Ensure the user can only pick one group per activity/person and that the selected group is preserved through the cart and payment flow so the backend can persist group membership after payment. 

### Description
- Limit calendar pills and session slots to age-eligible groups and clear a previously selected group when switching to a family member for whom that group is invalid; surface a small UI hint with the selected person’s age and an empty-state when there are no eligible groups. (UI: `src/app/activities/join/[id]/join-enrollment-panel.tsx`, `src/app/activities/join/[id]/group-schedule-calendar.tsx`) 
- Replace same-activity/same-person cart entries so a person cannot have multiple group selections for the same activity, and include `groupId` in the stored cart items. (Cart UI: `src/app/activities/join/[id]/join-enrollment-panel.tsx`, `src/app/activities/cart/page.tsx`) 
- Carry `groupId` through quote/checkout and include it in MercadoPago `external_reference` so group selection survives payment flows. (API: `src/app/api/activities/cart/checkout/route.ts`, `src/app/api/activities/cart/quote/route.ts`) 
- Validate group ownership, age range, and group capacity during server-side quote/checkout (`buildCartQuote`) and persist group membership when registering participants after MercadoPago notifications or manual payment approval. (Server: `src/lib/cart-checkout.ts`, `src/app/api/mercadopago/notifications/route.ts`, `src/lib/services/manual-payment-service.ts`) 

Files touched: `src/app/activities/join/[id]/join-enrollment-panel.tsx`, `src/app/activities/join/[id]/group-schedule-calendar.tsx`, `src/app/activities/cart/page.tsx`, `src/app/api/activities/cart/checkout/route.ts`, `src/app/api/activities/cart/quote/route.ts`, `src/app/api/mercadopago/notifications/route.ts`, `src/lib/cart-checkout.ts`, `src/lib/services/manual-payment-service.ts`.

### Testing
- Ran `pnpm lint` which completed (only a pre-existing Prettier warning remains in `src/app/api/users/[id]/children/[childId]/route.ts`). 
- Attempted `pnpm build` which failed in this environment because Next.js could not fetch the Google Font `Chivo` from `fonts.googleapis.com`. 
- Ran `pnpm exec tsc --noEmit` which surfaced unrelated, pre-existing test/type errors in `tests/api/pickup-notices.test.ts` and did not indicate type issues in the changed activity/cart/payment code. 
- Ran automatic formatting (`prettier --write`) and committed the changes successfully.

Unresolved risks
- The production build in this environment is blocked by the Google Fonts fetch failure, so I could not produce a built artifact or run full end-to-end rendering verification here. 
- Existing pending payment preferences created before this change will not include `groupId` in their external references and therefore will not retroactively assign groups; only new cart checkouts will carry group selections. 
- There are unrelated TypeScript/test failures in the repo which prevented a clean `tsc --noEmit` in this environment but they do not appear to be caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7f925714832880f5f772dd2ed601)