### PR TITLE
Quitar etiqueta “Ver/Ocultar” en Profesores asignados de /professor/students

### DIFF
--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -550,9 +550,6 @@ export default function StudentsSearch({
                     >
                       <span className="font-medium">Profesores asignados</span>
                       <span className="flex items-center gap-2 text-xs text-muted-foreground">
-                        <span className="rounded-full border px-2.5 py-1 font-medium text-foreground">
-                          {professorsExpanded ? 'Ocultar' : 'Ver'}
-                        </span>
                         {selectedGroup.professors.length} profesor
                         {selectedGroup.professors.length === 1 ? '' : 'es'}
                         <svg


### PR DESCRIPTION
### Motivation
- Alinear la cabecera del bloque “Profesores asignados” con el patrón usado en “Participantes” removiendo el texto/botón visual “Ver/Ocultar” mientras se preserva el comportamiento desplegable.

### Description
- Se eliminó el span que renderizaba `{professorsExpanded ? 'Ocultar' : 'Ver'}` en `src/app/professor/students/students-search.tsx`, manteniendo el botón con `aria-expanded`, contador y la flecha de colapso.

### Testing
- Se ejecutó `pnpm lint` y `git diff --check`, ambos finalizaron correctamente; permaneció una advertencia Prettier preexistente en `src/app/api/users/[id]/children/[childId]/route.ts` fuera del cambio realizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb32b4c3bc832890ac2c737ba0d0d7)