### PR TITLE
Add professor activity tabs to My Activities

### DIFF
--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -357,7 +357,24 @@ export default async function MyActivitiesPage({
         <h1 className="text-2xl font-semibold tracking-tight">
           Mis actividades
         </h1>
-        <p className="text-sm text-muted-foreground">
+        {isProfessorView && professorAssignments.length > 0 && (
+          <nav
+            aria-label="Actividades asignadas"
+            className="mt-3 flex flex-wrap gap-2"
+          >
+            {professorAssignments.map(({ activity }) => (
+              <Link
+                key={activity.id}
+                href={`/activities/${activity.id}`}
+                prefetch={true}
+                className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/15 hover:text-primary"
+              >
+                {activity.name}
+              </Link>
+            ))}
+          </nav>
+        )}
+        <p className="mt-2 text-sm text-muted-foreground">
           {isProfessorView
             ? 'Actividades en las que estás asignado como profesor.'
             : 'Actividades en las que estás inscripto vos o alguien de tu familia.'}


### PR DESCRIPTION
### Motivation
- Improve professor UX by exposing quick-access tabs for activities the professor is assigned to, enabling direct navigation from the "Mis actividades" header to an activity's detail page.

### Description
- Add a small nav of rounded tab/chip links shown only for professors with assignments in `src/app/my-activities/page.tsx`, where each tab displays the activity name and links to `/activities/[id]`, and adjust spacing of the descriptive paragraph below the header.

### Testing
- Ran `pnpm lint` (Next.js ESLint/Prettier); lint completed successfully and the change introduced no new lint errors (there is an existing Prettier warning in an unrelated file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4333fce08328b0bf79605754e9e5)