### PR TITLE
Update professor my-activities agenda

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -164,6 +164,7 @@ export default async function MyActivitiesPage({
           activityGroupId: true,
           cancelled: true,
           activity: { select: { id: true, name: true } },
+          activityGroup: { select: { name: true } },
         },
         orderBy: { date: 'asc' },
       });
@@ -179,7 +180,9 @@ export default async function MyActivitiesPage({
           id: d.id,
           date: d.date.toISOString().slice(0, 10),
           activityId: d.activity.id,
-          activityName: d.activity.name,
+          activityName: isProfessorView
+            ? (d.activityGroup?.name ?? d.activity.name)
+            : d.activity.name,
           schedule: d.schedule,
           geoLocation: d.geoLocation,
           sportIcon: d.sportIcon,
@@ -366,219 +369,222 @@ export default async function MyActivitiesPage({
         variant={isProfessorView ? 'professor-agenda' : 'month'}
       />
 
-      <div className="mt-6 space-y-4">
-        <div className="inline-flex rounded-lg border bg-muted/30 p-1">
-          <Link
-            href="/my-activities"
-            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-              selectedTab === 'current'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Actuales ({currentItems.length})
-          </Link>
-          <Link
-            href="/my-activities?tab=old"
-            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-              selectedTab === 'old'
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-          >
-            Antiguas ({oldItems.length})
-          </Link>
-        </div>
-
-        {visibleItems.length === 0 ? (
-          <div className="py-16 text-center text-muted-foreground">
-            <p>
-              {selectedTab === 'old'
-                ? 'No tenés actividades antiguas.'
-                : 'Todavía no tenés actividades actuales.'}
-            </p>
+      {!isProfessorView && (
+        <div className="mt-6 space-y-4">
+          <div className="inline-flex rounded-lg border bg-muted/30 p-1">
+            <Link
+              href="/my-activities"
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                selectedTab === 'current'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Actuales ({currentItems.length})
+            </Link>
+            <Link
+              href="/my-activities?tab=old"
+              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+                selectedTab === 'old'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Antiguas ({oldItems.length})
+            </Link>
           </div>
-        ) : (
-          <ul className="space-y-4">
-            {visibleItems.map(
-              ({ activity, labels, participants, sessions, isProfessor }) => (
-                <li
-                  key={activity.id}
-                  className="rounded-xl border bg-card p-5 shadow-sm space-y-4"
-                >
-                  <div>
-                    <Link
-                      href={`/activities/${activity.id}`}
-                      prefetch={true}
-                      className="text-lg font-semibold transition-colors hover:text-primary leading-snug"
-                    >
-                      {activity.name}
-                    </Link>
-                    <div className="mt-2 flex flex-wrap gap-2">
-                      {labels.map((label) => (
-                        <span
-                          key={label}
-                          className="rounded-full bg-primary/10 px-3 py-0.5 text-sm font-medium text-primary"
-                        >
-                          {label}
-                        </span>
-                      ))}
+
+          {visibleItems.length === 0 ? (
+            <div className="py-16 text-center text-muted-foreground">
+              <p>
+                {selectedTab === 'old'
+                  ? 'No tenés actividades antiguas.'
+                  : 'Todavía no tenés actividades actuales.'}
+              </p>
+            </div>
+          ) : (
+            <ul className="space-y-4">
+              {visibleItems.map(
+                ({ activity, labels, participants, sessions, isProfessor }) => (
+                  <li
+                    key={activity.id}
+                    className="rounded-xl border bg-card p-5 shadow-sm space-y-4"
+                  >
+                    <div>
+                      <Link
+                        href={`/activities/${activity.id}`}
+                        prefetch={true}
+                        className="text-lg font-semibold transition-colors hover:text-primary leading-snug"
+                      >
+                        {activity.name}
+                      </Link>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {labels.map((label) => (
+                          <span
+                            key={label}
+                            className="rounded-full bg-primary/10 px-3 py-0.5 text-sm font-medium text-primary"
+                          >
+                            {label}
+                          </span>
+                        ))}
+                      </div>
                     </div>
-                  </div>
 
-                  {sessions.length > 0 && (
-                    <div className="space-y-2 border-t pt-3">
-                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                        Próximas sesiones
-                      </p>
-                      <ul className="space-y-2">
-                        {sessions.map((s) => {
-                          const sessionParticipantNames = Array.from(
-                            new Set(
-                              (s.activityGroupId
-                                ? participants.filter(
-                                    (participant) =>
-                                      participant.isChild &&
-                                      participant.groupId === s.activityGroupId
-                                  )
-                                : participants
-                              ).map((participant) => participant.label)
-                            )
-                          );
-                          const mapHref =
-                            s.latitude != null && s.longitude != null
-                              ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}`
-                              : null;
-                          const mapEmbedSrc =
-                            s.latitude != null && s.longitude != null
-                              ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}&z=15&output=embed`
-                              : null;
-                          const dateLabel = new Date(
-                            s.date + 'T12:00:00'
-                          ).toLocaleDateString('es-AR', {
-                            weekday: 'short',
-                            day: 'numeric',
-                            month: 'short',
-                          });
-                          return (
-                            <li key={s.id}>
-                              <details
-                                className={`group rounded-lg border px-3 py-2 ${s.cancelled ? 'border-red-200 bg-red-50' : 'bg-muted/40'}`}
-                              >
-                                <summary className="flex cursor-pointer list-none items-center gap-3">
-                                  {s.sportIcon ? (
-                                    <Image
-                                      src={`/icons/${s.sportIcon}`}
-                                      alt=""
-                                      width={56}
-                                      height={56}
-                                      className={`h-14 w-14 shrink-0 object-contain ${s.cancelled ? 'opacity-40' : ''}`}
-                                    />
-                                  ) : (
-                                    <span className="h-14 w-14 shrink-0" />
-                                  )}
-                                  <div className="min-w-0 flex-1">
-                                    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                                      <p
-                                        className={`text-sm font-medium leading-tight ${s.cancelled ? 'line-through text-muted-foreground' : ''}`}
-                                      >
-                                        {dateLabel} · {s.schedule}
-                                      </p>
-                                      {s.groupName && (
-                                        <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                                          {s.groupName}
-                                        </span>
-                                      )}
-                                      {s.cancelled && (
-                                        <span className="rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold text-red-700">
-                                          Cancelado
-                                        </span>
-                                      )}
-                                      {sessionParticipantNames.length > 0 && (
-                                        <div className="flex flex-wrap gap-1">
-                                          {sessionParticipantNames.map(
-                                            (name) => (
-                                              <span
-                                                key={name}
-                                                className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
-                                              >
-                                                {name}
-                                              </span>
-                                            )
-                                          )}
-                                        </div>
-                                      )}
-                                    </div>
-                                    <p className="truncate text-xs text-muted-foreground">
-                                      {s.geoLocation}
-                                    </p>
-                                  </div>
-                                  <span className="text-xs text-link underline-offset-4 group-open:underline">
-                                    Ver detalle
-                                  </span>
-                                </summary>
-
-                                <div className="mt-3 space-y-3 border-t pt-3">
-                                  <div className="grid gap-3 md:grid-cols-[1fr_180px] md:items-start">
-                                    <div className="space-y-2">
-                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                        Ubicación
-                                      </p>
-                                      <p className="text-sm text-muted-foreground">
+                    {sessions.length > 0 && (
+                      <div className="space-y-2 border-t pt-3">
+                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                          Próximas sesiones
+                        </p>
+                        <ul className="space-y-2">
+                          {sessions.map((s) => {
+                            const sessionParticipantNames = Array.from(
+                              new Set(
+                                (s.activityGroupId
+                                  ? participants.filter(
+                                      (participant) =>
+                                        participant.isChild &&
+                                        participant.groupId ===
+                                          s.activityGroupId
+                                    )
+                                  : participants
+                                ).map((participant) => participant.label)
+                              )
+                            );
+                            const mapHref =
+                              s.latitude != null && s.longitude != null
+                                ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}`
+                                : null;
+                            const mapEmbedSrc =
+                              s.latitude != null && s.longitude != null
+                                ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}&z=15&output=embed`
+                                : null;
+                            const dateLabel = new Date(
+                              s.date + 'T12:00:00'
+                            ).toLocaleDateString('es-AR', {
+                              weekday: 'short',
+                              day: 'numeric',
+                              month: 'short',
+                            });
+                            return (
+                              <li key={s.id}>
+                                <details
+                                  className={`group rounded-lg border px-3 py-2 ${s.cancelled ? 'border-red-200 bg-red-50' : 'bg-muted/40'}`}
+                                >
+                                  <summary className="flex cursor-pointer list-none items-center gap-3">
+                                    {s.sportIcon ? (
+                                      <Image
+                                        src={`/icons/${s.sportIcon}`}
+                                        alt=""
+                                        width={56}
+                                        height={56}
+                                        className={`h-14 w-14 shrink-0 object-contain ${s.cancelled ? 'opacity-40' : ''}`}
+                                      />
+                                    ) : (
+                                      <span className="h-14 w-14 shrink-0" />
+                                    )}
+                                    <div className="min-w-0 flex-1">
+                                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                                        <p
+                                          className={`text-sm font-medium leading-tight ${s.cancelled ? 'line-through text-muted-foreground' : ''}`}
+                                        >
+                                          {dateLabel} · {s.schedule}
+                                        </p>
+                                        {s.groupName && (
+                                          <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                                            {s.groupName}
+                                          </span>
+                                        )}
+                                        {s.cancelled && (
+                                          <span className="rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold text-red-700">
+                                            Cancelado
+                                          </span>
+                                        )}
+                                        {sessionParticipantNames.length > 0 && (
+                                          <div className="flex flex-wrap gap-1">
+                                            {sessionParticipantNames.map(
+                                              (name) => (
+                                                <span
+                                                  key={name}
+                                                  className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
+                                                >
+                                                  {name}
+                                                </span>
+                                              )
+                                            )}
+                                          </div>
+                                        )}
+                                      </div>
+                                      <p className="truncate text-xs text-muted-foreground">
                                         {s.geoLocation}
                                       </p>
-                                      {mapHref && (
-                                        <a
-                                          href={mapHref}
-                                          target="_blank"
-                                          rel="noreferrer"
-                                          className="inline-block text-xs text-link hover:underline underline-offset-4"
-                                        >
-                                          Abrir en Google Maps
-                                        </a>
-                                      )}
-                                      {isProfessor && (
-                                        <div>
-                                          <Link
-                                            href={`/activities/${activity.id}/days/${s.id}`}
-                                            prefetch={true}
-                                            className="inline-flex rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+                                    </div>
+                                    <span className="text-xs text-link underline-offset-4 group-open:underline">
+                                      Ver detalle
+                                    </span>
+                                  </summary>
+
+                                  <div className="mt-3 space-y-3 border-t pt-3">
+                                    <div className="grid gap-3 md:grid-cols-[1fr_180px] md:items-start">
+                                      <div className="space-y-2">
+                                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                          Ubicación
+                                        </p>
+                                        <p className="text-sm text-muted-foreground">
+                                          {s.geoLocation}
+                                        </p>
+                                        {mapHref && (
+                                          <a
+                                            href={mapHref}
+                                            target="_blank"
+                                            rel="noreferrer"
+                                            className="inline-block text-xs text-link hover:underline underline-offset-4"
                                           >
-                                            Ver sesión
-                                          </Link>
+                                            Abrir en Google Maps
+                                          </a>
+                                        )}
+                                        {isProfessor && (
+                                          <div>
+                                            <Link
+                                              href={`/activities/${activity.id}/days/${s.id}`}
+                                              prefetch={true}
+                                              className="inline-flex rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+                                            >
+                                              Ver sesión
+                                            </Link>
+                                          </div>
+                                        )}
+                                      </div>
+
+                                      {mapEmbedSrc && (
+                                        <div className="overflow-hidden rounded-xl border bg-background">
+                                          <iframe
+                                            title={`Mapa de ${activity.name}`}
+                                            src={mapEmbedSrc}
+                                            width="100%"
+                                            height="160"
+                                            loading="lazy"
+                                            className="block w-full"
+                                            style={{ border: 0 }}
+                                            referrerPolicy="no-referrer-when-downgrade"
+                                          />
                                         </div>
                                       )}
                                     </div>
-
-                                    {mapEmbedSrc && (
-                                      <div className="overflow-hidden rounded-xl border bg-background">
-                                        <iframe
-                                          title={`Mapa de ${activity.name}`}
-                                          src={mapEmbedSrc}
-                                          width="100%"
-                                          height="160"
-                                          loading="lazy"
-                                          className="block w-full"
-                                          style={{ border: 0 }}
-                                          referrerPolicy="no-referrer-when-downgrade"
-                                        />
-                                      </div>
-                                    )}
                                   </div>
-                                </div>
-                              </details>
-                            </li>
-                          );
-                        })}
-                      </ul>
-                    </div>
-                  )}
-                </li>
-              )
-            )}
-          </ul>
-        )}
-      </div>
+                                </details>
+                              </li>
+                            );
+                          })}
+                        </ul>
+                      </div>
+                    )}
+                  </li>
+                )
+              )}
+            </ul>
+          )}
+        </div>
+      )}
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Professors should see the assigned activity group name in the calendar/agenda so the displayed label reflects the group they are assigned to instead of the activity title.
- The bottom participant-oriented tabs "Actuales" / "Antiguas" are not relevant in professor mode and should be hidden to avoid duplicate or confusing UI for professors.

### Description
- Added `activityGroup: { select: { name: true } }` to the calendar query in `src/app/my-activities/page.tsx` and use `activityGroup?.name ?? activity.name` as the `activityName` when `isProfessorView` is true so the calendar shows the group name for professor sessions.
- Wrapped the lower "Actuales / Antiguas" tabs and the session list in a `!isProfessorView` conditional so that this section is rendered only for members (keeps member UX intact while hiding it for professors).
- Files touched: `src/app/my-activities/page.tsx`.

### Testing
- Ran `pnpm lint`, which completed successfully but surfaced a preexisting Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts` (unrelated to this change).
- Ran `pnpm exec tsc --noEmit`, which failed due to preexisting type errors in `tests/api/pickup-notices.test.ts` that are unrelated to this patch.
- Ran `prettier --write` on the modified file and `git diff --check` to ensure formatting and basic checks passed locally; local lint/format steps completed.
- Unresolved risk: the repository-wide typecheck is currently blocked by unrelated test typing errors, so CI typecheck may still fail even though the UI change is isolated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3e2cd4308328a90788e4e7d06d07)