### PR TITLE
Rename professor payments menu label

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -378,7 +378,7 @@ export default function Navbar() {
                       href="/my-payments"
                       className="block w-full text-left px-4 py-2 hover:bg-muted hover:text-primary transition-colors text-sm border-t text-black"
                     >
-                      Mis pagos
+                      Ingresos
                     </Link>
                   )}
                   <select
@@ -604,7 +604,7 @@ export default function Navbar() {
                   className={navLinkClass('/my-payments')}
                   onClick={() => setMenuOpen(false)}
                 >
-                  Mis pagos
+                  Ingresos
                 </Link>
               )}
               <ProfileSwitcher className="self-start" />


### PR DESCRIPTION
### Motivation
- Update the professor-facing menu label for the `/my-payments` route from "Mis pagos" to "Ingresos" to match the requested wording.

### Description
- Replaced two occurrences of the label in `src/components/navbar.tsx` (profile dropdown and main/mobile professor navigation) so the link to `/my-payments` now displays "Ingresos".

### Testing
- Ran `pnpm lint` which completed (showed an unrelated Prettier warning outside the changed file) and `git diff --check`, and both checks passed for the modified file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb321a0cec8328a64217b0923784bb)