### PR TITLE
Mover selector “Para quién” encima de “Elegí grupo y horarios”

### DIFF
--- a/src/app/activities/join/[id]/join-enrollment-panel.tsx
+++ b/src/app/activities/join/[id]/join-enrollment-panel.tsx
@@ -286,6 +286,16 @@ export default function JoinEnrollmentPanel({
 
   return (
     <div className="space-y-4 lg:grid lg:grid-cols-[1fr_auto] lg:items-start lg:gap-8">
+      {session && people.length > 1 && (
+        <div className="rounded-xl border bg-card p-5 lg:col-start-1">
+          <PersonPicker
+            people={people}
+            value={selectedPersonId}
+            onChange={setSelectedPersonId}
+          />
+        </div>
+      )}
+
       {groups.length > 0 && (
         <div className="lg:col-span-2">
           <GroupScheduleCalendar
@@ -298,16 +308,6 @@ export default function JoinEnrollmentPanel({
             selectedPersonAge={selectedPersonAge}
             isPersonSelected={Boolean(effectivePersonId)}
             activityStartDate={activityStartDate}
-          />
-        </div>
-      )}
-
-      {session && people.length > 1 && (
-        <div className="rounded-xl border bg-card p-5 lg:col-start-1">
-          <PersonPicker
-            people={people}
-            value={selectedPersonId}
-            onChange={setSelectedPersonId}
           />
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia de inscripción para padres/socios asegurando que el recuadro “Para quién” aparezca antes del calendario “Elegí grupo y horarios” cuando hay varias personas seleccionables.

### Description
- Reordené el JSX en `src/app/activities/join/[id]/join-enrollment-panel.tsx` para renderizar `PersonPicker` antes de `GroupScheduleCalendar` cuando `session && people.length > 1`.

### Testing
- Ejecuté `pnpm lint` y `git diff --check`; el linter se completó mostrando una advertencia Prettier preexistente en otro archivo pero sin errores relacionados al cambio, y `git diff --check` pasó; los cambios fueron commiteados con el mensaje `Move person selector above schedule picker`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb56bf5a388328badd60b6602b13f0)