### PR TITLE
Move group professor contacts to professor groups

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -2,7 +2,6 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
-import { MessageCircle } from 'lucide-react';
 import { authOptions } from '@/lib/auth';
 import RoleSwitchPrompt from '@/components/role-switch-prompt';
 import { hasProfessorCapability } from '@/lib/roles';
@@ -23,11 +22,6 @@ type UpcomingSession = {
   activityGroupId: string | null;
   groupName: string | null;
   cancelled: boolean;
-  professors: Array<{
-    userId: string;
-    name: string | null;
-    lastName: string | null;
-  }>;
 };
 
 type ActivityParticipantSummary = {
@@ -218,12 +212,6 @@ export default async function MyActivitiesPage({
           activityId: true,
           cancelled: true,
           activityGroup: { select: { name: true } },
-          professors: {
-            select: {
-              userId: true,
-              user: { select: { name: true, lastName: true } },
-            },
-          },
         },
         orderBy: { date: 'asc' },
       });
@@ -250,11 +238,6 @@ export default async function MyActivitiesPage({
             activityGroupId: s.activityGroupId,
             groupName: s.activityGroup?.name ?? null,
             cancelled: s.cancelled,
-            professors: s.professors.map((professor) => ({
-              userId: professor.userId,
-              name: professor.user.name,
-              lastName: professor.user.lastName,
-            })),
           });
           sessionsByActivity.set(s.activityId, list);
         }
@@ -533,47 +516,6 @@ export default async function MyActivitiesPage({
                                 </summary>
 
                                 <div className="mt-3 space-y-3 border-t pt-3">
-                                  <div>
-                                    <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                      Profesores del grupo
-                                    </p>
-                                    {s.professors.length > 0 ? (
-                                      <div className="mt-2 flex flex-wrap gap-2">
-                                        {s.professors.map((professor) => {
-                                          const professorName =
-                                            `${professor.name ?? ''}${professor.lastName ? ` ${professor.lastName}` : ''}`.trim() ||
-                                            'Sin nombre';
-                                          return (
-                                            <span
-                                              key={professor.userId}
-                                              className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-0.5 text-sm font-medium text-primary"
-                                            >
-                                              <Link
-                                                href={`/professors/${professor.userId}`}
-                                                prefetch={true}
-                                                className="hover:underline underline-offset-4"
-                                              >
-                                                {professorName}
-                                              </Link>
-                                              <Link
-                                                href={`/chat?with=${professor.userId}`}
-                                                prefetch={true}
-                                                aria-label={`Iniciar chat con ${professorName}`}
-                                                className="inline-flex h-5 w-5 items-center justify-center rounded-full hover:bg-primary/10 transition-colors"
-                                              >
-                                                <MessageCircle className="h-3.5 w-3.5" />
-                                              </Link>
-                                            </span>
-                                          );
-                                        })}
-                                      </div>
-                                    ) : (
-                                      <p className="mt-2 text-xs text-muted-foreground">
-                                        No hay profesores asignados.
-                                      </p>
-                                    )}
-                                  </div>
-
                                   <div className="grid gap-3 md:grid-cols-[1fr_180px] md:items-start">
                                     <div className="space-y-2">
                                       <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">

--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -126,6 +126,19 @@ export default async function ProfessorStudentsPage() {
           date: true,
           schedule: true,
           cancelled: true,
+          professors: {
+            select: {
+              userId: true,
+              user: {
+                select: {
+                  name: true,
+                  lastName: true,
+                  email: true,
+                  phone: true,
+                },
+              },
+            },
+          },
         },
       },
       members: {
@@ -316,49 +329,83 @@ export default async function ProfessorStudentsPage() {
     return nameA.localeCompare(nameB, 'es');
   });
 
-  const groups: ProfessorGroupEntry[] = activityGroups.map((group) => ({
-    id: group.id,
-    name: group.name,
-    activityName: group.activity.name,
-    description: group.description,
-    capacity: group.capacity,
-    minAge: group.minAge,
-    maxAge: group.maxAge,
-    schedules: summarizeActivitySchedules(
-      group.activity.activityType,
-      group.days
-    ).map((day) => ({
-      id: day.id,
-      date: day.date.toISOString(),
-      weekday: day.weekday,
-      schedule: day.schedule,
-      cancelled: day.cancelled,
-      repeatsWeekly: day.repeatsWeekly,
-    })),
-    participants: group.members
-      .map((member) => {
-        const participant = member.activityParticipant;
+  const groups: ProfessorGroupEntry[] = activityGroups.map((group) => {
+    const professorsById = new Map<
+      string,
+      {
+        userId: string;
+        name: string;
+        email: string;
+        phone: string | null;
+        sessionCount: number;
+      }
+    >();
 
-        if (participant.child) {
-          return {
-            id: member.id,
-            type: 'child' as const,
-            name: formatFullName(participant.child),
-            age: calculateAge(participant.child.birthDate),
-            responsibleName: formatFullName(participant.user),
-          };
+    for (const day of group.days) {
+      for (const professor of day.professors) {
+        const existing = professorsById.get(professor.userId);
+        if (existing) {
+          existing.sessionCount += 1;
+          continue;
         }
 
-        return {
-          id: member.id,
-          type: 'adult' as const,
-          name: formatFullName(participant.user),
-          age: calculateAge(participant.user.birthDate),
-          responsibleName: null,
-        };
-      })
-      .sort((a, b) => a.name.localeCompare(b.name, 'es')),
-  }));
+        professorsById.set(professor.userId, {
+          userId: professor.userId,
+          name: formatFullName(professor.user),
+          email: professor.user.email,
+          phone: professor.user.phone,
+          sessionCount: 1,
+        });
+      }
+    }
+
+    return {
+      id: group.id,
+      name: group.name,
+      activityName: group.activity.name,
+      description: group.description,
+      capacity: group.capacity,
+      minAge: group.minAge,
+      maxAge: group.maxAge,
+      professors: Array.from(professorsById.values()).sort((a, b) =>
+        a.name.localeCompare(b.name, 'es')
+      ),
+      schedules: summarizeActivitySchedules(
+        group.activity.activityType,
+        group.days
+      ).map((day) => ({
+        id: day.id,
+        date: day.date.toISOString(),
+        weekday: day.weekday,
+        schedule: day.schedule,
+        cancelled: day.cancelled,
+        repeatsWeekly: day.repeatsWeekly,
+      })),
+      participants: group.members
+        .map((member) => {
+          const participant = member.activityParticipant;
+
+          if (participant.child) {
+            return {
+              id: member.id,
+              type: 'child' as const,
+              name: formatFullName(participant.child),
+              age: calculateAge(participant.child.birthDate),
+              responsibleName: formatFullName(participant.user),
+            };
+          }
+
+          return {
+            id: member.id,
+            type: 'adult' as const,
+            name: formatFullName(participant.user),
+            age: calculateAge(participant.user.birthDate),
+            responsibleName: null,
+          };
+        })
+        .sort((a, b) => a.name.localeCompare(b.name, 'es')),
+    };
+  });
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-8 space-y-6">

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
+import { MessageCircle } from 'lucide-react';
 import { Select } from '@/components/ui/select';
 
 type Tutor = {
@@ -19,6 +20,13 @@ export type ProfessorGroupEntry = {
   capacity: number | null;
   minAge: number | null;
   maxAge: number | null;
+  professors: {
+    userId: string;
+    name: string;
+    email: string;
+    phone: string | null;
+    sessionCount: number;
+  }[];
   schedules: {
     id: string;
     date: string;
@@ -451,6 +459,59 @@ export default function StudentsSearch({
                         </span>
                       )}
                     </div>
+                  </div>
+
+                  <div className="rounded-xl border bg-background p-4">
+                    <h3 className="font-medium">Profesores asignados</h3>
+                    {selectedGroup.professors.length === 0 ? (
+                      <p className="mt-2 text-sm text-muted-foreground">
+                        Este grupo todavía no tiene profesores asignados en sus
+                        sesiones.
+                      </p>
+                    ) : (
+                      <ul className="mt-3 grid gap-2 sm:grid-cols-2">
+                        {selectedGroup.professors.map((professor) => (
+                          <li
+                            key={professor.userId}
+                            className="rounded-lg border bg-card p-3 text-sm"
+                          >
+                            <div className="flex items-start justify-between gap-3">
+                              <div className="min-w-0 space-y-1">
+                                <Link
+                                  href={`/professors/${professor.userId}`}
+                                  prefetch={true}
+                                  className="font-medium hover:text-primary hover:underline underline-offset-4"
+                                >
+                                  {professor.name}
+                                </Link>
+                                <p className="truncate text-xs text-muted-foreground">
+                                  {professor.email}
+                                </p>
+                                {professor.phone && (
+                                  <p className="text-xs text-muted-foreground">
+                                    {professor.phone}
+                                  </p>
+                                )}
+                                <p className="text-xs text-muted-foreground">
+                                  {professor.sessionCount} sesión
+                                  {professor.sessionCount === 1 ? '' : 'es'}
+                                  asignada
+                                  {professor.sessionCount === 1 ? '' : 's'}
+                                </p>
+                              </div>
+                              <Link
+                                href={`/chat?with=${professor.userId}`}
+                                prefetch={true}
+                                aria-label={`Iniciar chat con ${professor.name}`}
+                                className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full border text-primary transition-colors hover:bg-primary/10"
+                              >
+                                <MessageCircle className="h-4 w-4" />
+                              </Link>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                   </div>
 
                   <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">


### PR DESCRIPTION
### Motivation
- Consolidate professor contact information at the group level so professors appear on each group in `/professor/students` and remove repetitive per-session contacts from `/my-activities`.

### Description
- Removed per-session professor fetch and the “Profesores del grupo” contact block from `src/app/my-activities/page.tsx` so upcoming sessions no longer fetch or render professor contact data.
- Extended the `activityGroup` query in `src/app/professor/students/page.tsx` to include day-level professor assignments and aggregated them per group into a `professors` list with `userId`, `name`, `email`, `phone` and `sessionCount`.
- Added a new “Profesores asignados” block in `src/app/professor/students/students-search.tsx` that lists professors for the selected group with links to the professor profile and chat, email/phone when available, and assigned session counts, and imported `MessageCircle` for the chat UI.
- Files touched: `src/app/my-activities/page.tsx`, `src/app/professor/students/page.tsx`, `src/app/professor/students/students-search.tsx`.
- Unresolved risks: UI screenshots were not captured because views require authentication and the environment had no seeded session/credentials.

### Testing
- Ran `pnpm lint` which completed successfully, with an existing Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts` unrelated to these changes.
- Ran `pnpm exec tsc --noEmit` which failed due to existing typing errors in `tests/api/pickup-notices.test.ts` unrelated to the modified files.
- Verified `git diff --check` and created a commit (`Move group professor contacts to professor groups`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fab0413fe083289640acc7139e02df)