### PR TITLE
fix(news): guard news data load and add route error boundary

### DIFF
--- a/src/app/news/error.tsx
+++ b/src/app/news/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+export default function NewsError({ reset }: { reset: () => void }) {
+  return (
+    <main className="mx-auto max-w-3xl px-4 py-12">
+      <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center shadow-sm">
+        <p className="text-sm font-semibold uppercase tracking-wide text-destructive">
+          Noticias
+        </p>
+        <h1 className="mt-2 text-2xl font-bold tracking-tight">
+          No pudimos abrir la página de noticias
+        </h1>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Ocurrió un problema al cargar los comunicados. Probá de nuevo y, si el
+          error continúa, avisale a administración.
+        </p>
+        <button
+          type="button"
+          onClick={() => reset()}
+          className="mt-6 rounded-lg bg-primary px-4 py-2 text-sm font-semibold text-primary-foreground shadow-sm hover:opacity-90"
+        >
+          Reintentar
+        </button>
+      </div>
+    </main>
+  );
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
-import { NewsScope, type Prisma } from '@prisma/client';
+import type { Prisma, Role } from '@prisma/client';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getReadableActivityIds, isNewsAdminRole } from '@/lib/news-access';
@@ -14,6 +14,16 @@ type NewsWithRelations = Prisma.NewsGetPayload<{
     media: true;
   };
 }>;
+
+type ActivityOption = {
+  id: string;
+  name: string;
+};
+
+type NewsPageData = {
+  news: NewsWithRelations[];
+  activities: ActivityOption[];
+};
 
 function formatDate(date: Date) {
   return new Intl.DateTimeFormat('es-AR', {
@@ -28,34 +38,32 @@ function creatorName(news: NewsWithRelations) {
   return parts.length > 0 ? parts.join(' ') : 'Administración';
 }
 
-export default async function NewsPage() {
-  const session = await getServerSession(authOptions);
-  if (!session?.user) {
-    redirect('/login');
-  }
+async function loadNewsPageData({
+  isAdmin,
+  userId,
+  role,
+}: {
+  isAdmin: boolean;
+  userId: string;
+  role: Role;
+}): Promise<NewsPageData> {
+  const readableActivityIds = await getReadableActivityIds({ userId, role });
 
-  const role = session.user.activeRole ?? session.user.role;
-  const isAdmin = isNewsAdminRole(role);
-  const readableActivityIds = await getReadableActivityIds({
-    userId: session.user.id,
-    role,
-  });
+  const readableActivityWhere: Prisma.NewsWhereInput[] = [
+    { scope: 'CLUB' },
+    ...(readableActivityIds && readableActivityIds.length > 0
+      ? [
+          {
+            scope: 'ACTIVITY' as const,
+            activityId: { in: readableActivityIds },
+          },
+        ]
+      : []),
+  ];
 
   const where: Prisma.NewsWhereInput = isAdmin
     ? {}
-    : {
-        OR: [
-          { scope: NewsScope.CLUB },
-          ...(readableActivityIds && readableActivityIds.length > 0
-            ? [
-                {
-                  scope: NewsScope.ACTIVITY,
-                  activityId: { in: readableActivityIds },
-                },
-              ]
-            : []),
-        ],
-      };
+    : { OR: readableActivityWhere };
 
   const [news, activities] = await Promise.all([
     prisma.news.findMany({
@@ -76,6 +84,34 @@ export default async function NewsPage() {
       : Promise.resolve([]),
   ]);
 
+  return { news, activities };
+}
+
+export default async function NewsPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    redirect('/login');
+  }
+
+  const role = session.user.activeRole ?? session.user.role;
+  const isAdmin = isNewsAdminRole(role);
+
+  let pageData: NewsPageData;
+  let loadError = false;
+  try {
+    pageData = await loadNewsPageData({
+      isAdmin,
+      userId: session.user.id,
+      role,
+    });
+  } catch (err) {
+    console.error('[news] failed to render news page', err);
+    loadError = true;
+    pageData = { news: [], activities: [] };
+  }
+
+  const { news, activities } = pageData;
+
   return (
     <main className="mx-auto max-w-5xl space-y-6 px-4 py-8">
       <header className="space-y-2">
@@ -90,7 +126,17 @@ export default async function NewsPage() {
 
       {isAdmin && <CreateNewsForm activities={activities} />}
 
-      {news.length === 0 ? (
+      {loadError ? (
+        <div className="rounded-2xl border border-destructive/30 bg-destructive/5 p-8 text-center shadow-sm">
+          <h2 className="text-lg font-semibold text-destructive">
+            No pudimos cargar las noticias
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Intentá actualizar la página en unos minutos. Si el problema
+            continúa, avisale a administración.
+          </p>
+        </div>
+      ) : news.length === 0 ? (
         <div className="rounded-2xl border bg-card p-8 text-center shadow-sm">
           <h2 className="text-lg font-semibold">Todavía no hay noticias</h2>
           <p className="mt-1 text-sm text-muted-foreground">


### PR DESCRIPTION
### Motivation
- Prevent the generic Server Components render error on `/news` when the Prisma query or underlying data access fails, and provide a clear, recoverable UI instead of an opaque production error.

### Description
- Extracted the news/activities Prisma query into a guarded helper `loadNewsPageData` and replaced runtime enum usage with typed string filters to avoid type/runtime mismatches in Server Components.
- Wrapped the data load in `try/catch` and surface a friendly in-page fallback when loading fails, controlled by a `loadError` flag.
- Added a route-level error boundary at `src/app/news/error.tsx` that shows a user-facing message and a `Reintentar` (retry) button.
- Files touched: `src/app/news/page.tsx`, `src/app/news/error.tsx`.

### Testing
- `pnpm lint` — passed; a preexisting Prettier warning remains in `src/app/api/users/[id]/children/[childId]/route.ts` and is unrelated to this change.
- `pnpm exec tsc --noEmit --pretty false` — the type check run failed due to unrelated test type errors in `tests/api/pickup-notices.test.ts`, and there are no remaining type errors in `src/app/news/page.tsx` after the change.
- `pnpm build` — failed in this environment because Next.js could not fetch the Google font `Chivo` from `fonts.googleapis.com` (network/environment limitation), not because of the `/news` changes.
- Unresolved risks: database/migration problems (missing News tables) will still prevent news from loading even though the page now shows a friendly error; the route requires an authenticated session so reproducing locally needs a valid user; unrelated test/type failures remain in the repo and should be addressed separately.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb6fc47a5c83288b9427c69473a7b2)