### PR TITLE
Add institutional news section

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -58,6 +58,12 @@ Agents should check this before searching the codebase.
   - File: `src/app/activities/[id]/edit/page.tsx`
   - Related form: `src/app/activities/[id]/edit/form.tsx`
 
+### News
+
+- `/news` → Institutional news feed for members, professors, and admins
+  - File: `src/app/news/page.tsx`
+  - Related component: `src/app/news/create-news-form.tsx`
+
 ### User
 
 - `/profile` → User profile
@@ -269,6 +275,14 @@ Agents should check this before searching the codebase.
 - `POST /api/forms/[id]/responses` → submit response
   - File: `src/app/api/forms/[id]/responses/route.ts`
   - Validation: `src/lib/validations/form.ts`
+
+### News API
+
+- `POST /api/news` → create institutional news with optional image/video media and dispatch notifications
+  - File: `src/app/api/news/route.ts`
+
+- `GET /api/news/[id]/media` → stream private news media to authorized users
+  - File: `src/app/api/news/[id]/media/route.ts`
 
 ### Messaging
 

--- a/prisma/migrations/20260506120000_add_news/migration.sql
+++ b/prisma/migrations/20260506120000_add_news/migration.sql
@@ -1,0 +1,56 @@
+-- CreateEnum
+CREATE TYPE "NewsScope" AS ENUM ('CLUB', 'ACTIVITY');
+
+-- CreateEnum
+CREATE TYPE "NewsMediaType" AS ENUM ('IMAGE', 'VIDEO');
+
+-- AlterEnum
+ALTER TYPE "NotificationType" ADD VALUE 'NEWS_CREATED';
+
+-- CreateTable
+CREATE TABLE "News" (
+    "id" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "scope" "NewsScope" NOT NULL,
+    "activityId" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "News_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "NewsMedia" (
+    "id" TEXT NOT NULL,
+    "newsId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "type" "NewsMediaType" NOT NULL,
+    "fileName" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "NewsMedia_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "News_scope_createdAt_idx" ON "News"("scope", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "News_activityId_createdAt_idx" ON "News"("activityId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "News_createdById_createdAt_idx" ON "News"("createdById", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "NewsMedia_newsId_idx" ON "NewsMedia"("newsId");
+
+-- AddForeignKey
+ALTER TABLE "News" ADD CONSTRAINT "News_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "News" ADD CONSTRAINT "News_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "NewsMedia" ADD CONSTRAINT "NewsMedia_newsId_fkey" FOREIGN KEY ("newsId") REFERENCES "News"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -57,6 +57,7 @@ model User {
   pickupNoticesAsAlternate   PickupNotice[] @relation("PickupNoticeAlternatePerson")
   pickupNoticeAcknowledgments PickupNoticeAcknowledgment[]
   notifications              Notification[]
+  createdNews                News[]                    @relation("NewsCreatedBy")
   pushAlertSubscriptions     PushAlertSubscription[]
   notificationPreferences    NotificationPreference[]
   professorProfile           ProfessorProfile?
@@ -163,6 +164,7 @@ model Activity {
   description  String?
   price        Int                   @default(0)
   participants ActivityParticipant[]
+  news         News[]
   professors   ActivityProfessor[]
   groups       ActivityGroup[]
   days         ActivityDay[]
@@ -688,6 +690,47 @@ enum PaymentStatus {
   CANCELLED
 }
 
+model News {
+  id          String      @id @default(cuid())
+  title       String
+  body        String
+  scope       NewsScope
+  activityId  String?
+  activity    Activity?   @relation(fields: [activityId], references: [id], onDelete: SetNull)
+  createdById String
+  createdBy   User        @relation("NewsCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
+  media       NewsMedia[]
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
+
+  @@index([scope, createdAt])
+  @@index([activityId, createdAt])
+  @@index([createdById, createdAt])
+}
+
+model NewsMedia {
+  id        String        @id @default(cuid())
+  newsId    String
+  news      News          @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  url       String
+  mimeType  String
+  type      NewsMediaType
+  fileName  String?
+  createdAt DateTime      @default(now())
+
+  @@index([newsId])
+}
+
+enum NewsScope {
+  CLUB
+  ACTIVITY
+}
+
+enum NewsMediaType {
+  IMAGE
+  VIDEO
+}
+
 enum NotificationType {
   ACTIVITY_DAY_NEW
   ACTIVITY_DAY_UPDATED
@@ -700,6 +743,7 @@ enum NotificationType {
   PAYMENT_REJECTED
   ACTIVITY_CAPACITY_FULL
   CHAT_MESSAGE_NEW
+  NEWS_CREATED
 }
 
 model ProfessorProfile {

--- a/src/app/api/news/[id]/media/route.ts
+++ b/src/app/api/news/[id]/media/route.ts
@@ -1,0 +1,50 @@
+import { get } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canUserReadNews } from '@/lib/news-access';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return new NextResponse(null, { status: 401 });
+  }
+
+  const media = await prisma.newsMedia.findUnique({
+    where: { id: params.id },
+    select: { url: true, mimeType: true, newsId: true },
+  });
+
+  if (!media) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  const canRead = await canUserReadNews({
+    userId: session.user.id,
+    role: session.user.activeRole ?? session.user.role,
+    newsId: media.newsId,
+  });
+
+  if (!canRead) {
+    return new NextResponse(null, { status: 403 });
+  }
+
+  try {
+    const blob = await get(media.url, { access: 'private' });
+    if (!blob || blob.statusCode !== 200) {
+      return new NextResponse(null, { status: 404 });
+    }
+
+    const headers = Object.fromEntries(blob.headers.entries());
+    headers['Content-Type'] = media.mimeType;
+    headers['Cache-Control'] = 'private, max-age=300';
+
+    return new NextResponse(blob.stream, { headers });
+  } catch {
+    return new NextResponse(null, { status: 404 });
+  }
+}

--- a/src/app/api/news/route.ts
+++ b/src/app/api/news/route.ts
@@ -1,0 +1,180 @@
+import { del, put } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession, type Session } from 'next-auth';
+import { NewsMediaType, NewsScope } from '@prisma/client';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { notifyNewsCreated } from '@/lib/notifications/notification-service';
+
+const MAX_MEDIA_FILES = 6;
+const MAX_IMAGE_SIZE = 8 * 1024 * 1024;
+const MAX_VIDEO_SIZE = 80 * 1024 * 1024;
+
+function isAdminSession(session: Session | null) {
+  const role = session?.user.activeRole ?? session?.user.role;
+  return role === 'ADMIN' || role === 'SUPER_ADMIN';
+}
+
+function extensionForFile(file: File) {
+  const name = file.name.trim();
+  const dot = name.lastIndexOf('.');
+  if (dot >= 0 && dot < name.length - 1) {
+    return name
+      .slice(dot)
+      .toLowerCase()
+      .replace(/[^.a-z0-9]/g, '');
+  }
+  const subtype = file.type.split('/')[1]?.split(';')[0];
+  return subtype ? `.${subtype.replace(/[^a-z0-9]/gi, '').toLowerCase()}` : '';
+}
+
+function mediaTypeFor(file: File): NewsMediaType | null {
+  if (file.type.startsWith('image/')) return 'IMAGE';
+  if (file.type.startsWith('video/')) return 'VIDEO';
+  return null;
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user || !isAdminSession(session)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const title = String(formData.get('title') ?? '').trim();
+  const body = String(formData.get('body') ?? '').trim();
+  const scopeInput = String(formData.get('scope') ?? 'CLUB');
+  const activityId = String(formData.get('activityId') ?? '').trim();
+  const scope = scopeInput === 'ACTIVITY' ? NewsScope.ACTIVITY : NewsScope.CLUB;
+  const files = formData
+    .getAll('media')
+    .filter((file): file is File => file instanceof File && file.size > 0);
+
+  if (!title) {
+    return NextResponse.json(
+      { error: 'El título de la noticia es obligatorio' },
+      { status: 400 }
+    );
+  }
+
+  if (!body) {
+    return NextResponse.json(
+      { error: 'El texto de la noticia es obligatorio' },
+      { status: 400 }
+    );
+  }
+
+  if (title.length > 160) {
+    return NextResponse.json(
+      { error: 'El título debe tener menos de 160 caracteres' },
+      { status: 400 }
+    );
+  }
+
+  if (scope === 'ACTIVITY' && !activityId) {
+    return NextResponse.json(
+      { error: 'Seleccioná una actividad para esta noticia' },
+      { status: 400 }
+    );
+  }
+
+  if (files.length > MAX_MEDIA_FILES) {
+    return NextResponse.json(
+      { error: `Podés cargar hasta ${MAX_MEDIA_FILES} archivos` },
+      { status: 400 }
+    );
+  }
+
+  if (scope === 'ACTIVITY') {
+    const activityExists = await prisma.activity.count({
+      where: { id: activityId },
+    });
+    if (!activityExists) {
+      return NextResponse.json(
+        { error: 'Actividad no encontrada' },
+        { status: 404 }
+      );
+    }
+  }
+
+  for (const file of files) {
+    const type = mediaTypeFor(file);
+    if (!type) {
+      return NextResponse.json(
+        { error: 'Solo se permiten imágenes o videos' },
+        { status: 400 }
+      );
+    }
+    const maxSize = type === 'IMAGE' ? MAX_IMAGE_SIZE : MAX_VIDEO_SIZE;
+    if (file.size > maxSize) {
+      return NextResponse.json(
+        {
+          error:
+            type === 'IMAGE'
+              ? 'Cada imagen debe pesar menos de 8 MB'
+              : 'Cada video debe pesar menos de 80 MB',
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  const uploaded: Array<{
+    url: string;
+    mimeType: string;
+    type: NewsMediaType;
+    fileName: string;
+  }> = [];
+
+  try {
+    for (const file of files) {
+      const type = mediaTypeFor(file);
+      if (!type) continue;
+      const pathname = `news/${crypto.randomUUID()}${extensionForFile(file)}`;
+      const blob = await put(pathname, file, {
+        access: 'private',
+        contentType: file.type,
+      });
+      uploaded.push({
+        url: blob.url,
+        mimeType: file.type,
+        type,
+        fileName: file.name,
+      });
+    }
+
+    const news = await prisma.news.create({
+      data: {
+        title,
+        body,
+        scope,
+        activityId: scope === 'ACTIVITY' ? activityId : null,
+        createdById: session.user.id,
+        media: uploaded.length
+          ? {
+              create: uploaded.map((media) => ({
+                url: media.url,
+                mimeType: media.mimeType,
+                type: media.type,
+                fileName: media.fileName,
+              })),
+            }
+          : undefined,
+      },
+      select: { id: true },
+    });
+
+    await notifyNewsCreated(news.id);
+
+    return NextResponse.json({ ok: true, id: news.id }, { status: 201 });
+  } catch (err) {
+    await Promise.all(
+      uploaded.map((file) => del(file.url).catch(() => undefined))
+    );
+    console.error('[news] create failed', err);
+    return NextResponse.json(
+      { error: 'No se pudo crear la noticia' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/news/create-news-form.tsx
+++ b/src/app/news/create-news-form.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useMemo, useState } from 'react';
+
+type ActivityOption = {
+  id: string;
+  name: string;
+};
+
+type CreateNewsFormProps = {
+  activities: ActivityOption[];
+};
+
+export default function CreateNewsForm({ activities }: CreateNewsFormProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [scope, setScope] = useState<'CLUB' | 'ACTIVITY'>('CLUB');
+  const [submitting, setSubmitting] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const firstActivityId = useMemo(() => activities[0]?.id ?? '', [activities]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    setMessage(null);
+
+    const formData = new FormData(event.currentTarget);
+    formData.set('scope', scope);
+    if (scope === 'CLUB') {
+      formData.delete('activityId');
+    }
+
+    try {
+      const response = await fetch('/api/news', {
+        method: 'POST',
+        body: formData,
+      });
+      const data = (await response.json()) as { error?: string };
+      if (!response.ok) {
+        setError(data.error ?? 'No se pudo crear la noticia');
+        return;
+      }
+
+      event.currentTarget.reset();
+      setScope('CLUB');
+      setOpen(false);
+      setMessage('Noticia creada y notificaciones enviadas.');
+      router.refresh();
+    } catch {
+      setError('No se pudo conectar con el servidor');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-2xl border bg-card p-4 shadow-sm">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Noticias institucionales</h2>
+          <p className="text-sm text-muted-foreground">
+            Creá novedades para todo el club o para personas vinculadas a una
+            actividad.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setOpen((value) => !value)}
+          className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:opacity-90"
+        >
+          {open ? 'Cerrar' : 'Crear noticia'}
+        </button>
+      </div>
+
+      {message && (
+        <p className="mt-3 text-sm font-medium text-green-700">{message}</p>
+      )}
+      {error && (
+        <p className="mt-3 text-sm font-medium text-red-700">{error}</p>
+      )}
+
+      {open && (
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4 border-t pt-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="space-y-1 text-sm font-medium">
+              Título
+              <input
+                name="title"
+                maxLength={160}
+                required
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+                placeholder="Ej: Asamblea anual del club"
+              />
+            </label>
+            <fieldset className="space-y-2 text-sm font-medium">
+              <legend>Destinatarios</legend>
+              <label className="flex items-center gap-2 rounded-lg border px-3 py-2 font-normal">
+                <input
+                  type="radio"
+                  name="scopeChoice"
+                  checked={scope === 'CLUB'}
+                  onChange={() => setScope('CLUB')}
+                />
+                Para todo el club
+              </label>
+              <label className="flex items-center gap-2 rounded-lg border px-3 py-2 font-normal">
+                <input
+                  type="radio"
+                  name="scopeChoice"
+                  checked={scope === 'ACTIVITY'}
+                  onChange={() => setScope('ACTIVITY')}
+                  disabled={activities.length === 0}
+                />
+                Por actividad
+              </label>
+            </fieldset>
+          </div>
+
+          {scope === 'ACTIVITY' && (
+            <label className="block space-y-1 text-sm font-medium">
+              Actividad
+              <select
+                name="activityId"
+                required
+                defaultValue={firstActivityId}
+                className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              >
+                {activities.map((activity) => (
+                  <option key={activity.id} value={activity.id}>
+                    {activity.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <label className="block space-y-1 text-sm font-medium">
+            Texto de la noticia
+            <textarea
+              name="body"
+              required
+              rows={6}
+              className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+              placeholder="Escribí el comunicado, indicaciones, fechas o información importante..."
+            />
+          </label>
+
+          <label className="block space-y-1 text-sm font-medium">
+            Imágenes o videos
+            <input
+              name="media"
+              type="file"
+              accept="image/*,video/*"
+              multiple
+              className="w-full rounded-lg border bg-background px-3 py-2 text-sm"
+            />
+            <span className="block text-xs font-normal text-muted-foreground">
+              Hasta 6 archivos. Imágenes hasta 8 MB y videos hasta 80 MB cada
+              uno.
+            </span>
+          </label>
+
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {submitting ? 'Publicando...' : 'Publicar noticia'}
+          </button>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,0 +1,169 @@
+import Image from 'next/image';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
+import { NewsScope, type Prisma } from '@prisma/client';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { getReadableActivityIds, isNewsAdminRole } from '@/lib/news-access';
+import CreateNewsForm from './create-news-form';
+
+type NewsWithRelations = Prisma.NewsGetPayload<{
+  include: {
+    activity: { select: { name: true } };
+    createdBy: { select: { name: true; lastName: true } };
+    media: true;
+  };
+}>;
+
+function formatDate(date: Date) {
+  return new Intl.DateTimeFormat('es-AR', {
+    day: '2-digit',
+    month: 'long',
+    year: 'numeric',
+  }).format(date);
+}
+
+function creatorName(news: NewsWithRelations) {
+  const parts = [news.createdBy.name, news.createdBy.lastName].filter(Boolean);
+  return parts.length > 0 ? parts.join(' ') : 'Administración';
+}
+
+export default async function NewsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const role = session.user.activeRole ?? session.user.role;
+  const isAdmin = isNewsAdminRole(role);
+  const readableActivityIds = await getReadableActivityIds({
+    userId: session.user.id,
+    role,
+  });
+
+  const where: Prisma.NewsWhereInput = isAdmin
+    ? {}
+    : {
+        OR: [
+          { scope: NewsScope.CLUB },
+          ...(readableActivityIds && readableActivityIds.length > 0
+            ? [
+                {
+                  scope: NewsScope.ACTIVITY,
+                  activityId: { in: readableActivityIds },
+                },
+              ]
+            : []),
+        ],
+      };
+
+  const [news, activities] = await Promise.all([
+    prisma.news.findMany({
+      where,
+      include: {
+        activity: { select: { name: true } },
+        createdBy: { select: { name: true, lastName: true } },
+        media: { orderBy: { createdAt: 'asc' } },
+      },
+      orderBy: { createdAt: 'desc' },
+      take: 50,
+    }),
+    isAdmin
+      ? prisma.activity.findMany({
+          select: { id: true, name: true },
+          orderBy: { name: 'asc' },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  return (
+    <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
+      <header className="space-y-2">
+        <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+          Club Hualas
+        </p>
+        <h1 className="text-3xl font-bold tracking-tight">Noticias</h1>
+        <p className="max-w-2xl text-muted-foreground">
+          Comunicados institucionales y novedades de tus actividades.
+        </p>
+      </header>
+
+      {isAdmin && <CreateNewsForm activities={activities} />}
+
+      {news.length === 0 ? (
+        <div className="rounded-2xl border bg-card p-8 text-center shadow-sm">
+          <h2 className="text-lg font-semibold">Todavía no hay noticias</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Cuando administración publique novedades, vas a encontrarlas acá.
+          </p>
+        </div>
+      ) : (
+        <section className="space-y-4" aria-label="Listado de noticias">
+          {news.map((item) => (
+            <article
+              id={item.id}
+              key={item.id}
+              className="scroll-mt-24 rounded-2xl border bg-card p-5 shadow-sm"
+            >
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="space-y-1">
+                  <span className="inline-flex rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                    {item.scope === 'CLUB'
+                      ? 'Para todo el club'
+                      : (item.activity?.name ?? 'Actividad')}
+                  </span>
+                  <h2 className="text-2xl font-semibold tracking-tight">
+                    {item.title}
+                  </h2>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  {formatDate(item.createdAt)}
+                </p>
+              </div>
+
+              <p className="mt-2 text-sm text-muted-foreground">
+                Publicado por {creatorName(item)}
+              </p>
+
+              <div className="mt-4 whitespace-pre-wrap leading-7 text-foreground/90">
+                {item.body}
+              </div>
+
+              {item.media.length > 0 && (
+                <div className="mt-5 grid gap-3 md:grid-cols-2">
+                  {item.media.map((media) => {
+                    const src = `/api/news/${media.id}/media`;
+                    return media.type === 'IMAGE' ? (
+                      <div
+                        key={media.id}
+                        className="relative aspect-video overflow-hidden rounded-xl border bg-muted"
+                      >
+                        <Image
+                          src={src}
+                          alt={media.fileName ?? item.title}
+                          fill
+                          unoptimized
+                          className="object-cover"
+                          sizes="(min-width: 768px) 50vw, 100vw"
+                        />
+                      </div>
+                    ) : (
+                      <video
+                        key={media.id}
+                        src={src}
+                        controls
+                        className="aspect-video w-full rounded-xl border bg-black"
+                      >
+                        Tu navegador no puede reproducir este video.
+                      </video>
+                    );
+                  })}
+                </div>
+              )}
+            </article>
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/app/profile/notifications/page.tsx
+++ b/src/app/profile/notifications/page.tsx
@@ -28,6 +28,7 @@ const TYPE_ROLES: Record<NotificationType, Role[]> = {
   PAYMENT_REJECTED: ALL_ROLES,
   ACTIVITY_CAPACITY_FULL: ['ADMIN', 'SUPER_ADMIN'],
   CHAT_MESSAGE_NEW: ALL_ROLES,
+  NEWS_CREATED: ALL_ROLES,
 };
 
 const TYPE_LABELS: Record<
@@ -80,6 +81,11 @@ const TYPE_LABELS: Record<
   CHAT_MESSAGE_NEW: {
     title: 'Mensajes nuevos',
     description: 'Cuando recibís un mensaje en el chat interno.',
+  },
+  NEWS_CREATED: {
+    title: 'Noticias institucionales',
+    description:
+      'Cuando administración publica una noticia para el club o tus actividades.',
   },
 };
 

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -235,17 +235,30 @@ export default function Navbar() {
               {isMember ? t.myActivities : t.activities}
             </Link>
           )}
-          {isProfessor && (
-            <Link
-              href="/professor/students"
-              className={navLinkClass('/professor/students')}
-              prefetch={true}
-            >
-              Mis grupos
+          {isMemberRole && (
+            <Link href="/news" className={navLinkClass('/news')}>
+              Noticias
             </Link>
+          )}
+          {isProfessor && (
+            <>
+              <Link
+                href="/professor/students"
+                className={navLinkClass('/professor/students')}
+                prefetch={true}
+              >
+                Mis grupos
+              </Link>
+              <Link href="/news" className={navLinkClass('/news')}>
+                Noticias
+              </Link>
+            </>
           )}
           {isAdmin && (
             <>
+              <Link href="/news" className={navLinkClass('/news')}>
+                Noticias
+              </Link>
               <Link
                 href="/admin/users"
                 className={navLinkClass('/admin/users')}
@@ -485,6 +498,15 @@ export default function Navbar() {
               )}
               {isMemberRole && (
                 <Link
+                  href="/news"
+                  className={navLinkClass('/news')}
+                  onClick={() => setMenuOpen(false)}
+                >
+                  Noticias
+                </Link>
+              )}
+              {isMemberRole && (
+                <Link
                   href="/activities/cart"
                   className={cn(
                     navLinkClass('/activities/cart'),
@@ -543,6 +565,13 @@ export default function Navbar() {
               {isAdmin && (
                 <>
                   <Link
+                    href="/news"
+                    className={navLinkClass('/news')}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    Noticias
+                  </Link>
+                  <Link
                     href="/admin/users"
                     className={navLinkClass('/admin/users')}
                     onClick={() => setMenuOpen(false)}
@@ -589,14 +618,23 @@ export default function Navbar() {
                 </Link>
               )}
               {isProfessor && (
-                <Link
-                  href="/professor/students"
-                  className={navLinkClass('/professor/students')}
-                  onClick={() => setMenuOpen(false)}
-                  prefetch={true}
-                >
-                  Mis grupos
-                </Link>
+                <>
+                  <Link
+                    href="/professor/students"
+                    className={navLinkClass('/professor/students')}
+                    onClick={() => setMenuOpen(false)}
+                    prefetch={true}
+                  >
+                    Mis grupos
+                  </Link>
+                  <Link
+                    href="/news"
+                    className={navLinkClass('/news')}
+                    onClick={() => setMenuOpen(false)}
+                  >
+                    Noticias
+                  </Link>
+                </>
               )}
               {isProfessor && (
                 <Link

--- a/src/components/notifications/notification-item.tsx
+++ b/src/components/notifications/notification-item.tsx
@@ -13,6 +13,7 @@ import {
   XCircle,
   Users,
   MessageSquare,
+  Newspaper,
 } from 'lucide-react';
 import type { NotificationType } from '@prisma/client';
 import { cn } from '@/lib/utils';
@@ -29,6 +30,7 @@ const ICONS: Record<NotificationType, typeof Bell> = {
   PAYMENT_REJECTED: XCircle,
   ACTIVITY_CAPACITY_FULL: Users,
   CHAT_MESSAGE_NEW: MessageSquare,
+  NEWS_CREATED: Newspaper,
 };
 
 function relativeTime(date: Date): string {

--- a/src/lib/news-access.ts
+++ b/src/lib/news-access.ts
@@ -1,0 +1,56 @@
+import { prisma } from '@/lib/prisma';
+import type { Role } from '@prisma/client';
+import { getAccessibleChildOwnerIds } from '@/lib/family-access';
+
+export type NewsAccessUser = {
+  userId: string;
+  role: Role;
+};
+
+export function isNewsAdminRole(role: Role) {
+  return role === 'ADMIN' || role === 'SUPER_ADMIN';
+}
+
+export async function getReadableActivityIds(user: NewsAccessUser) {
+  if (isNewsAdminRole(user.role)) return null;
+
+  if (user.role === 'PROFESSOR') {
+    const assignments = await prisma.activityProfessor.findMany({
+      where: { userId: user.userId },
+      select: { activityId: true },
+    });
+    return [...new Set(assignments.map((a) => a.activityId))];
+  }
+
+  const accessibleChildOwnerIds = await getAccessibleChildOwnerIds(user.userId);
+  const participations = await prisma.activityParticipant.findMany({
+    where: {
+      OR: [
+        { userId: user.userId },
+        { child: { userId: { in: accessibleChildOwnerIds } } },
+      ],
+    },
+    select: { activityId: true },
+  });
+  return [...new Set(participations.map((p) => p.activityId))];
+}
+
+export async function canUserReadNews({
+  userId,
+  role,
+  newsId,
+}: NewsAccessUser & { newsId: string }) {
+  if (isNewsAdminRole(role)) return true;
+
+  const news = await prisma.news.findUnique({
+    where: { id: newsId },
+    select: { scope: true, activityId: true },
+  });
+
+  if (!news) return false;
+  if (news.scope === 'CLUB') return true;
+  if (!news.activityId) return false;
+
+  const activityIds = await getReadableActivityIds({ userId, role });
+  return activityIds?.includes(news.activityId) ?? true;
+}

--- a/src/lib/notifications/notification-service.ts
+++ b/src/lib/notifications/notification-service.ts
@@ -12,6 +12,7 @@ import {
   recipientsForActivityParticipant,
   recipientsForCapacityFull,
   recipientsForChatMessage,
+  recipientsForNews,
 } from './recipients';
 
 function logFailure(label: string, err: unknown): void {
@@ -543,5 +544,43 @@ export async function notifyChatMessage(messageId: string): Promise<void> {
     });
   } catch (err) {
     logFailure('notifyChatMessage', err);
+  }
+}
+
+export async function notifyNewsCreated(newsId: string): Promise<void> {
+  try {
+    const news = await prisma.news.findUnique({
+      where: { id: newsId },
+      select: {
+        id: true,
+        title: true,
+        body: true,
+        scope: true,
+        activityId: true,
+        activity: { select: { name: true } },
+      },
+    });
+    if (!news) return;
+    const recipients = await recipientsForNews(newsId);
+    if (recipients.length === 0) return;
+    const title =
+      news.scope === 'ACTIVITY' && news.activity?.name
+        ? `Noticia — ${news.activity.name}`
+        : 'Noticia institucional';
+    const preview =
+      news.body.length > 120 ? `${news.body.slice(0, 117)}...` : news.body;
+    await dispatch({
+      type: 'NEWS_CREATED',
+      recipients,
+      title,
+      body: `${news.title}: ${preview}`,
+      url: `/news#${news.id}`,
+      data: {
+        newsId: news.id,
+        activityId: news.activityId ?? null,
+      } as Prisma.JsonObject,
+    });
+  } catch (err) {
+    logFailure('notifyNewsCreated', err);
   }
 }

--- a/src/lib/notifications/recipients.ts
+++ b/src/lib/notifications/recipients.ts
@@ -214,3 +214,39 @@ export async function recipientsForChatMessage(
     conversationId: message.conversationId,
   };
 }
+
+export async function recipientsForNews(newsId: string): Promise<string[]> {
+  const news = await prisma.news.findUnique({
+    where: { id: newsId },
+    select: { scope: true, activityId: true, createdById: true },
+  });
+  if (!news) return [];
+
+  if (news.scope === 'CLUB') {
+    const users = await prisma.user.findMany({
+      where: { isActive: true },
+      select: { id: true },
+    });
+    return users.map((u) => u.id);
+  }
+
+  if (!news.activityId) return [];
+
+  const [participants, professors] = await Promise.all([
+    prisma.activityParticipant.findMany({
+      where: { activityId: news.activityId },
+      select: { userId: true },
+    }),
+    prisma.activityProfessor.findMany({
+      where: { activityId: news.activityId },
+      select: { userId: true },
+    }),
+  ]);
+
+  return [
+    ...new Set([
+      ...participants.map((p) => p.userId),
+      ...professors.map((p) => p.userId),
+    ]),
+  ];
+}

--- a/src/lib/validations/notifications.ts
+++ b/src/lib/validations/notifications.ts
@@ -12,6 +12,7 @@ export const NOTIFICATION_TYPES = [
   'PAYMENT_REJECTED',
   'ACTIVITY_CAPACITY_FULL',
   'CHAT_MESSAGE_NEW',
+  'NEWS_CREATED',
 ] as const;
 
 export const notificationTypeSchema = z.enum(NOTIFICATION_TYPES);


### PR DESCRIPTION
### Motivation
- Provide an admin-managed institutional "Noticias" section so administrators can publish club-wide or activity-scoped news that reach members/professors with in-app + push notifications and optional media.

### Description
- Add database models `News` and `NewsMedia`, enums `NewsScope`/`NewsMediaType` and migration SQL to store news and media and extend `NotificationType` with `NEWS_CREATED` (`prisma/schema.prisma`, `prisma/migrations/20260506120000_add_news/migration.sql`).
- Implement `POST /api/news` to validate admin permissions, accept title/body, optional `activityId`, upload up to 6 images/videos to Vercel Blob and persist `News` + `NewsMedia` records (`src/app/api/news/route.ts`).
- Implement secure media streaming `GET /api/news/[id]/media` that enforces read permissions before proxying private blob content (`src/app/api/news/[id]/media/route.ts`).
- Add server-side helpers for access control (`src/lib/news-access.ts`), recipients for news dispatch (`src/lib/notifications/recipients.ts`) and `notifyNewsCreated` dispatching `NEWS_CREATED` through the existing notification pipeline (`src/lib/notifications/notification-service.ts`).
- Add frontend news feed page `/news` with an admin `CreateNewsForm` (scope selection: `CLUB` or `ACTIVITY`, body, media upload) and rendering of images/videos for authorized users (`src/app/news/page.tsx`, `src/app/news/create-news-form.tsx`).
- Add navbar links for `Noticias` for members, professors and admins and add icon support for `NEWS_CREATED` notifications (`src/components/navbar.tsx`, `src/components/notifications/notification-item.tsx`).
- Register the new route and API in `ROUTE_MAP.md` and wire the new notification type into validation/preferences (`src/lib/validations/notifications.ts`, `src/app/profile/notifications/page.tsx`).

### Testing
- `pnpm prisma:generate` — succeeded and Prisma client regenerated.
- `DATABASE_URL='postgresql://user:pass@localhost:5432/hualas' pnpm exec prisma validate` — schema validated successfully with a test `DATABASE_URL`.
- `pnpm lint` — ran; only a preexisting Prettier warning remains in `src/app/api/users/[id]/children/[childId]/route.ts` and no new lint failures from this change.
- `pnpm build` / `next build` — blocked by environment failure fetching Google Font `Chivo` during the build process (network/font fetch issue), preventing a full production build validation.
- `pnpm exec tsc --noEmit` — local type-check reported unrelated existing test/type errors in `tests/api/pickup-notices.test.ts` (these are external to the News changes); notification-related TypeScript adjustments were applied as part of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb67fcd8448328aab8339292168f6d)