### PR TITLE
Move my activities view toggle above agenda

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -372,6 +372,36 @@ export default function ActivityCalendar({
 
   return (
     <div className="space-y-3">
+      {variant !== 'month' && (
+        <div className="inline-flex rounded-lg border bg-muted/30 p-1">
+          <button
+            type="button"
+            onClick={() => setShowMonthCalendar(false)}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              !showMonthCalendar
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            aria-pressed={!showMonthCalendar}
+          >
+            Día
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowMonthCalendar(true)}
+            className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+              showMonthCalendar
+                ? 'bg-background text-foreground shadow-sm'
+                : 'text-muted-foreground hover:text-foreground'
+            }`}
+            aria-pressed={showMonthCalendar}
+          >
+            <CalendarDays className="h-4 w-4" aria-hidden="true" />
+            Calendario mensual
+          </button>
+        </div>
+      )}
+
       {variant !== 'month' && !showMonthCalendar && (
         <div className="rounded-xl border bg-card p-4 shadow-sm">
           <div className="mb-3 flex items-center justify-between gap-3">
@@ -554,36 +584,6 @@ export default function ActivityCalendar({
               })}
             </div>
           </div>
-        </div>
-      )}
-
-      {variant !== 'month' && (
-        <div className="inline-flex rounded-lg border bg-muted/30 p-1">
-          <button
-            type="button"
-            onClick={() => setShowMonthCalendar(false)}
-            className={`rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-              !showMonthCalendar
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-            aria-pressed={!showMonthCalendar}
-          >
-            Día
-          </button>
-          <button
-            type="button"
-            onClick={() => setShowMonthCalendar(true)}
-            className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
-              showMonthCalendar
-                ? 'bg-background text-foreground shadow-sm'
-                : 'text-muted-foreground hover:text-foreground'
-            }`}
-            aria-pressed={showMonthCalendar}
-          >
-            <CalendarDays className="h-4 w-4" aria-hidden="true" />
-            Calendario mensual
-          </button>
         </div>
       )}
 


### PR DESCRIPTION
### Motivation
- Ensure the "Día / Calendario mensual" toggle appears directly under the `Mis actividades` intro so the view selector (tags like “calendario”/“día”) stays at the top for professor, parent and member views.

### Description
- Reordered the render in `src/app/my-activities/activity-calendar.tsx` so the Day/Month toggle is rendered before the agenda and month calendar blocks, removing the duplicate placement and keeping the toggle immediately below the page intro.

### Testing
- Ran `pnpm lint` (passed; an unrelated existing Prettier warning was shown elsewhere), `pnpm exec prettier --check src/app/my-activities/activity-calendar.tsx` (passed), and `git diff --check` (no issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb661ce1388328bcd166852668bf4f)