### PR TITLE
Add newspaper icon to News navbar link

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { Menu, X } from 'lucide-react';
+import { Menu, Newspaper, X } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import { useSession, signOut } from 'next-auth/react';
 import { cn } from '@/lib/utils';
@@ -173,6 +173,22 @@ export default function Navbar() {
     />
   );
 
+  const renderNewsLink = (onClick?: () => void) => (
+    <Link
+      href="/news"
+      className={cn(navLinkClass('/news'), 'inline-flex items-center gap-2')}
+      onClick={onClick}
+    >
+      <span
+        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-current/25 bg-current/10"
+        aria-hidden="true"
+      >
+        <Newspaper className="h-5 w-5" strokeWidth={2.2} />
+      </span>
+      <span>Noticias</span>
+    </Link>
+  );
+
   return (
     <nav
       className={cn(
@@ -235,11 +251,7 @@ export default function Navbar() {
               {isMember ? t.myActivities : t.activities}
             </Link>
           )}
-          {isMemberRole && (
-            <Link href="/news" className={navLinkClass('/news')}>
-              Noticias
-            </Link>
-          )}
+          {isMemberRole && renderNewsLink()}
           {isProfessor && (
             <>
               <Link
@@ -249,16 +261,12 @@ export default function Navbar() {
               >
                 Mis grupos
               </Link>
-              <Link href="/news" className={navLinkClass('/news')}>
-                Noticias
-              </Link>
+              {renderNewsLink()}
             </>
           )}
           {isAdmin && (
             <>
-              <Link href="/news" className={navLinkClass('/news')}>
-                Noticias
-              </Link>
+              {renderNewsLink()}
               <Link
                 href="/admin/users"
                 className={navLinkClass('/admin/users')}
@@ -496,15 +504,7 @@ export default function Navbar() {
                   {isMember ? t.myActivities : t.activities}
                 </Link>
               )}
-              {isMemberRole && (
-                <Link
-                  href="/news"
-                  className={navLinkClass('/news')}
-                  onClick={() => setMenuOpen(false)}
-                >
-                  Noticias
-                </Link>
-              )}
+              {isMemberRole && renderNewsLink(() => setMenuOpen(false))}
               {isMemberRole && (
                 <Link
                   href="/activities/cart"
@@ -564,13 +564,7 @@ export default function Navbar() {
               </Link>
               {isAdmin && (
                 <>
-                  <Link
-                    href="/news"
-                    className={navLinkClass('/news')}
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    Noticias
-                  </Link>
+                  {renderNewsLink(() => setMenuOpen(false))}
                   <Link
                     href="/admin/users"
                     className={navLinkClass('/admin/users')}
@@ -627,13 +621,7 @@ export default function Navbar() {
                   >
                     Mis grupos
                   </Link>
-                  <Link
-                    href="/news"
-                    className={navLinkClass('/news')}
-                    onClick={() => setMenuOpen(false)}
-                  >
-                    Noticias
-                  </Link>
+                  {renderNewsLink(() => setMenuOpen(false))}
                 </>
               )}
               {isProfessor && (


### PR DESCRIPTION
### Motivation
- Make the newly added `Noticias` menu entry visually consistent with the other navbar items by matching color/active states and adding an inline icon that respects the existing aesthetic.
- Avoid introducing new image assets by using a vector icon that inherits the link color and behaves like other nav items on hover/active.

### Description
- Added a reusable `renderNewsLink` helper in `src/components/navbar.tsx` that renders the `Noticias` link with an inline newspaper icon and reuses `navLinkClass` so it inherits the existing color/active/hover states.
- Imported `Newspaper` from `lucide-react` and placed the icon inside a rounded bordered container that uses `currentColor` so it visually matches other icons and text.
- Replaced duplicated `Noticias` link instances across desktop and mobile sections with calls to `renderNewsLink` to keep markup consistent.
- Files touched: `src/components/navbar.tsx`.

### Testing
- Ran `pnpm lint`, which completed successfully; a preexisting Prettier warning remains in `src/app/api/users/[id]/children/[childId]/route.ts` and is unrelated to this change.
- Verified the component changes via static review of `src/components/navbar.tsx` for correct usage of `navLinkClass` and `renderNewsLink`; visual verification in a running browser was not performed in this patch.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6d4404e48328989f2c89e74bc4fc)