### PR TITLE
Add professor invoice uploads and admin view

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -317,6 +317,18 @@ Agents should check this before searching the codebase.
 - `POST /api/professors/[id]/payments` → create payment record (COUNTER/ADMIN only)
   - File: `src/app/api/professors/[id]/payments/route.ts`
 
+- `GET /api/professors/[id]/invoices` → list professor invoices
+  - File: `src/app/api/professors/[id]/invoices/route.ts`
+
+- `POST /api/professors/[id]/invoices` → upload professor invoice file (professor self only)
+  - File: `src/app/api/professors/[id]/invoices/route.ts`
+
+- `GET /api/professor-invoices/[invoiceId]/file` → download professor invoice file
+  - File: `src/app/api/professor-invoices/[invoiceId]/file/route.ts`
+
+- `DELETE /api/professor-invoices/[invoiceId]` → delete professor invoice (professor self or accounting)
+  - File: `src/app/api/professor-invoices/[invoiceId]/route.ts`
+
 - `PATCH /api/professor-payments/[paymentId]` → update payment status
   - File: `src/app/api/professor-payments/[paymentId]/route.ts`
 

--- a/prisma/migrations/20260506120000_add_professor_invoices/migration.sql
+++ b/prisma/migrations/20260506120000_add_professor_invoices/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "ProfessorInvoice" (
+    "id" TEXT NOT NULL,
+    "professorId" TEXT NOT NULL,
+    "originalName" TEXT NOT NULL,
+    "contentType" TEXT NOT NULL,
+    "size" INTEGER NOT NULL,
+    "blobUrl" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ProfessorInvoice_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProfessorInvoice_professorId_createdAt_idx" ON "ProfessorInvoice"("professorId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "ProfessorInvoice" ADD CONSTRAINT "ProfessorInvoice_professorId_fkey" FOREIGN KEY ("professorId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,6 +61,7 @@ model User {
   notificationPreferences    NotificationPreference[]
   professorProfile           ProfessorProfile?
   professorPaymentsCreated   ProfessorPayment[] @relation("ProfessorPaymentCreatedBy")
+  professorInvoices          ProfessorInvoice[] @relation("ProfessorInvoices")
   roleAssignments            UserRoleAssignment[] @relation("UserRoleAssignmentUser")
   roleAssignmentsGranted     UserRoleAssignment[] @relation("UserRoleAssignmentAssignedBy")
 }
@@ -736,6 +737,20 @@ model ProfessorPayment {
   @@unique([professorProfileId, periodMonth, periodYear])
   @@index([professorProfileId])
   @@index([status, periodMonth, periodYear])
+}
+
+model ProfessorInvoice {
+  id           String   @id @default(cuid())
+  professorId  String
+  professor    User     @relation("ProfessorInvoices", fields: [professorId], references: [id], onDelete: Cascade)
+  originalName String
+  contentType  String
+  size         Int
+  blobUrl      String
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  @@index([professorId, createdAt])
 }
 
 enum ProfessorPaymentStatus {

--- a/src/app/accounting/professors/[id]/page.tsx
+++ b/src/app/accounting/professors/[id]/page.tsx
@@ -1,9 +1,11 @@
 import Link from 'next/link';
-import { notFound, redirect } from 'next/navigation';
+import { notFound } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
-import { isAccountingRole, formatPersonName } from '@/lib/accounting';
+import { formatPersonName } from '@/lib/accounting';
+import { buildProfessorInvoiceFileUrl } from '@/lib/blob-urls';
+import ProfessorInvoicesPanel from '@/components/accounting/professor-invoices-panel';
 import ProfessorProfileForm from './professor-profile-form';
 
 export default async function ProfessorAccountingDetailPage({
@@ -35,6 +37,9 @@ export default async function ProfessorAccountingDetailPage({
           },
         },
       },
+      professorInvoices: {
+        orderBy: { createdAt: 'desc' },
+      },
     },
   });
 
@@ -62,6 +67,15 @@ export default async function ProfessorAccountingDetailPage({
     createdBy: p.createdBy,
   }));
 
+  const invoices = professor.professorInvoices.map((invoice) => ({
+    id: invoice.id,
+    originalName: invoice.originalName,
+    contentType: invoice.contentType,
+    size: invoice.size,
+    createdAt: invoice.createdAt.toISOString(),
+    fileUrl: buildProfessorInvoiceFileUrl(invoice.id),
+  }));
+
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
@@ -84,6 +98,15 @@ export default async function ProfessorAccountingDetailPage({
         professorId={professor.id}
         profile={profile}
         payments={payments}
+      />
+
+      <ProfessorInvoicesPanel
+        professorId={professor.id}
+        initialInvoices={invoices}
+        canDelete={true}
+        title="Facturas"
+        description="Facturas cargadas por el profesor desde Mis pagos."
+        emptyMessage="El profesor todavía no cargó facturas."
       />
     </div>
   );

--- a/src/app/api/professor-invoices/[invoiceId]/file/route.ts
+++ b/src/app/api/professor-invoices/[invoiceId]/file/route.ts
@@ -1,0 +1,64 @@
+import { get } from '@vercel/blob';
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { isAccountingRole } from '@/lib/accounting';
+import { prisma } from '@/lib/prisma';
+
+function encodeFileName(fileName: string) {
+  return encodeURIComponent(fileName)
+    .replace(/'/g, '%27')
+    .replace(/\(/g, '%28')
+    .replace(/\)/g, '%29')
+    .replace(/\*/g, '%2A');
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { invoiceId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as any)?.id;
+  const role = (session?.user as any)?.role;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+  }
+
+  const invoice = await prisma.professorInvoice.findUnique({
+    where: { id: params.invoiceId },
+    select: {
+      professorId: true,
+      originalName: true,
+      contentType: true,
+      blobUrl: true,
+    },
+  });
+
+  if (!invoice) return new NextResponse(null, { status: 404 });
+
+  const isProfessorSelf =
+    role === 'PROFESSOR' && userId === invoice.professorId;
+  const isAccounting = isAccountingRole(role);
+  if (!isProfessorSelf && !isAccounting) {
+    return NextResponse.json({ error: 'Sin permiso' }, { status: 403 });
+  }
+
+  try {
+    const blob = await get(invoice.blobUrl, { access: 'private' });
+    if (!blob || blob.statusCode !== 200 || !blob.stream) {
+      return new NextResponse(null, { status: 404 });
+    }
+
+    const headers = Object.fromEntries(blob.headers.entries());
+    headers['Cache-Control'] = 'private, no-store, max-age=0';
+    headers['Content-Type'] = invoice.contentType;
+    headers['Content-Disposition'] = `inline; filename*=UTF-8''${encodeFileName(
+      invoice.originalName
+    )}`;
+
+    return new NextResponse(blob.stream, { headers });
+  } catch {
+    return new NextResponse(null, { status: 404 });
+  }
+}

--- a/src/app/api/professor-invoices/[invoiceId]/route.ts
+++ b/src/app/api/professor-invoices/[invoiceId]/route.ts
@@ -1,0 +1,44 @@
+import { del } from '@vercel/blob';
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { isAccountingRole } from '@/lib/accounting';
+import { prisma } from '@/lib/prisma';
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { invoiceId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as any)?.id;
+  const role = (session?.user as any)?.role;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+  }
+
+  const invoice = await prisma.professorInvoice.findUnique({
+    where: { id: params.invoiceId },
+    select: { id: true, professorId: true, blobUrl: true },
+  });
+
+  if (!invoice) return new NextResponse(null, { status: 404 });
+
+  const isProfessorSelf =
+    role === 'PROFESSOR' && userId === invoice.professorId;
+  const isAccounting = isAccountingRole(role);
+  if (!isProfessorSelf && !isAccounting) {
+    return NextResponse.json({ error: 'Sin permiso' }, { status: 403 });
+  }
+
+  await prisma.professorInvoice.delete({ where: { id: invoice.id } });
+
+  try {
+    await del(invoice.blobUrl);
+  } catch {
+    // The database record is the source of truth; do not fail the user action
+    // if Blob storage has already removed the file.
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/src/app/api/professors/[id]/invoices/route.ts
+++ b/src/app/api/professors/[id]/invoices/route.ts
@@ -1,0 +1,158 @@
+import { put } from '@vercel/blob';
+import { getServerSession } from 'next-auth';
+import { NextResponse } from 'next/server';
+import { authOptions } from '@/lib/auth';
+import { isAccountingRole } from '@/lib/accounting';
+import { buildProfessorInvoiceFileUrl } from '@/lib/blob-urls';
+import { prisma } from '@/lib/prisma';
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const ALLOWED_CONTENT_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+function getSafeExtension(fileName: string, contentType: string) {
+  const ext = fileName.includes('.')
+    ? fileName.slice(fileName.lastIndexOf('.')).toLowerCase()
+    : '';
+  if (['.pdf', '.jpg', '.jpeg', '.png', '.webp'].includes(ext)) return ext;
+  if (contentType === 'application/pdf') return '.pdf';
+  if (contentType === 'image/png') return '.png';
+  if (contentType === 'image/webp') return '.webp';
+  return '.jpg';
+}
+
+function serializeInvoice(invoice: {
+  id: string;
+  originalName: string;
+  contentType: string;
+  size: number;
+  createdAt: Date;
+}) {
+  return {
+    id: invoice.id,
+    originalName: invoice.originalName,
+    contentType: invoice.contentType,
+    size: invoice.size,
+    createdAt: invoice.createdAt.toISOString(),
+    fileUrl: buildProfessorInvoiceFileUrl(invoice.id),
+  };
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as any)?.id;
+  const role = (session?.user as any)?.role;
+
+  if (!userId) {
+    return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
+  }
+
+  const isProfessorSelf = role === 'PROFESSOR' && userId === params.id;
+  const isAccounting = isAccountingRole(role);
+  if (!isProfessorSelf && !isAccounting) {
+    return NextResponse.json({ error: 'Sin permiso' }, { status: 403 });
+  }
+
+  const professor = await prisma.user.findFirst({
+    where: {
+      id: params.id,
+      roleAssignments: { some: { role: 'PROFESSOR' } },
+    },
+    select: { id: true },
+  });
+
+  if (!professor) {
+    return NextResponse.json(
+      { error: 'Profesor no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  const invoices = await prisma.professorInvoice.findMany({
+    where: { professorId: params.id },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return NextResponse.json({ invoices: invoices.map(serializeInvoice) });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  const userId = (session?.user as any)?.id;
+  const role = (session?.user as any)?.role;
+
+  if (!userId || role !== 'PROFESSOR' || userId !== params.id) {
+    return NextResponse.json({ error: 'Sin permiso' }, { status: 403 });
+  }
+
+  const professor = await prisma.user.findFirst({
+    where: {
+      id: params.id,
+      roleAssignments: { some: { role: 'PROFESSOR' } },
+    },
+    select: { id: true },
+  });
+
+  if (!professor) {
+    return NextResponse.json(
+      { error: 'Profesor no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  const formData = await req.formData();
+  const file = formData.get('file');
+
+  if (!(file instanceof File)) {
+    return NextResponse.json(
+      { error: 'No se recibió ningún archivo' },
+      { status: 400 }
+    );
+  }
+
+  if (!ALLOWED_CONTENT_TYPES.has(file.type)) {
+    return NextResponse.json(
+      { error: 'La factura debe ser PDF, JPG, PNG o WebP' },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_FILE_SIZE) {
+    return NextResponse.json(
+      { error: 'La factura debe pesar menos de 10 MB' },
+      { status: 400 }
+    );
+  }
+
+  const ext = getSafeExtension(file.name, file.type);
+  const pathname = `professor-invoices/${params.id}/${crypto.randomUUID()}${ext}`;
+  const blob = await put(pathname, file, {
+    access: 'private',
+    contentType: file.type,
+  });
+
+  const invoice = await prisma.professorInvoice.create({
+    data: {
+      professorId: params.id,
+      originalName: file.name || `factura${ext}`,
+      contentType: file.type,
+      size: file.size,
+      blobUrl: blob.url,
+    },
+  });
+
+  return NextResponse.json(
+    { invoice: serializeInvoice(invoice) },
+    { status: 201 }
+  );
+}

--- a/src/app/my-payments/page.tsx
+++ b/src/app/my-payments/page.tsx
@@ -3,6 +3,8 @@ import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
 import { formatAmount } from '@/lib/accounting';
+import { buildProfessorInvoiceFileUrl } from '@/lib/blob-urls';
+import ProfessorInvoicesPanel from '@/components/accounting/professor-invoices-panel';
 
 const MONTHS = [
   'Enero',
@@ -26,14 +28,29 @@ export default async function MyPaymentsPage() {
 
   if (!userId || role !== 'PROFESSOR') redirect('/');
 
-  const profile = await prisma.professorProfile.findUnique({
-    where: { userId },
-    include: {
-      payments: {
-        orderBy: [{ periodYear: 'desc' }, { periodMonth: 'desc' }],
+  const [profile, invoices] = await Promise.all([
+    prisma.professorProfile.findUnique({
+      where: { userId },
+      include: {
+        payments: {
+          orderBy: [{ periodYear: 'desc' }, { periodMonth: 'desc' }],
+        },
       },
-    },
-  });
+    }),
+    prisma.professorInvoice.findMany({
+      where: { professorId: userId },
+      orderBy: { createdAt: 'desc' },
+    }),
+  ]);
+
+  const invoiceRows = invoices.map((invoice) => ({
+    id: invoice.id,
+    originalName: invoice.originalName,
+    contentType: invoice.contentType,
+    size: invoice.size,
+    createdAt: invoice.createdAt.toISOString(),
+    fileUrl: buildProfessorInvoiceFileUrl(invoice.id),
+  }));
 
   return (
     <div className="mx-auto max-w-3xl space-y-8 px-4 py-8">
@@ -159,6 +176,16 @@ export default async function MyPaymentsPage() {
           </section>
         </>
       )}
+
+      <ProfessorInvoicesPanel
+        professorId={userId}
+        initialInvoices={invoiceRows}
+        canUpload={true}
+        canDelete={true}
+        title="Mis facturas"
+        description="Subí tus facturas en PDF o imagen para que contaduría las revise desde tu perfil de profesor."
+        emptyMessage="Todavía no subiste facturas."
+      />
     </div>
   );
 }

--- a/src/components/accounting/professor-invoices-panel.tsx
+++ b/src/components/accounting/professor-invoices-panel.tsx
@@ -1,0 +1,228 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+type ProfessorInvoice = {
+  id: string;
+  originalName: string;
+  contentType: string;
+  size: number;
+  createdAt: string;
+  fileUrl: string;
+};
+
+type Props = {
+  professorId: string;
+  initialInvoices: ProfessorInvoice[];
+  canUpload?: boolean;
+  canDelete?: boolean;
+  title?: string;
+  description?: string;
+  emptyMessage?: string;
+};
+
+function formatFileSize(size: number) {
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${Math.round(size / 1024)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function ProfessorInvoicesPanel({
+  professorId,
+  initialInvoices,
+  canUpload = false,
+  canDelete = false,
+  title = 'Mis facturas',
+  description = 'Subí tus facturas en PDF o imagen para que contaduría las revise.',
+  emptyMessage = 'Todavía no hay facturas cargadas.',
+}: Props) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [invoices, setInvoices] = useState(initialInvoices);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [deletingId, setDeletingId] = useState('');
+
+  const uploadFile = async (file: File) => {
+    setError('');
+    setSuccess('');
+
+    if (file.size > 10 * 1024 * 1024) {
+      setError('La factura debe pesar menos de 10 MB.');
+      return;
+    }
+
+    const formData = new FormData();
+    formData.append('file', file);
+    setUploading(true);
+
+    try {
+      const res = await fetch(`/api/professors/${professorId}/invoices`, {
+        method: 'POST',
+        body: formData,
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) {
+        throw new Error(body?.error ?? 'No se pudo subir la factura');
+      }
+      setInvoices((prev) => [body.invoice as ProfessorInvoice, ...prev]);
+      setSuccess('Factura subida correctamente.');
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al subir factura');
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const deleteInvoice = async (invoiceId: string) => {
+    setError('');
+    setSuccess('');
+    setDeletingId(invoiceId);
+
+    try {
+      const res = await fetch(`/api/professor-invoices/${invoiceId}`, {
+        method: 'DELETE',
+      });
+      if (!res.ok) throw new Error('No se pudo eliminar la factura');
+      setInvoices((prev) => prev.filter((invoice) => invoice.id !== invoiceId));
+      setSuccess('Factura eliminada correctamente.');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'Error al eliminar factura'
+      );
+    } finally {
+      setDeletingId('');
+    }
+  };
+
+  return (
+    <section className="rounded-xl border p-6 space-y-5">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-lg font-semibold">{title}</h2>
+            <span className="inline-flex items-center rounded-full border border-primary/20 bg-primary/10 px-2.5 py-0.5 text-xs font-medium text-primary">
+              Facturas
+            </span>
+          </div>
+          <p className="text-sm text-muted-foreground">{description}</p>
+        </div>
+        {canUpload && (
+          <Button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading}
+            className="shrink-0"
+          >
+            {uploading ? 'Subiendo...' : 'Subir factura'}
+          </Button>
+        )}
+      </div>
+
+      {canUpload && (
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="application/pdf,image/jpeg,image/png,image/webp"
+          className="hidden"
+          onChange={(e) => {
+            const file = e.target.files?.[0];
+            if (file) uploadFile(file);
+          }}
+        />
+      )}
+
+      {error && (
+        <div className="rounded-md border border-rose-200 bg-rose-50 px-3 py-2 text-sm text-rose-700">
+          {error}
+        </div>
+      )}
+      {success && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+          {success}
+        </div>
+      )}
+
+      {invoices.length === 0 ? (
+        <div className="rounded-lg border border-dashed bg-muted/20 p-4 text-sm text-muted-foreground">
+          {emptyMessage}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left">Archivo</th>
+                <th className="px-4 py-3 text-left">Tipo</th>
+                <th className="px-4 py-3 text-left">Tamaño</th>
+                <th className="px-4 py-3 text-left">Cargada</th>
+                <th className="px-4 py-3 text-right">Acciones</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {invoices.map((invoice) => (
+                <tr
+                  key={invoice.id}
+                  className="hover:bg-muted/20 transition-colors"
+                >
+                  <td className="px-4 py-3 font-medium max-w-[260px] truncate">
+                    {invoice.originalName}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {invoice.contentType === 'application/pdf'
+                      ? 'PDF'
+                      : 'Imagen'}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-muted-foreground">
+                    {formatFileSize(invoice.size)}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {new Date(invoice.createdAt).toLocaleDateString('es-AR')}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        asChild
+                        variant="outline"
+                        className="px-3 py-1 text-xs"
+                      >
+                        <a
+                          href={invoice.fileUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Ver
+                        </a>
+                      </Button>
+                      {canDelete && (
+                        <Button
+                          type="button"
+                          variant="outline"
+                          disabled={deletingId === invoice.id}
+                          onClick={() => deleteInvoice(invoice.id)}
+                          className="text-rose-600 border-rose-200 hover:bg-rose-50 px-3 py-1 text-xs"
+                        >
+                          {deletingId === invoice.id
+                            ? 'Eliminando...'
+                            : 'Eliminar'}
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {canUpload && (
+        <p className="text-xs text-muted-foreground">
+          Formatos permitidos: PDF, JPG, PNG o WebP. Tamaño máximo: 10 MB.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/src/lib/blob-urls.ts
+++ b/src/lib/blob-urls.ts
@@ -5,3 +5,7 @@ export function buildAccountingMovementReceiptUrl(id: string) {
 export function buildManualPaymentReceiptUrl(id: string) {
   return `/api/accounting/manual-payments/${id}/receipt`;
 }
+
+export function buildProfessorInvoiceFileUrl(id: string) {
+  return `/api/professor-invoices/${id}/file`;
+}


### PR DESCRIPTION
### Motivation
- Professors need a “Mis facturas” area in `my-payments` to upload invoice files and contaduría needs a “Facturas” tag in each professor profile to review those uploads.
- Store invoice metadata in the database and files in private blob storage with strict permission checks and file validations.

### Description
- Added a `ProfessorInvoice` Prisma model and migration to persist invoice metadata (`originalName`, `contentType`, `size`, `blobUrl`, timestamps) and linked it to `User`.
- Implemented secure API routes to list and upload invoices at `GET/POST /api/professors/[id]/invoices`, to stream/download files at `GET /api/professor-invoices/[invoiceId]/file`, and to delete invoices at `DELETE /api/professor-invoices/[invoiceId]`, using `@vercel/blob` and validating content type and max size (10 MB).
- Added a reusable `ProfessorInvoicesPanel` UI component with upload, view and delete actions, and integrated it into `src/app/my-payments/page.tsx` (professor self) and `src/app/accounting/professors/[id]/page.tsx` (contaduría view) with proper permission gating.
- Added helper `buildProfessorInvoiceFileUrl` and documented the new endpoints in `ROUTE_MAP.md`.

### Testing
- Ran Prisma validation and client generation: `pnpm exec prisma validate && pnpm prisma:generate` — succeeded with a local DB URL provided for validation.
- Ran linter: `pnpm lint` — succeeded (one preexisting prettier warning unrelated to these changes).
- Ran TypeScript check with a temporary `tsconfig` excluding test files for faster iteration: `pnpm exec tsc -p tsconfig.agent-check.json --noEmit` — succeeded for the compiled files (tests excluded for isolation).
- Ran unit tests: `pnpm test -- --runInBand` — failed in preexisting, unrelated suites (`pickup-notices`, `cart-checkout`, `accounting`), not introduced by these changes.
- Attempted production build: `pnpm build` — failed due to environment limitation fetching Google Fonts (`Chivo`) from `fonts.googleapis.com` during Next.js font processing, not related to the invoice feature.
- Unresolved risks: file streaming relies on Blob storage availability and private access behavior; front-end visual verification and end-to-end upload/download flows could not be validated due to the build/network limitation; tests failing elsewhere in the repo should be investigated separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb63598e64832886ac64bd76ee7e01)