### PR TITLE
Show group tags above calendar and collapse calendar behind chip

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { CalendarDays } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import BulkSessionCreator from './bulk-session-creator';
 import ActivityCalendar, {
@@ -76,6 +77,7 @@ export default function ActivityDaysPanel({
 }: ActivityDaysPanelProps) {
   const router = useRouter();
   const [showBulkCreator, setShowBulkCreator] = useState(false);
+  const [showCalendar, setShowCalendar] = useState(false);
 
   const calendarDays: CalendarActivityDay[] = days.map((day) => ({
     id: day.id,
@@ -135,23 +137,33 @@ export default function ActivityDaysPanel({
           )}
         </div>
 
-        {days.length > 0 && (
-          <div className="mt-6">
-            <ActivityCalendar
-              activityDays={calendarDays}
-              onEdit={
-                canManageDays
-                  ? (dayId) =>
-                      router.push(
-                        `/activities/${activityId}/days/${dayId}/edit`
-                      )
-                  : undefined
-              }
-            />
-          </div>
-        )}
+        {days.length > 0 ? (
+          <div className="mt-6 space-y-4">
+            <button
+              type="button"
+              onClick={() => setShowCalendar((current) => !current)}
+              className="inline-flex items-center gap-2 rounded-full border border-primary/20 bg-primary/5 px-4 py-2 text-sm font-semibold text-primary transition-colors hover:bg-primary/10"
+              aria-expanded={showCalendar}
+            >
+              <CalendarDays className="h-4 w-4" aria-hidden="true" />
+              Calendario
+            </button>
 
-        {days.length === 0 && (
+            {showCalendar && (
+              <ActivityCalendar
+                activityDays={calendarDays}
+                onEdit={
+                  canManageDays
+                    ? (dayId) =>
+                        router.push(
+                          `/activities/${activityId}/days/${dayId}/edit`
+                        )
+                    : undefined
+                }
+              />
+            )}
+          </div>
+        ) : (
           <p className="mt-6 text-sm text-muted-foreground font-body">
             Aún no hay días cargados para esta actividad.
           </p>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -483,6 +483,21 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           </div>
         </div>
 
+        {isAdmin && activityGroupOptions.length > 0 && (
+          <div className="mt-8 flex flex-wrap gap-2">
+            {activityGroupOptions.map((group) => (
+              <Link
+                key={group.id}
+                href={`/activities/${activity.id}/groups/${group.id}`}
+                prefetch={true}
+                className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
+              >
+                {group.name}
+              </Link>
+            ))}
+          </div>
+        )}
+
         {canSeeSessions && (
           <ActivityDaysPanel
             activityId={activity.id}
@@ -538,21 +553,6 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                 pickupNotices: day.pickupNotices || [],
               }))}
           />
-        )}
-
-        {isAdmin && activityGroupOptions.length > 0 && (
-          <div className="mt-8 flex flex-wrap gap-2">
-            {activityGroupOptions.map((group) => (
-              <Link
-                key={group.id}
-                href={`/activities/${activity.id}/groups/${group.id}`}
-                prefetch={true}
-                className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-muted transition-colors"
-              >
-                {group.name}
-              </Link>
-            ))}
-          </div>
         )}
 
         {(isAdmin || isProfessor) && (


### PR DESCRIPTION
### Motivation
- Make activity group tags more visible by surfacing them above the activity sessions area so they appear above the calendar on the activity detail page.
- Reduce visual noise by collapsing the full monthly calendar behind a compact rounded "Calendario" chip with a calendar icon that expands the calendar on demand.

### Description
- Moved the activity group tag list to render before the `ActivityDaysPanel` on `src/app/activities/[id]/page.tsx` so group tags appear above the calendar.
- Replaced the always-visible `ActivityCalendar` in `src/app/activities/[id]/activity-days-panel.tsx` with a toggleable calendar chip using a `CalendarDays` icon and a `showCalendar` state, so the calendar is shown only when the chip is expanded.
- Added the `CalendarDays` import and the `showCalendar` state to `src/app/activities/[id]/activity-days-panel.tsx` and adjusted markup to show the chip and conditional calendar.
- Files touched: `src/app/activities/[id]/page.tsx`, `src/app/activities/[id]/activity-days-panel.tsx`.

### Testing
- Ran `pnpm lint` which completed successfully but reported an existing Prettier warning unrelated to these changes.
- Ran `pnpm exec tsc --noEmit` which failed due to pre-existing TypeScript test typing errors in `tests/api/pickup-notices.test.ts` not related to this UI change.
- Type checks and linting did not raise issues for the modified files themselves.
- Unresolved risks: visual/regression checks were not performed locally (no screenshots or running dev server), and responsive/layout edge cases may need manual QA in the browser.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb583712488328974c18efdd1d891c)