### PR TITLE
Fix news icon styling and my payments resilience

### DIFF
--- a/src/app/my-payments/page.tsx
+++ b/src/app/my-payments/page.tsx
@@ -4,6 +4,7 @@ import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
 import { formatAmount } from '@/lib/accounting';
 import { buildProfessorInvoiceFileUrl } from '@/lib/blob-urls';
+import type { ProfessorInvoice } from '@prisma/client';
 import ProfessorInvoicesPanel from '@/components/accounting/professor-invoices-panel';
 
 const MONTHS = [
@@ -24,24 +25,29 @@ const MONTHS = [
 export default async function MyPaymentsPage() {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as any)?.id;
-  const role = (session?.user as any)?.role;
+  const role =
+    (session?.user as any)?.activeRole ?? (session?.user as any)?.role;
 
   if (!userId || role !== 'PROFESSOR') redirect('/');
 
-  const [profile, invoices] = await Promise.all([
-    prisma.professorProfile.findUnique({
-      where: { userId },
-      include: {
-        payments: {
-          orderBy: [{ periodYear: 'desc' }, { periodMonth: 'desc' }],
-        },
+  const profile = await prisma.professorProfile.findUnique({
+    where: { userId },
+    include: {
+      payments: {
+        orderBy: [{ periodYear: 'desc' }, { periodMonth: 'desc' }],
       },
-    }),
-    prisma.professorInvoice.findMany({
+    },
+  });
+
+  let invoices: ProfessorInvoice[] = [];
+  try {
+    invoices = await prisma.professorInvoice.findMany({
       where: { professorId: userId },
       orderBy: { createdAt: 'desc' },
-    }),
-  ]);
+    });
+  } catch (err) {
+    console.error('[my-payments] failed to load professor invoices', err);
+  }
 
   const invoiceRows = invoices.map((invoice) => ({
     id: invoice.id,

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -179,12 +179,11 @@ export default function Navbar() {
       className={cn(navLinkClass('/news'), 'inline-flex items-center gap-2')}
       onClick={onClick}
     >
-      <span
-        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border border-current/25 bg-current/10"
+      <Newspaper
+        className="h-5 w-5 shrink-0 text-current"
+        strokeWidth={2.2}
         aria-hidden="true"
-      >
-        <Newspaper className="h-5 w-5" strokeWidth={2.2} />
-      </span>
+      />
       <span>Noticias</span>
     </Link>
   );


### PR DESCRIPTION
### Motivation
- El ícono de Noticias en la barra de navegación tenía un recuadro que lo hacía distinto visualmente del resto de íconos; debe usar el mismo color que los demás enlaces de navegación.
- La página `/my-payments` podía fallar si la carga de facturas del profesor lanzaba una excepción o si `activeRole` no se respetaba, provocando errores de renderizado para profesores.

### Description
- Reemplacé el bloque con recuadro por el ícono directo en `src/components/navbar.tsx`, usando `Newspaper` con la clase `text-current` para que herede el color del link. (`src/components/navbar.tsx`)
- Hice que `/my-payments` use `activeRole` cuando esté presente para la verificación de rol. (`src/app/my-payments/page.tsx`)
- Separé la consulta de `professorInvoice` en un bloque `try/catch` para que la página muestre igualmente la información bancaria y el historial de pagos si falla la carga de facturas, y añadí el tipo `ProfessorInvoice` importado para clarificar el mapeo. (`src/app/my-payments/page.tsx`)
- Los archivos modificados son `src/components/navbar.tsx` y `src/app/my-payments/page.tsx`.

### Testing
- Ejecuté `pnpm lint --file src/components/navbar.tsx --file src/app/my-payments/page.tsx` y no arrojó advertencias ni errores. (éxito)
- Ejecuté `pnpm lint` a nivel de proyecto; pasó con una advertencia preexistente de `prettier` en `src/app/api/users/[id]/children/[childId]/route.ts`. (éxito con advertencia)
- Ejecuté `pnpm exec tsc --noEmit --pretty false`; hubo errores de tipado en tests existentes relacionados con `pickup-notices` (fallo por problemas previos al cambio). (fallo — no relacionado con estas modificaciones)
- Ejecuté `pnpm prisma:generate` con éxito y traté `pnpm build`, pero la compilación falló en este entorno por una imposibilidad de descargar la fuente Google `Chivo` usada por `next/font`. (fallo por entorno)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb727547f48328b4bbb62522a7d27c)