### PR TITLE
Use dropdown for professor group selection

### DIFF
--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from 'react';
 import Link from 'next/link';
+import { Select } from '@/components/ui/select';
 
 type Tutor = {
   name: string;
@@ -387,35 +388,29 @@ export default function StudentsSearch({
             </div>
           ) : (
             <>
-              <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-                {groups.map((group) => {
-                  const isSelected = selectedGroup?.id === group.id;
-                  return (
-                    <button
-                      key={group.id}
-                      type="button"
-                      onClick={() => setSelectedGroupId(group.id)}
-                      className={`rounded-xl border p-4 text-left shadow-sm transition-colors ${
-                        isSelected
-                          ? 'border-primary bg-primary/10 ring-2 ring-primary/20'
-                          : 'bg-card hover:border-primary/50 hover:bg-primary/5'
-                      }`}
-                    >
-                      <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        {group.activityName}
-                      </p>
-                      <p className="mt-1 font-semibold text-foreground">
-                        {group.name}
-                      </p>
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        {group.participants.length} participante
-                        {group.participants.length === 1 ? '' : 's'} ·{' '}
-                        {getAgeSummary(group.participants)}
-                      </p>
-                    </button>
-                  );
-                })}
-              </div>
+              <label className="block space-y-2 rounded-xl border bg-card p-4 shadow-sm">
+                <span className="text-sm font-medium text-foreground">
+                  Seleccioná un grupo
+                </span>
+                <Select
+                  value={selectedGroup?.id ?? ''}
+                  onValueChange={setSelectedGroupId}
+                  aria-label="Seleccionar grupo para ver su información"
+                >
+                  {groups.map((group) => (
+                    <option key={group.id} value={group.id}>
+                      {group.activityName} — {group.name} (
+                      {group.participants.length} participante
+                      {group.participants.length === 1 ? '' : 's'} ·{' '}
+                      {getAgeSummary(group.participants)})
+                    </option>
+                  ))}
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Elegí una opción para actualizar la información del recuadro
+                  de abajo.
+                </p>
+              </label>
 
               {selectedGroup && (
                 <section className="rounded-2xl border bg-card p-5 shadow-sm space-y-5">


### PR DESCRIPTION
### Motivation
- Cambiar la interfaz de selección de grupos en `/professor/students` para que las opciones de mis grupos estén dentro de un menú desplegable y al elegir una opción se muestre la información en el recuadro inferior tal como estaba.

### Description
- Reemplacé la rejilla de tarjetas/botones de selección de grupos por un `Select` reutilizable importado de `@/components/ui/select` y vinculé su `value`/`onValueChange` a `selectedGroupId` para actualizar la vista de detalle. 
- Mantuve intacto el panel de detalle del grupo debajo del selector para que al cambiar la opción se muestre la misma información (días/horarios, participantes, cupo, edades, etc.).
- Modifiqué `src/app/professor/students/students-search.tsx` para agregar la importación del `Select` y sustituir el bloque de botones por un label con el menú desplegable que lista actividad, nombre, cantidad de participantes y resumen de edades en cada opción.

### Testing
- Ejecuté el formateo/linting con Prettier y `pnpm lint`, los checks de estilo pasaron pero quedó una advertencia preexistente de Prettier en `src/app/api/users/[id]/children/[childId]/route.ts` que no está relacionada con este cambio. 
- Ejecuté `pnpm exec tsc --noEmit` y falló por errores TypeScript preexistentes en tests (`tests/api/pickup-notices.test.ts`) que no son causados por esta modificación. 
- Verifiqué manualmente que el selector actualiza `selectedGroup` y que el panel de detalle consume la misma estructura de datos sin cambios funcionales.

Unresolved risks
- Es necesario validar visualmente en un navegador con sesión de profesor porque la página depende de datos y autenticación para confirmar el comportamiento UX final. 
- Hay errores TypeScript en la suite de tests del repo que impiden que `tsc --noEmit` quede totalmente limpio y podrían ocultar impactos en CI si no se resuelven.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa4906298832885f9839d8ea3024c)