### PR TITLE
My activities: show enrolled tags and open member session details in modal with Materials + Maps

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -84,7 +84,10 @@ export default function ActivityDaysPanel({
     activityName: 'Actividad',
     schedule: day.schedule,
     geoLocation: day.geoLocation,
+    description: day.description,
     sportIcon: day.sportIcon,
+    latitude: day.latitude,
+    longitude: day.longitude,
     cancelled: false,
   }));
 

--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -21,7 +21,10 @@ export type CalendarActivityDay = {
   activityName: string;
   schedule: string;
   geoLocation: string;
+  description: string | null;
   sportIcon: string | null;
+  latitude: number | null;
+  longitude: number | null;
   cancelled: boolean;
   attendanceOptions?: CalendarAttendanceOption[];
 };
@@ -63,6 +66,15 @@ function formatDayTitle(date: Date, todayKey: string): string {
   if (key === todayKey) return 'hoy';
 
   return date.toLocaleDateString('es-AR', { weekday: 'long' });
+}
+
+function getGoogleMapsHref(day: CalendarActivityDay): string {
+  const query =
+    day.latitude != null && day.longitude != null
+      ? `${day.latitude},${day.longitude}`
+      : day.geoLocation;
+
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(query)}`;
 }
 
 function ActivityIcon({
@@ -161,6 +173,7 @@ export default function ActivityCalendar({
     null
   );
   const [attendanceError, setAttendanceError] = useState('');
+  const [detailDay, setDetailDay] = useState<CalendarActivityDay | null>(null);
   const todayCardRef = useRef<HTMLElement | null>(null);
   const compactScrollerRef = useRef<HTMLDivElement | null>(null);
   const compactCardRefs = useRef<Map<string, HTMLElement>>(new Map());
@@ -426,6 +439,7 @@ export default function ActivityCalendar({
                       <div className="space-y-3">
                         {visibleActivities.map((day) => {
                           const detailHref = `/activities/${day.activityId}/days/${day.id}`;
+                          const isMemberAgenda = variant === 'member-agenda';
 
                           return (
                             <div
@@ -438,13 +452,23 @@ export default function ActivityCalendar({
                                   featured={isMainDay}
                                 />
                                 <div className="flex flex-wrap items-center gap-2">
-                                  <Link
-                                    href={detailHref}
-                                    prefetch={true}
-                                    className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
-                                  >
-                                    Ver detalle
-                                  </Link>
+                                  {isMemberAgenda ? (
+                                    <button
+                                      type="button"
+                                      onClick={() => setDetailDay(day)}
+                                      className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                    >
+                                      Ver detalle
+                                    </button>
+                                  ) : (
+                                    <Link
+                                      href={detailHref}
+                                      prefetch={true}
+                                      className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
+                                    >
+                                      Ver detalle
+                                    </Link>
+                                  )}
                                 </div>
                                 {day.attendanceOptions &&
                                   day.attendanceOptions.length > 0 && (
@@ -731,13 +755,23 @@ export default function ActivityCalendar({
                   </div>
                   {(variant !== 'month' || onEdit) && (
                     <div className="mt-2 flex gap-2">
-                      <Link
-                        href={`/activities/${d.activityId}/days/${d.id}`}
-                        prefetch={true}
-                        className="shrink-0 rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
-                      >
-                        Ver detalle
-                      </Link>
+                      {variant === 'member-agenda' ? (
+                        <button
+                          type="button"
+                          onClick={() => setDetailDay(d)}
+                          className="shrink-0 rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                        >
+                          Ver detalle
+                        </button>
+                      ) : (
+                        <Link
+                          href={`/activities/${d.activityId}/days/${d.id}`}
+                          prefetch={true}
+                          className="shrink-0 rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+                        >
+                          Ver detalle
+                        </Link>
+                      )}
                       {onEdit && (
                         <button
                           type="button"
@@ -753,6 +787,74 @@ export default function ActivityCalendar({
               ))}
             </div>
           )}
+        </div>
+      )}
+
+      {detailDay && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="activity-day-detail-title"
+        >
+          <div className="w-full max-w-md rounded-2xl bg-background p-5 shadow-xl">
+            <div className="space-y-1">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Detalle de la sesión
+              </p>
+              <h2
+                id="activity-day-detail-title"
+                className="text-lg font-semibold text-foreground"
+              >
+                {detailDay.activityName}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                {new Date(detailDay.date + 'T12:00:00').toLocaleDateString(
+                  'es-AR',
+                  { weekday: 'long', day: 'numeric', month: 'long' }
+                )}{' '}
+                · {detailDay.schedule}
+              </p>
+            </div>
+
+            <div className="mt-4 space-y-4">
+              <div className="rounded-xl border bg-muted/20 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Materiales
+                </p>
+                <p className="mt-2 whitespace-pre-line text-sm text-foreground">
+                  {detailDay.description?.trim() || 'Sin materiales cargados.'}
+                </p>
+              </div>
+
+              <div className="rounded-xl border bg-muted/20 p-4">
+                <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Ubicación
+                </p>
+                <p className="mt-2 text-sm text-foreground">
+                  {detailDay.geoLocation}
+                </p>
+                <a
+                  href={getGoogleMapsHref(detailDay)}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-3 inline-flex rounded-full border border-primary px-3 py-1 text-xs font-semibold text-primary transition-colors hover:bg-primary/10"
+                >
+                  Ver en Maps
+                </a>
+              </div>
+            </div>
+
+            <div className="mt-5 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setDetailDay(null)}
+                className="rounded-full border px-4 py-2 text-sm font-medium transition-colors hover:bg-muted"
+              >
+                Cerrar
+              </button>
+            </div>
+          </div>
         </div>
       )}
 

--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
@@ -11,31 +10,7 @@ import ActivityCalendar, {
   type CalendarActivityDay,
 } from './activity-calendar';
 
-type UpcomingSession = {
-  id: string;
-  date: string;
-  schedule: string;
-  geoLocation: string;
-  sportIcon: string | null;
-  latitude: number | null;
-  longitude: number | null;
-  activityGroupId: string | null;
-  groupName: string | null;
-  cancelled: boolean;
-};
-
-type ActivityParticipantSummary = {
-  id: string;
-  label: string;
-  isChild: boolean;
-  groupId: string | null;
-};
-
-export default async function MyActivitiesPage({
-  searchParams,
-}: {
-  searchParams?: Promise<{ tab?: string }>;
-}) {
+export default async function MyActivitiesPage() {
   const session = await getServerSession(authOptions);
   if (!session) {
     redirect('/login');
@@ -159,6 +134,7 @@ export default async function MyActivitiesPage({
           date: true,
           schedule: true,
           geoLocation: true,
+          description: true,
           sportIcon: true,
           latitude: true,
           longitude: true,
@@ -207,7 +183,10 @@ export default async function MyActivitiesPage({
               : d.activity.name,
             schedule: d.schedule,
             geoLocation: d.geoLocation,
+            description: d.description,
             sportIcon: d.sportIcon,
+            latitude: d.latitude,
+            longitude: d.longitude,
             cancelled: d.cancelled,
             attendanceOptions: visibleParticipants.map((participant) => {
               const label = participant.child
@@ -229,69 +208,11 @@ export default async function MyActivitiesPage({
     }
   }
 
-  // Group upcoming sessions per activity (max 3)
-  const sessionsByActivity = new Map<string, UpcomingSession[]>();
-  if (activityIds.length > 0) {
-    try {
-      const rawSessions = await prisma.activityDay.findMany({
-        where: {
-          activityId: { in: activityIds },
-          date: { gte: new Date(new Date().setHours(0, 0, 0, 0)) },
-          ...(isProfessorView ? { professors: { some: { userId } } } : {}),
-        },
-        select: {
-          id: true,
-          date: true,
-          schedule: true,
-          geoLocation: true,
-          sportIcon: true,
-          latitude: true,
-          longitude: true,
-          activityGroupId: true,
-          activityId: true,
-          cancelled: true,
-          activityGroup: { select: { name: true } },
-        },
-        orderBy: { date: 'asc' },
-      });
-      for (const s of rawSessions) {
-        if (!isProfessorView) {
-          const scope = participantScopeByActivity.get(s.activityId);
-          if (!scope) continue;
-          if (s.activityGroupId === null) {
-            // Unrestricted days are visible to every participant in the activity.
-          } else if (!scope.groupIds.has(s.activityGroupId)) {
-            continue;
-          }
-        }
-        const list = sessionsByActivity.get(s.activityId) ?? [];
-        if (list.length < 3) {
-          list.push({
-            id: s.id,
-            date: s.date.toISOString().slice(0, 10),
-            schedule: s.schedule,
-            geoLocation: s.geoLocation,
-            sportIcon: s.sportIcon,
-            latitude: s.latitude,
-            longitude: s.longitude,
-            activityGroupId: s.activityGroupId,
-            groupName: s.activityGroup?.name ?? null,
-            cancelled: s.cancelled,
-          });
-          sessionsByActivity.set(s.activityId, list);
-        }
-      }
-    } catch {
-      /* ignore */
-    }
-  }
-
   const grouped = new Map<
     string,
     {
       activity: (typeof participations)[number]['activity'];
       labels: Set<string>;
-      participants: ActivityParticipantSummary[];
     }
   >();
 
@@ -303,24 +224,10 @@ export default async function MyActivitiesPage({
     const entry = grouped.get(key);
     if (entry) {
       entry.labels.add(label);
-      entry.participants.push({
-        id: p.id,
-        label,
-        isChild: Boolean(p.child),
-        groupId: p.groupMembership?.activityGroupId ?? null,
-      });
     } else {
       grouped.set(key, {
         activity: p.activity,
         labels: new Set([label]),
-        participants: [
-          {
-            id: p.id,
-            label,
-            isChild: Boolean(p.child),
-            groupId: p.groupMembership?.activityGroupId ?? null,
-          },
-        ],
       });
     }
   }
@@ -334,56 +241,14 @@ export default async function MyActivitiesPage({
       grouped.set(key, {
         activity: assignment.activity,
         labels: new Set(['Profesor']),
-        participants: [],
       });
     }
   }
 
-  const professorActivityIds = new Set(
-    professorAssignments.map((a) => a.activity.id)
-  );
-
-  const items = Array.from(grouped.values()).map((entry) => {
-    const isProfessor = professorActivityIds.has(entry.activity.id);
-    const rawSessions = sessionsByActivity.get(entry.activity.id) ?? [];
-
-    const groupIds = new Set(
-      entry.participants
-        .map((participant) => participant.groupId)
-        .filter((groupId): groupId is string => Boolean(groupId))
-    );
-    const sessions = isProfessor
-      ? rawSessions
-      : rawSessions.filter((sessionItem) => {
-          if (sessionItem.activityGroupId === null) {
-            return true;
-          }
-
-          return groupIds.has(sessionItem.activityGroupId);
-        });
-
-    return {
-      activity: entry.activity,
-      labels: Array.from(entry.labels),
-      participants: entry.participants,
-      sessions,
-      isProfessor,
-    };
-  });
-
-  const resolvedSearchParams = await searchParams;
-  const requestedTab = resolvedSearchParams?.tab;
-  const selectedTab = requestedTab === 'old' ? 'old' : 'current';
-  const today = new Date(new Date().setHours(0, 0, 0, 0));
-
-  const currentItems = items.filter(({ sessions }) =>
-    sessions.some((sessionItem) => new Date(sessionItem.date) >= today)
-  );
-  const oldItems = items.filter(
-    ({ sessions }) =>
-      !sessions.some((sessionItem) => new Date(sessionItem.date) >= today)
-  );
-  const visibleItems = selectedTab === 'old' ? oldItems : currentItems;
+  const activityTags = Array.from(grouped.values()).map((entry) => ({
+    activity: entry.activity,
+    labels: Array.from(entry.labels),
+  }));
 
   return (
     <main className="mx-auto max-w-5xl px-4 py-6">
@@ -391,17 +256,22 @@ export default async function MyActivitiesPage({
         <h1 className="text-2xl font-semibold tracking-tight">
           Mis actividades
         </h1>
-        {isProfessorView && professorAssignments.length > 0 && (
+        {activityTags.length > 0 && (
           <nav
-            aria-label="Actividades asignadas"
+            aria-label={
+              isProfessorView
+                ? 'Actividades asignadas'
+                : 'Actividades inscriptas'
+            }
             className="mt-3 flex flex-wrap gap-2"
           >
-            {professorAssignments.map(({ activity }) => (
+            {activityTags.map(({ activity, labels }) => (
               <Link
                 key={activity.id}
                 href={`/activities/${activity.id}`}
                 prefetch={true}
                 className="rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/15 hover:text-primary"
+                title={labels.join(', ')}
               >
                 {activity.name}
               </Link>
@@ -419,223 +289,6 @@ export default async function MyActivitiesPage({
         activityDays={calendarDays}
         variant={isProfessorView ? 'professor-agenda' : 'member-agenda'}
       />
-
-      {!isProfessorView && (
-        <div className="mt-6 space-y-4">
-          <div className="inline-flex rounded-lg border bg-muted/30 p-1">
-            <Link
-              href="/my-activities"
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                selectedTab === 'current'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Actuales ({currentItems.length})
-            </Link>
-            <Link
-              href="/my-activities?tab=old"
-              className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-                selectedTab === 'old'
-                  ? 'bg-background text-foreground shadow-sm'
-                  : 'text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              Antiguas ({oldItems.length})
-            </Link>
-          </div>
-
-          {visibleItems.length === 0 ? (
-            <div className="py-16 text-center text-muted-foreground">
-              <p>
-                {selectedTab === 'old'
-                  ? 'No tenés actividades antiguas.'
-                  : 'Todavía no tenés actividades actuales.'}
-              </p>
-            </div>
-          ) : (
-            <ul className="space-y-4">
-              {visibleItems.map(
-                ({ activity, labels, participants, sessions, isProfessor }) => (
-                  <li
-                    key={activity.id}
-                    className="rounded-xl border bg-card p-5 shadow-sm space-y-4"
-                  >
-                    <div>
-                      <Link
-                        href={`/activities/${activity.id}`}
-                        prefetch={true}
-                        className="text-lg font-semibold transition-colors hover:text-primary leading-snug"
-                      >
-                        {activity.name}
-                      </Link>
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        {labels.map((label) => (
-                          <span
-                            key={label}
-                            className="rounded-full bg-primary/10 px-3 py-0.5 text-sm font-medium text-primary"
-                          >
-                            {label}
-                          </span>
-                        ))}
-                      </div>
-                    </div>
-
-                    {sessions.length > 0 && (
-                      <div className="space-y-2 border-t pt-3">
-                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                          Próximas sesiones
-                        </p>
-                        <ul className="space-y-2">
-                          {sessions.map((s) => {
-                            const sessionParticipantNames = Array.from(
-                              new Set(
-                                (s.activityGroupId
-                                  ? participants.filter(
-                                      (participant) =>
-                                        participant.isChild &&
-                                        participant.groupId ===
-                                          s.activityGroupId
-                                    )
-                                  : participants
-                                ).map((participant) => participant.label)
-                              )
-                            );
-                            const mapHref =
-                              s.latitude != null && s.longitude != null
-                                ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}`
-                                : null;
-                            const mapEmbedSrc =
-                              s.latitude != null && s.longitude != null
-                                ? `https://www.google.com/maps?q=${s.latitude},${s.longitude}&z=15&output=embed`
-                                : null;
-                            const dateLabel = new Date(
-                              s.date + 'T12:00:00'
-                            ).toLocaleDateString('es-AR', {
-                              weekday: 'short',
-                              day: 'numeric',
-                              month: 'short',
-                            });
-                            return (
-                              <li key={s.id}>
-                                <details
-                                  className={`group rounded-lg border px-3 py-2 ${s.cancelled ? 'border-red-200 bg-red-50' : 'bg-muted/40'}`}
-                                >
-                                  <summary className="flex cursor-pointer list-none items-center gap-3">
-                                    {s.sportIcon ? (
-                                      <Image
-                                        src={`/icons/${s.sportIcon}`}
-                                        alt=""
-                                        width={56}
-                                        height={56}
-                                        className={`h-14 w-14 shrink-0 object-contain ${s.cancelled ? 'opacity-40' : ''}`}
-                                      />
-                                    ) : (
-                                      <span className="h-14 w-14 shrink-0" />
-                                    )}
-                                    <div className="min-w-0 flex-1">
-                                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
-                                        <p
-                                          className={`text-sm font-medium leading-tight ${s.cancelled ? 'line-through text-muted-foreground' : ''}`}
-                                        >
-                                          {dateLabel} · {s.schedule}
-                                        </p>
-                                        {s.groupName && (
-                                          <span className="rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
-                                            {s.groupName}
-                                          </span>
-                                        )}
-                                        {s.cancelled && (
-                                          <span className="rounded-full bg-red-100 px-2 py-0.5 text-[11px] font-semibold text-red-700">
-                                            Cancelado
-                                          </span>
-                                        )}
-                                        {sessionParticipantNames.length > 0 && (
-                                          <div className="flex flex-wrap gap-1">
-                                            {sessionParticipantNames.map(
-                                              (name) => (
-                                                <span
-                                                  key={name}
-                                                  className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary"
-                                                >
-                                                  {name}
-                                                </span>
-                                              )
-                                            )}
-                                          </div>
-                                        )}
-                                      </div>
-                                      <p className="truncate text-xs text-muted-foreground">
-                                        {s.geoLocation}
-                                      </p>
-                                    </div>
-                                    <span className="text-xs text-link underline-offset-4 group-open:underline">
-                                      Ver detalle
-                                    </span>
-                                  </summary>
-
-                                  <div className="mt-3 space-y-3 border-t pt-3">
-                                    <div className="grid gap-3 md:grid-cols-[1fr_180px] md:items-start">
-                                      <div className="space-y-2">
-                                        <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                          Ubicación
-                                        </p>
-                                        <p className="text-sm text-muted-foreground">
-                                          {s.geoLocation}
-                                        </p>
-                                        {mapHref && (
-                                          <a
-                                            href={mapHref}
-                                            target="_blank"
-                                            rel="noreferrer"
-                                            className="inline-block text-xs text-link hover:underline underline-offset-4"
-                                          >
-                                            Abrir en Google Maps
-                                          </a>
-                                        )}
-                                        {isProfessor && (
-                                          <div>
-                                            <Link
-                                              href={`/activities/${activity.id}/days/${s.id}`}
-                                              prefetch={true}
-                                              className="inline-flex rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
-                                            >
-                                              Ver sesión
-                                            </Link>
-                                          </div>
-                                        )}
-                                      </div>
-
-                                      {mapEmbedSrc && (
-                                        <div className="overflow-hidden rounded-xl border bg-background">
-                                          <iframe
-                                            title={`Mapa de ${activity.name}`}
-                                            src={mapEmbedSrc}
-                                            width="100%"
-                                            height="160"
-                                            loading="lazy"
-                                            className="block w-full"
-                                            style={{ border: 0 }}
-                                            referrerPolicy="no-referrer-when-downgrade"
-                                          />
-                                        </div>
-                                      )}
-                                    </div>
-                                  </div>
-                                </details>
-                              </li>
-                            );
-                          })}
-                        </ul>
-                      </div>
-                    )}
-                  </li>
-                )
-              )}
-            </ul>
-          )}
-        </div>
-      )}
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Implement the requested member UX: show small activity tags under the “Mis actividades” title, and let members open a compact session detail from the daily calendar that shows "Materiales" and a "Ver en Maps" link. 
- Simplify the member view by removing the expanded current/old session lists from the page and rely on the calendar as the primary sessions surface.

### Description
- Show enrolled/assigned activities as small tag links under the page heading and remove the member-side Current/Old lists from `/my-activities`, consolidating session access to the calendar (`src/app/my-activities/page.tsx`).
- Enrich the calendar day payload and type to include `description`, `latitude`, and `longitude`, and add a member-only detail modal opened from "Ver detalle" that displays `Materiales` (uses `description`) and a Google Maps link (`src/app/my-activities/activity-calendar.tsx`).
- Ensure the admin/activity panel that reuses the calendar forwards the new fields (`description`, `latitude`, `longitude`) when building `CalendarActivityDay` objects (`src/app/activities/[id]/activity-days-panel.tsx`).

### Testing
- Ran formatter on touched files with `pnpm exec prettier --write <files>` which completed successfully.
- Ran linter with `pnpm lint` which exits cleanly but reports an unrelated existing Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts`.
- Ran TypeScript checks with `pnpm exec tsc --noEmit` which failed due to unrelated test typing errors in `tests/api/pickup-notices.test.ts` (mocks/NextRequest typing issues) and not because of the modified UI files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb48c63a3083288ca831cc20d5bf03)