### PR TITLE
Fix parent access for pickup notices

### DIFF
--- a/src/app/api/pickup-notices/[noticeId]/route.ts
+++ b/src/app/api/pickup-notices/[noticeId]/route.ts
@@ -3,19 +3,26 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { updatePickupNoticeSchema } from '@/lib/validations/pickup-notice';
+import { getAccessibleChildOwnerIds } from '@/lib/family-access';
 import { z } from 'zod';
 
 async function checkNoticeOwnershipAndFuture(noticeId: string, userId: string) {
   const notice = await prisma.pickupNotice.findUnique({
     where: { id: noticeId },
-    include: { activityDay: true },
+    include: { activityDay: true, child: { select: { userId: true } } },
   });
 
   if (!notice) {
     return { valid: false, status: 404, message: 'Notice not found' };
   }
 
-  if (notice.createdById !== userId) {
+  let canManageNotice = notice.createdById === userId;
+  if (!canManageNotice) {
+    const accessibleOwnerIds = await getAccessibleChildOwnerIds(userId);
+    canManageNotice = accessibleOwnerIds.includes(notice.child?.userId ?? '');
+  }
+
+  if (!canManageNotice) {
     return { valid: false, status: 403, message: 'Cannot modify this notice' };
   }
 

--- a/src/app/profile/pickup-notices/[noticeId]/edit/page.tsx
+++ b/src/app/profile/pickup-notices/[noticeId]/edit/page.tsx
@@ -5,7 +5,11 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
 import { PickupNoticeForm } from '@/components/pickup-notice/parent-form';
-import { getAccessibleChildrenWhere } from '@/lib/family-access';
+import {
+  getAccessibleChildOwnerIds,
+  getAccessibleChildrenWhere,
+} from '@/lib/family-access';
+import { isActiveMember } from '@/lib/roles';
 
 export default async function EditPickupNoticePage({
   params,
@@ -18,12 +22,7 @@ export default async function EditPickupNoticePage({
     redirect('/login');
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: (session.user as any).id },
-    select: { role: true },
-  });
-
-  if (user?.role !== 'MEMBER') {
+  if (!isActiveMember(session)) {
     redirect('/profile/pickup-notices');
   }
 
@@ -39,7 +38,13 @@ export default async function EditPickupNoticePage({
     },
   });
 
-  if (!notice || notice.createdById !== (session.user as any).id) {
+  const accessibleOwnerIds = await getAccessibleChildOwnerIds(session.user.id);
+  const canManageNotice =
+    notice &&
+    (notice.createdById === session.user.id ||
+      accessibleOwnerIds.includes(notice.child.userId));
+
+  if (!canManageNotice) {
     redirect('/profile/pickup-notices');
   }
 

--- a/src/app/profile/pickup-notices/new/page.tsx
+++ b/src/app/profile/pickup-notices/new/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
 import ActivityDaySelector from './activity-day-selector';
 import { getAccessibleChildOwnerIds } from '@/lib/family-access';
+import { isActiveMember } from '@/lib/roles';
 
 export default async function CreatePickupNoticePage() {
   const session = await getServerSession(authOptions);
@@ -13,12 +14,7 @@ export default async function CreatePickupNoticePage() {
     redirect('/login');
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: (session.user as any).id },
-    select: { role: true },
-  });
-
-  if (user?.role !== 'MEMBER') {
+  if (!isActiveMember(session)) {
     redirect('/profile/pickup-notices');
   }
 

--- a/src/app/profile/pickup-notices/page.tsx
+++ b/src/app/profile/pickup-notices/page.tsx
@@ -5,6 +5,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { Button } from '@/components/ui/button';
 import { getAccessibleChildrenWhere } from '@/lib/family-access';
+import { isActiveAdmin, isActiveMember, isActiveProfessor } from '@/lib/roles';
 
 export default async function PickupNoticesPage() {
   const session = await getServerSession(authOptions);
@@ -12,15 +13,11 @@ export default async function PickupNoticesPage() {
     redirect('/login');
   }
 
-  const user = await prisma.user.findUnique({
-    where: { id: (session.user as any).id },
-    select: { role: true },
-  });
-
-  const isProfessor = user?.role === 'PROFESSOR' || user?.role === 'ADMIN';
-  const isMember = user?.role === 'MEMBER';
+  const isMember = isActiveMember(session);
+  const isProfessor = isActiveProfessor(session) || isActiveAdmin(session);
 
   let where: any = { deletedAt: null };
+  let accessibleChildIds: string[] = [];
 
   if (isMember) {
     const userChildren = await prisma.child.findMany({
@@ -28,13 +25,13 @@ export default async function PickupNoticesPage() {
       select: { id: true },
     });
 
-    const childIds = userChildren.map((c) => c.id);
+    accessibleChildIds = userChildren.map((c) => c.id);
 
     where = {
       deletedAt: null,
       OR: [
         { createdById: (session.user as any).id },
-        { childId: { in: childIds } },
+        { childId: { in: accessibleChildIds } },
       ],
     };
   } else if (isProfessor) {
@@ -126,8 +123,13 @@ export default async function PickupNoticesPage() {
       ) : (
         <div className="space-y-4">
           {notices.map((notice) => {
-            const isOwnNotice =
-              isProfessor || notice.createdById === (session.user as any).id;
+            const wasCreatedByCurrentUser =
+              notice.createdById === session.user.id;
+            const isOwnNotice = isProfessor || wasCreatedByCurrentUser;
+            const canManageAsParent =
+              isMember &&
+              (wasCreatedByCurrentUser ||
+                accessibleChildIds.includes(notice.childId));
             return (
               <div
                 key={notice.id}
@@ -211,7 +213,7 @@ export default async function PickupNoticesPage() {
                     </div>
                   </div>
                 )}
-                {isMember && isOwnNotice && (
+                {canManageAsParent && (
                   <div className="mt-4 flex gap-2">
                     <Link href={`/profile/pickup-notices/${notice.id}/edit`}>
                       <Button variant="outline">Editar</Button>


### PR DESCRIPTION
### Motivation
- Parents with family-group access could not manage pickup notices for children they are responsible for, and role checks used the persisted `role` instead of the active profile role causing incorrect views for users with multiple profiles. 
- The API edit/delete guard only allowed the original creator to modify a notice, which blocked valid family-member flows.

### Description
- Use active profile helpers (`isActiveMember`, `isActiveProfessor`, `isActiveAdmin`) for page-level role checks so profile switching is respected in the pickup-notices views. 
- Compute accessible children via family access and allow parents to manage notices for any child they can access, not only those they personally created. 
- Update the edit page to allow managing a notice when the session user is the creator or has family access to the notice's child. 
- Apply the same family-access check in the API guard by including the child's `userId` and consulting `getAccessibleChildOwnerIds` before denying edit/delete. 
- Files touched: `src/app/profile/pickup-notices/page.tsx`, `src/app/profile/pickup-notices/new/page.tsx`, `src/app/profile/pickup-notices/[noticeId]/edit/page.tsx`, `src/app/api/pickup-notices/[noticeId]/route.ts`.

### Testing
- Ran `pnpm lint` which completed successfully but surfaced an existing Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts` (pre-existing, unrelated). 
- Ran `git diff --check` which passed with no new issues. 
- Ran `pnpm exec tsc --noEmit` which failed due to pre-existing type/mocking issues in `tests/api/pickup-notices.test.ts` (stale Prisma mocks and `Request` vs `NextRequest` assumptions). 
- Ran the pickup-notices unit tests with `pnpm test -- pickup-notices` which failed for the same existing test-suite mock/typing issues (several expectations failed because tests mock Prisma differently than current runtime shape); the failures are test-suite compatibility problems rather than the new access logic itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5267cfb8832891de34dd34ecfc36)