### PR TITLE
Ajustar agenda semanal de Mis actividades

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -44,10 +44,7 @@ const MONTHS = [
   'Noviembre',
   'Diciembre',
 ];
-const COMPACT_DAY_OFFSETS = Array.from(
-  { length: 61 },
-  (_, index) => index - 14
-);
+const COMPACT_DAY_OFFSETS = Array.from({ length: 15 }, (_, index) => index - 7);
 
 type CalendarVariant = 'month' | 'professor-agenda' | 'member-agenda';
 
@@ -63,9 +60,10 @@ function addDays(date: Date, amount: number): Date {
 
 function formatDayTitle(date: Date, todayKey: string): string {
   const key = toLocalDateKey(date);
-  if (key === todayKey) return 'hoy';
+  const weekday = date.toLocaleDateString('es-AR', { weekday: 'long' });
+  if (key === todayKey) return `Hoy · ${weekday}`;
 
-  return date.toLocaleDateString('es-AR', { weekday: 'long' });
+  return weekday;
 }
 
 function getGoogleMapsHref(day: CalendarActivityDay): string {
@@ -412,7 +410,7 @@ export default function ActivityCalendar({
                   : 'Agenda de actividades'}
               </p>
               <p className="text-xs text-muted-foreground">
-                Deslizá para ver días anteriores o próximos.
+                Deslizá para ver hasta una semana atrás o adelante.
               </p>
             </div>
           </div>
@@ -425,6 +423,7 @@ export default function ActivityCalendar({
               {compactDays.map(({ date, key, activities }) => {
                 const isMainDay = key === activeCompactKey;
                 const title = formatDayTitle(date, todayKey);
+                const hasActivities = activities.length > 0;
                 const visibleActivities = activities.slice(
                   0,
                   isMainDay ? 3 : 2
@@ -437,15 +436,23 @@ export default function ActivityCalendar({
                       if (key === todayKey) todayCardRef.current = node;
                     }}
                     className={[
-                      'rounded-2xl border bg-background p-4 shadow-sm transition-all',
-                      isMainDay
+                      'rounded-2xl border bg-background shadow-sm transition-all',
+                      hasActivities ? 'p-4' : 'p-3',
+                      hasActivities && isMainDay
                         ? 'w-64 scale-[1.02] border-primary/50 shadow-md'
-                        : 'w-52 opacity-60',
+                        : '',
+                      hasActivities && !isMainDay ? 'w-52 opacity-60' : '',
+                      !hasActivities && isMainDay
+                        ? 'w-44 scale-[1.02] border-primary/30 opacity-80 shadow-md'
+                        : '',
+                      !hasActivities && !isMainDay ? 'w-32 opacity-50' : '',
                     ]
                       .filter(Boolean)
                       .join(' ')}
                   >
-                    <div className="mb-3 flex items-start justify-between gap-3">
+                    <div
+                      className={`${hasActivities ? 'mb-3' : 'mb-2'} flex items-start justify-between gap-3`}
+                    >
                       <div>
                         <p
                           className={`${isMainDay ? 'text-base' : 'text-sm'} font-bold text-foreground`}
@@ -462,8 +469,8 @@ export default function ActivityCalendar({
                     </div>
 
                     {visibleActivities.length === 0 ? (
-                      <p className="rounded-xl border border-dashed p-3 text-sm text-muted-foreground">
-                        Sin actividades programadas.
+                      <p className="rounded-lg border border-dashed px-2 py-1.5 text-xs leading-tight text-muted-foreground">
+                        Sin actividad.
                       </p>
                     ) : (
                       <div className="space-y-3">

--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -118,13 +118,17 @@ export default async function MyActivitiesPage() {
   let calendarDays: CalendarActivityDay[] = [];
   if (activityIds.length > 0) {
     try {
-      const sixMonthsLater = new Date();
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const oneWeekAgo = new Date(today);
+      oneWeekAgo.setDate(oneWeekAgo.getDate() - 7);
+      const sixMonthsLater = new Date(today);
       sixMonthsLater.setMonth(sixMonthsLater.getMonth() + 6);
       const raw = await prisma.activityDay.findMany({
         where: {
           activityId: { in: activityIds },
           date: {
-            gte: new Date(new Date().setHours(0, 0, 0, 0)),
+            gte: oneWeekAgo,
             lte: sixMonthsLater,
           },
           ...(isProfessorView ? { professors: { some: { userId } } } : {}),


### PR DESCRIPTION
### Motivation
- Permitir que padres/socios y profesores puedan desplazarse hasta una semana hacia atrás y una semana hacia adelante en la vista compacta de `my-activities` para ver sesiones recientes y próximas.
- Mejorar la legibilidad del carrusel compact: marcar el día actual con el nombre del día de la semana y reducir el espacio ocupado por días sin actividad para facilitar el scroll.

### Description
- Limita el rango del carrusel compacto a 15 días (una semana atrás .. hoy .. una semana adelante) cambiando `COMPACT_DAY_OFFSETS` de 61 a 15 en `src/app/my-activities/activity-calendar.tsx`.
- Cambia el título del día actual para mostrar `Hoy · <día de la semana>` mediante la función `formatDayTitle` en `src/app/my-activities/activity-calendar.tsx`.
- Reduce la presencia visual de tarjetas sin actividad ajustando padding/anchos y el texto a "Sin actividad." para ocupar menos espacio y facilitar llegar al siguiente día con actividad en `src/app/my-activities/activity-calendar.tsx`.
- Actualiza el texto de ayuda del carrusel para indicar el nuevo rango (una semana atrás/adelante) y modifica la consulta en `src/app/my-activities/page.tsx` para incluir sesiones desde una semana atrás (`gte: oneWeekAgo`).
- Files touched: `src/app/my-activities/activity-calendar.tsx`, `src/app/my-activities/page.tsx`.
- Unresolved risk: la vista mensual no se modificó y puede mostrar más rango; el cambio afecta solo el carrusel compacto y la consulta para cargar días recientes.

### Testing
- `pnpm lint` — pasó; existe una advertencia preexistente de Prettier en `src/app/api/users/[id]/children/[childId]/route.ts` que no está relacionada con estos cambios.
- `pnpm exec tsc --noEmit` — informó errores de tipos en varias áreas relacionadas con Prisma/client y pruebas existentes que son previas al cambio y no fueron introducidas por esta PR.
- `git diff --check` — sin conflictos reportados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb9318b00c832899152a75e42d0d67)