### PR TITLE
Make news nav icon celeste

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -180,7 +180,7 @@ export default function Navbar() {
       onClick={onClick}
     >
       <Newspaper
-        className="h-5 w-5 shrink-0 text-current"
+        className="h-5 w-5 shrink-0 text-primary"
         strokeWidth={2.2}
         aria-hidden="true"
       />


### PR DESCRIPTION
### Motivation
- El ícono de la sección “Noticias” estaba usando el color de texto actual oscuro y debe mostrarse en el color primario celeste al igual que otros iconos, manteniendo el texto tal como está.

### Description
- Cambié la clase del icono `Newspaper` en `src/components/navbar.tsx` de `text-current` a `text-primary` para aplicar el color celeste del sitio sin tocar el texto ni otros estilos.

### Testing
- Ejecuté `pnpm lint` y `git diff --check` (ambos OK; `pnpm lint` mostró una advertencia de Prettier preexistente en `src/app/api/users/[id]/children/[childId]/route.ts`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb760169888328820b0a425e99a41b)