### PR TITLE
Simplify professor group selector labels

### DIFF
--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -404,10 +404,7 @@ export default function StudentsSearch({
                 >
                   {groups.map((group) => (
                     <option key={group.id} value={group.id}>
-                      {group.activityName} — {group.name} (
-                      {group.participants.length} participante
-                      {group.participants.length === 1 ? '' : 's'} ·{' '}
-                      {getAgeSummary(group.participants)})
+                      {group.activityName} — {group.name}
                     </option>
                   ))}
                 </Select>


### PR DESCRIPTION
### Motivation
- Make the “Seleccioná un grupo” dropdown in the professor students view more concise by showing only the activity and group name in each option, leaving counts and age summaries in the detailed panel below.

### Description
- Changed the option label rendering in `src/app/professor/students/students-search.tsx` from `{activityName} — {group.name} ({participants} participante(s) · {ageSummary})` to `{activityName} — {group.name}`, leaving the expanded group details unchanged.

### Testing
- Ran `pnpm lint` which completed (reported an existing unrelated Prettier warning in another file) and ran `git diff --check`; both checks passed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faa80460c08328bbc8e5e69d2fc496)