### PR TITLE
Align member activities agenda with professor view

### DIFF
--- a/src/app/api/activity-days/[dayId]/attendance/route.ts
+++ b/src/app/api/activity-days/[dayId]/attendance/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
+import { getAccessibleChildOwnerIds } from '@/lib/family-access';
 import { activityDayAttendanceSchema } from '@/lib/validations/activity';
 
 export async function PATCH(
@@ -51,9 +52,14 @@ export async function PATCH(
   }
 
   const isSelf = participant.userId === session.user.id;
-  const isParent = participant.child?.userId === session.user.id;
+  const accessibleChildOwnerIds = await getAccessibleChildOwnerIds(
+    session.user.id
+  );
+  const canManageChild = participant.child?.userId
+    ? accessibleChildOwnerIds.includes(participant.child.userId)
+    : false;
 
-  if (!isSelf && !isParent) {
+  if (!isSelf && !canManageChild) {
     const professorAssignment = await prisma.activityDayProfessor.findUnique({
       where: {
         activityDayId_userId: {

--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -4,6 +4,15 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { CalendarDays } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { enqueueMutation } from '@/lib/offline/pending-mutations';
+
+type AttendanceStatus = 'PENDING' | 'GOING' | 'NOT_GOING';
+
+type CalendarAttendanceOption = {
+  participantId: string;
+  label: string;
+  status: AttendanceStatus;
+};
 
 export type CalendarActivityDay = {
   id: string;
@@ -14,6 +23,7 @@ export type CalendarActivityDay = {
   geoLocation: string;
   sportIcon: string | null;
   cancelled: boolean;
+  attendanceOptions?: CalendarAttendanceOption[];
 };
 
 const WEEKDAYS = ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'];
@@ -36,7 +46,7 @@ const COMPACT_DAY_OFFSETS = Array.from(
   (_, index) => index - 14
 );
 
-type CalendarVariant = 'month' | 'professor-agenda';
+type CalendarVariant = 'month' | 'professor-agenda' | 'member-agenda';
 
 function toLocalDateKey(date: Date): string {
   return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
@@ -144,13 +154,20 @@ export default function ActivityCalendar({
     variant === 'month'
   );
   const [activeCompactKey, setActiveCompactKey] = useState(todayKey);
+  const [attendanceOverrides, setAttendanceOverrides] = useState<
+    Record<string, AttendanceStatus>
+  >({});
+  const [savingAttendanceKey, setSavingAttendanceKey] = useState<string | null>(
+    null
+  );
+  const [attendanceError, setAttendanceError] = useState('');
   const todayCardRef = useRef<HTMLElement | null>(null);
   const compactScrollerRef = useRef<HTMLDivElement | null>(null);
   const compactCardRefs = useRef<Map<string, HTMLElement>>(new Map());
   const scrollFrameRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (variant !== 'professor-agenda' || showMonthCalendar) return;
+    if (variant === 'month' || showMonthCalendar) return;
 
     todayCardRef.current?.scrollIntoView({
       block: 'nearest',
@@ -260,6 +277,73 @@ export default function ActivityCalendar({
     }
   }
 
+  async function updateAttendance(
+    dayId: string,
+    participantId: string,
+    status: AttendanceStatus
+  ) {
+    const overrideKey = `${dayId}:${participantId}`;
+    const previous = attendanceOverrides;
+
+    setAttendanceOverrides((current) => ({
+      ...current,
+      [overrideKey]: status,
+    }));
+    setSavingAttendanceKey(overrideKey);
+    setAttendanceError('');
+
+    if (!navigator.onLine) {
+      await enqueueMutation({
+        url: `/api/activity-days/${dayId}/attendance`,
+        method: 'PATCH',
+        body: { participantId, status },
+      });
+      setSavingAttendanceKey(null);
+      return;
+    }
+
+    try {
+      const res = await fetch(`/api/activity-days/${dayId}/attendance`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ participantId, status }),
+      });
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(
+          payload?.error || 'No se pudo actualizar la asistencia'
+        );
+      }
+    } catch (err) {
+      if (!navigator.onLine) {
+        await enqueueMutation({
+          url: `/api/activity-days/${dayId}/attendance`,
+          method: 'PATCH',
+          body: { participantId, status },
+        });
+      } else {
+        setAttendanceOverrides(previous);
+        setAttendanceError(
+          err instanceof Error
+            ? err.message
+            : 'No se pudo actualizar la asistencia'
+        );
+      }
+    } finally {
+      setSavingAttendanceKey(null);
+    }
+  }
+
+  function getAttendanceStatus(
+    dayId: string,
+    option: CalendarAttendanceOption
+  ) {
+    return (
+      attendanceOverrides[`${dayId}:${option.participantId}`] ?? option.status
+    );
+  }
+
   function handleCompactScroll() {
     if (scrollFrameRef.current !== null) {
       window.cancelAnimationFrame(scrollFrameRef.current);
@@ -275,11 +359,15 @@ export default function ActivityCalendar({
 
   return (
     <div className="space-y-3">
-      {variant === 'professor-agenda' && !showMonthCalendar && (
+      {variant !== 'month' && !showMonthCalendar && (
         <div className="rounded-xl border bg-card p-4 shadow-sm">
           <div className="mb-3 flex items-center justify-between gap-3">
             <div>
-              <p className="text-sm font-semibold">Agenda de profesor</p>
+              <p className="text-sm font-semibold">
+                {variant === 'professor-agenda'
+                  ? 'Agenda de profesor'
+                  : 'Agenda de actividades'}
+              </p>
               <p className="text-xs text-muted-foreground">
                 Deslizá para ver días anteriores o próximos.
               </p>
@@ -338,26 +426,95 @@ export default function ActivityCalendar({
                       <div className="space-y-3">
                         {visibleActivities.map((day) => {
                           const detailHref = `/activities/${day.activityId}/days/${day.id}`;
-                          const content = (
-                            <div className="space-y-3">
-                              <ActivitySummary day={day} featured={isMainDay} />
-                              {isMainDay && (
-                                <span className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline">
-                                  Ver detalle
-                                </span>
-                              )}
-                            </div>
-                          );
 
                           return (
-                            <Link
+                            <div
                               key={day.id}
-                              href={detailHref}
-                              prefetch={true}
-                              className="block rounded-xl p-2 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                              className="rounded-xl p-2 transition-colors hover:bg-muted/50"
                             >
-                              {content}
-                            </Link>
+                              <div className="space-y-3">
+                                <ActivitySummary
+                                  day={day}
+                                  featured={isMainDay}
+                                />
+                                <div className="flex flex-wrap items-center gap-2">
+                                  <Link
+                                    href={detailHref}
+                                    prefetch={true}
+                                    className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                  >
+                                    Ver detalle
+                                  </Link>
+                                </div>
+                                {day.attendanceOptions &&
+                                  day.attendanceOptions.length > 0 && (
+                                    <div className="space-y-2 border-t pt-2">
+                                      {day.attendanceOptions.map((option) => {
+                                        const status = getAttendanceStatus(
+                                          day.id,
+                                          option
+                                        );
+                                        const optionKey = `${day.id}:${option.participantId}`;
+                                        const isSaving =
+                                          savingAttendanceKey === optionKey;
+
+                                        return (
+                                          <div
+                                            key={option.participantId}
+                                            className="space-y-1"
+                                          >
+                                            <p className="truncate text-[11px] font-medium text-muted-foreground">
+                                              {option.label}
+                                            </p>
+                                            <div className="flex gap-2">
+                                              <button
+                                                type="button"
+                                                disabled={
+                                                  isSaving || day.cancelled
+                                                }
+                                                onClick={() =>
+                                                  updateAttendance(
+                                                    day.id,
+                                                    option.participantId,
+                                                    'GOING'
+                                                  )
+                                                }
+                                                className={`rounded-full border px-3 py-1 text-[11px] font-semibold transition-colors ${
+                                                  status === 'GOING'
+                                                    ? 'border-green-500 bg-green-500/10 text-green-700 dark:text-green-400'
+                                                    : 'border-border bg-background text-muted-foreground hover:bg-muted'
+                                                } disabled:cursor-not-allowed disabled:opacity-60`}
+                                              >
+                                                Voy
+                                              </button>
+                                              <button
+                                                type="button"
+                                                disabled={
+                                                  isSaving || day.cancelled
+                                                }
+                                                onClick={() =>
+                                                  updateAttendance(
+                                                    day.id,
+                                                    option.participantId,
+                                                    'NOT_GOING'
+                                                  )
+                                                }
+                                                className={`rounded-full border px-3 py-1 text-[11px] font-semibold transition-colors ${
+                                                  status === 'NOT_GOING'
+                                                    ? 'border-destructive bg-destructive/10 text-destructive'
+                                                    : 'border-border bg-background text-muted-foreground hover:bg-muted'
+                                                } disabled:cursor-not-allowed disabled:opacity-60`}
+                                              >
+                                                No voy
+                                              </button>
+                                            </div>
+                                          </div>
+                                        );
+                                      })}
+                                    </div>
+                                  )}
+                              </div>
+                            </div>
                           );
                         })}
                         {activities.length > visibleActivities.length && (
@@ -376,28 +533,33 @@ export default function ActivityCalendar({
         </div>
       )}
 
-      {variant === 'professor-agenda' && (
-        <div className="flex flex-wrap gap-2">
-          {showMonthCalendar ? (
-            <button
-              type="button"
-              onClick={() => setShowMonthCalendar(false)}
-              className="inline-flex items-center gap-2 rounded-full border bg-background px-4 py-2 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted"
-              aria-expanded={!showMonthCalendar}
-            >
-              Día
-            </button>
-          ) : (
-            <button
-              type="button"
-              onClick={() => setShowMonthCalendar(true)}
-              className="inline-flex items-center gap-2 rounded-full border bg-background px-4 py-2 text-sm font-semibold text-foreground shadow-sm transition-colors hover:bg-muted"
-              aria-expanded={showMonthCalendar}
-            >
-              <CalendarDays className="h-4 w-4" aria-hidden="true" />
-              Calendario
-            </button>
-          )}
+      {variant !== 'month' && (
+        <div className="inline-flex rounded-lg border bg-muted/30 p-1">
+          <button
+            type="button"
+            onClick={() => setShowMonthCalendar(false)}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              !showMonthCalendar
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            aria-pressed={!showMonthCalendar}
+          >
+            Día
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMonthCalendar(true)}
+            className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              showMonthCalendar
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            aria-pressed={showMonthCalendar}
+          >
+            <CalendarDays className="h-4 w-4" aria-hidden="true" />
+            Calendario mensual
+          </button>
         </div>
       )}
 
@@ -567,14 +729,14 @@ export default function ActivityCalendar({
                       </p>
                     </div>
                   </div>
-                  {(variant === 'professor-agenda' || onEdit) && (
+                  {(variant !== 'month' || onEdit) && (
                     <div className="mt-2 flex gap-2">
                       <Link
                         href={`/activities/${d.activityId}/days/${d.id}`}
                         prefetch={true}
                         className="shrink-0 rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
                       >
-                        Ver sesión
+                        Ver detalle
                       </Link>
                       {onEdit && (
                         <button
@@ -592,6 +754,12 @@ export default function ActivityCalendar({
             </div>
           )}
         </div>
+      )}
+
+      {attendanceError && (
+        <p className="text-sm font-medium text-destructive">
+          {attendanceError}
+        </p>
       )}
     </div>
   );

--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -25,6 +25,7 @@ type UpcomingSession = {
 };
 
 type ActivityParticipantSummary = {
+  id: string;
   label: string;
   isChild: boolean;
   groupId: string | null;
@@ -165,6 +166,9 @@ export default async function MyActivitiesPage({
           cancelled: true,
           activity: { select: { id: true, name: true } },
           activityGroup: { select: { name: true } },
+          attendances: {
+            select: { activityParticipantId: true, status: true },
+          },
         },
         orderBy: { date: 'asc' },
       });
@@ -173,21 +177,53 @@ export default async function MyActivitiesPage({
           if (isProfessorView) return true;
           const scope = participantScopeByActivity.get(d.activity.id);
           if (!scope) return false;
-          if (d.activityGroupId === null) return scope.hasUngroupedParticipant;
+          if (d.activityGroupId === null) return true;
           return scope.groupIds.has(d.activityGroupId);
         })
-        .map((d) => ({
-          id: d.id,
-          date: d.date.toISOString().slice(0, 10),
-          activityId: d.activity.id,
-          activityName: isProfessorView
-            ? (d.activityGroup?.name ?? d.activity.name)
-            : d.activity.name,
-          schedule: d.schedule,
-          geoLocation: d.geoLocation,
-          sportIcon: d.sportIcon,
-          cancelled: d.cancelled,
-        }));
+        .map((d) => {
+          const attendanceStatusByParticipant = new Map(
+            d.attendances.map((attendance) => [
+              attendance.activityParticipantId,
+              attendance.status,
+            ])
+          );
+          const visibleParticipants = isProfessorView
+            ? []
+            : participations.filter((participant) => {
+                if (participant.activity.id !== d.activity.id) return false;
+                const participantGroupId =
+                  participant.groupMembership?.activityGroupId ?? null;
+
+                if (d.activityGroupId === null) return true;
+                return participantGroupId === d.activityGroupId;
+              });
+
+          return {
+            id: d.id,
+            date: d.date.toISOString().slice(0, 10),
+            activityId: d.activity.id,
+            activityName: isProfessorView
+              ? (d.activityGroup?.name ?? d.activity.name)
+              : d.activity.name,
+            schedule: d.schedule,
+            geoLocation: d.geoLocation,
+            sportIcon: d.sportIcon,
+            cancelled: d.cancelled,
+            attendanceOptions: visibleParticipants.map((participant) => {
+              const label = participant.child
+                ? `${participant.child.name}${participant.child.lastName ? ` ${participant.child.lastName}` : ''}`
+                : (session.user.name ?? 'Yo');
+
+              return {
+                participantId: participant.id,
+                label,
+                status:
+                  attendanceStatusByParticipant.get(participant.id) ??
+                  'PENDING',
+              };
+            }),
+          };
+        });
     } catch {
       calendarDays = [];
     }
@@ -223,7 +259,7 @@ export default async function MyActivitiesPage({
           const scope = participantScopeByActivity.get(s.activityId);
           if (!scope) continue;
           if (s.activityGroupId === null) {
-            if (!scope.hasUngroupedParticipant) continue;
+            // Unrestricted days are visible to every participant in the activity.
           } else if (!scope.groupIds.has(s.activityGroupId)) {
             continue;
           }
@@ -268,6 +304,7 @@ export default async function MyActivitiesPage({
     if (entry) {
       entry.labels.add(label);
       entry.participants.push({
+        id: p.id,
         label,
         isChild: Boolean(p.child),
         groupId: p.groupMembership?.activityGroupId ?? null,
@@ -278,6 +315,7 @@ export default async function MyActivitiesPage({
         labels: new Set([label]),
         participants: [
           {
+            id: p.id,
             label,
             isChild: Boolean(p.child),
             groupId: p.groupMembership?.activityGroupId ?? null,
@@ -314,15 +352,11 @@ export default async function MyActivitiesPage({
         .map((participant) => participant.groupId)
         .filter((groupId): groupId is string => Boolean(groupId))
     );
-    const hasUngroupedParticipant = entry.participants.some(
-      (participant) => participant.groupId === null
-    );
-
     const sessions = isProfessor
       ? rawSessions
       : rawSessions.filter((sessionItem) => {
           if (sessionItem.activityGroupId === null) {
-            return hasUngroupedParticipant;
+            return true;
           }
 
           return groupIds.has(sessionItem.activityGroupId);
@@ -366,7 +400,7 @@ export default async function MyActivitiesPage({
 
       <ActivityCalendar
         activityDays={calendarDays}
-        variant={isProfessorView ? 'professor-agenda' : 'month'}
+        variant={isProfessorView ? 'professor-agenda' : 'member-agenda'}
       />
 
       {!isProfessorView && (


### PR DESCRIPTION
### Motivation
- Unificar el diseño de la página `my-activities` para socios/padres con la agenda de profesores para ofrecer una vista scrollable de días y facilitar confirmaciones de asistencia desde la tarjeta diaria.
- Permitir que cada día muestre “Ver detalle” y botones “Voy” / “No voy” que actualicen la asistencia via el endpoint existente, respetando la información que cada perfil puede ver y la visibilidad por grupos y relación familiar.

### Description
- Reutilicé la agenda estilo profesor para miembros creando el `member-agenda` variant y cambiando la vista en `src/app/my-activities/page.tsx` para pasar `variant={isProfessorView ? 'professor-agenda' : 'member-agenda'}`.
- Extendí la carga de `activityDay` para traer `attendances` y construí `attendanceOptions` por día con los participantes visibles al socio/padre, en `src/app/my-activities/page.tsx`.
- Añadí controles UI para confirmar asistencia (botones “Voy” / “No voy”, y enlace “Ver detalle”) dentro de las tarjetas de la agenda y del detalle mensual en `src/app/my-activities/activity-calendar.tsx` con manejo optimista y cola offline (`enqueueMutation`).
- Permití que el endpoint de asistencia acepte confirmaciones hechas por usuarios con acceso familiar al dueño del niño (además del propio participante y profesores asignados) en `src/app/api/activity-days/[dayId]/attendance/route.ts` usando `getAccessibleChildOwnerIds`.
- Ajusté la lógica de visibilidad para que días no restringidos a grupo sean visibles para todos los participantes de la actividad (no sólo para inscriptos sin grupo) y simplifiqué la navegación día/mes en la agenda.

### Testing
- Ejecuté `pnpm lint` y pasó (queda una advertencia Prettier preexistente en `src/app/api/users/[id]/children/[childId]/route.ts`).
- Ejecuté `pnpm exec tsc --noEmit` y falló por errores tipados en tests existentes (`tests/api/pickup-notices.test.ts`) que son previos a este cambio y no están relacionados.
- Verifiqué `git diff --check` y `git status --short` tras los cambios; el commit fue creado (`Align member activities agenda with professor view`).
- Riesgos no resueltos: no se levantó la app con una DB local para validar la experiencia visual completa y la integración runtime de la cola offline, y el chequeo TypeScript global queda bloqueado por errores de tests preexistentes que conviene corregir por separado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4420fb7c8328a7eeb166c0fa1ab4)