### PR TITLE
Renombrar 'Mis alumnos' a 'Mis grupos' y mostrar 'Mis grupos' por defecto

### DIFF
--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -155,7 +155,7 @@ export default function StudentsSearch({
   students: StudentEntry[];
   groups: ProfessorGroupEntry[];
 }) {
-  const [activeTab, setActiveTab] = useState<'students' | 'groups'>('students');
+  const [activeTab, setActiveTab] = useState<'students' | 'groups'>('groups');
   const [selectedGroupId, setSelectedGroupId] = useState(groups[0]?.id ?? '');
   const [query, setQuery] = useState('');
   const [participantsExpanded, setParticipantsExpanded] = useState(false);
@@ -182,19 +182,6 @@ export default function StudentsSearch({
       >
         <button
           type="button"
-          onClick={() => setActiveTab('students')}
-          className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-            activeTab === 'students'
-              ? 'bg-primary text-primary-foreground shadow-sm'
-              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
-          }`}
-          role="tab"
-          aria-selected={activeTab === 'students'}
-        >
-          Mis alumnos
-        </button>
-        <button
-          type="button"
           onClick={() => setActiveTab('groups')}
           className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === 'groups'
@@ -205,6 +192,19 @@ export default function StudentsSearch({
           aria-selected={activeTab === 'groups'}
         >
           Mis grupos
+        </button>
+        <button
+          type="button"
+          onClick={() => setActiveTab('students')}
+          className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+            activeTab === 'students'
+              ? 'bg-primary text-primary-foreground shadow-sm'
+              : 'text-muted-foreground hover:bg-muted hover:text-foreground'
+          }`}
+          role="tab"
+          aria-selected={activeTab === 'students'}
+        >
+          Mis alumnos
         </button>
       </div>
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -241,7 +241,7 @@ export default function Navbar() {
               className={navLinkClass('/professor/students')}
               prefetch={true}
             >
-              Mis alumnos
+              Mis grupos
             </Link>
           )}
           {isAdmin && (
@@ -595,7 +595,7 @@ export default function Navbar() {
                   onClick={() => setMenuOpen(false)}
                   prefetch={true}
                 >
-                  Mis alumnos
+                  Mis grupos
                 </Link>
               )}
               {isProfessor && (


### PR DESCRIPTION
### Motivation
- Aclarar la navegación de profesores renombrando la sección a "Mis grupos" y priorizar la vista de grupos al entrar a la sección.

### Description
- Reemplazado el texto de navegación de profesores de "Mis alumnos" a "Mis grupos" en `src/components/navbar.tsx` (escritorio y menú móvil).
- Reordenadas las pestañas en `src/app/professor/students/students-search.tsx` para mostrar primero "Mis grupos" y luego "Mis alumnos", y cambiado el estado inicial a `groups` para que la pestaña por defecto sea "Mis grupos".
- Archivos tocados: `src/components/navbar.tsx`, `src/app/professor/students/students-search.tsx`.
- Commit realizado con mensaje: "Renombrar sección de grupos de profesores".

### Testing
- Ejecutado `pnpm lint`, que finalizó correctamente; se reportó una advertencia preexistente de Prettier en `src/app/api/users/[id]/children/[childId]/route.ts` pero no relacionada con estos cambios.
- Ejecutado `git diff --check` sin errores relevantes y cambios committeados.

Unresolved risks
- Quedan otras ocurrencias textuales relacionadas (por ejemplo títulos y enlaces internos en las vistas de profesores) que no se modificaron y pueden quedar inconsistentes si se desea renombrar todo el dominio de texto; revisar `src/app/professor/students/page.tsx` y páginas relacionadas para una migración completa si es necesario.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faad4123548328810da9062192d002)