### PR TITLE
Fix attendance button labels

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -355,6 +355,37 @@ export default function ActivityCalendar({
     );
   }
 
+  function getAttendanceButtonState(status: AttendanceStatus) {
+    if (status === 'GOING') {
+      return {
+        nextStatus: 'NOT_GOING' as const,
+        label: 'Voy',
+        helper: 'Tocar para cambiar a No voy',
+        ariaPressed: true,
+        className: 'border-green-600 bg-green-50 text-green-700',
+      };
+    }
+
+    if (status === 'NOT_GOING') {
+      return {
+        nextStatus: 'GOING' as const,
+        label: 'No voy',
+        helper: 'Tocar para cambiar a Voy',
+        ariaPressed: false,
+        className: 'border-destructive bg-destructive/10 text-destructive',
+      };
+    }
+
+    return {
+      nextStatus: 'GOING' as const,
+      label: 'Confirmar que voy',
+      helper: 'Sin confirmar',
+      ariaPressed: false,
+      className:
+        'border-border bg-background text-muted-foreground hover:bg-muted',
+    };
+  }
+
   function handleCompactScroll() {
     if (scrollFrameRef.current !== null) {
       window.cancelAnimationFrame(scrollFrameRef.current);
@@ -518,6 +549,8 @@ export default function ActivityCalendar({
                                         const optionKey = `${day.id}:${option.participantId}`;
                                         const isSaving =
                                           savingAttendanceKey === optionKey;
+                                        const buttonState =
+                                          getAttendanceButtonState(status);
 
                                         return (
                                           <div key={option.participantId}>
@@ -530,25 +563,20 @@ export default function ActivityCalendar({
                                                 updateAttendance(
                                                   day.id,
                                                   option.participantId,
-                                                  status === 'NOT_GOING'
-                                                    ? 'GOING'
-                                                    : 'NOT_GOING'
+                                                  buttonState.nextStatus
                                                 )
                                               }
                                               aria-pressed={
-                                                status === 'NOT_GOING'
+                                                buttonState.ariaPressed
                                               }
-                                              className={`w-full rounded-full border px-3 py-1.5 text-left text-[11px] font-semibold transition-colors ${
-                                                status === 'NOT_GOING'
-                                                  ? 'border-destructive bg-destructive/10 text-destructive'
-                                                  : 'border-border bg-background text-muted-foreground hover:bg-muted'
-                                              } disabled:cursor-not-allowed disabled:opacity-60`}
+                                              className={`w-full rounded-full border px-3 py-1.5 text-left transition-colors ${buttonState.className} disabled:cursor-not-allowed disabled:opacity-60`}
                                             >
-                                              <span className="block truncate">
-                                                {status === 'NOT_GOING'
-                                                  ? 'Voy'
-                                                  : 'No voy'}{' '}
-                                                · {option.label}
+                                              <span className="block truncate text-[11px] font-semibold">
+                                                {buttonState.label} ·{' '}
+                                                {option.label}
+                                              </span>
+                                              <span className="block truncate text-[10px] font-medium opacity-75">
+                                                {buttonState.helper}
                                               </span>
                                             </button>
                                           </div>


### PR DESCRIPTION
### Motivation
- Users reported the attendance button showed the opposite text/color (e.g., red but labeled “Voy”), causing confusion, so the intent is to make the button reflect the current attendance state and clearly explain the toggle action.

### Description
- Add `getAttendanceButtonState` to map `AttendanceStatus` → `{ nextStatus, label, helper, ariaPressed, className }` and centralize visual/aria decisions.
- Replace the previous inline rendering for attendance buttons in `src/app/my-activities/activity-calendar.tsx` to use `buttonState.nextStatus` for the update action and `buttonState.label` / `buttonState.helper` / `buttonState.className` for display.
- Ensure `aria-pressed` follows the current logical state and make the pending state present as `Confirmar que voy` to avoid showing the opposite action.
- File modified: `src/app/my-activities/activity-calendar.tsx`.

### Testing
- Ran `pnpm exec prettier --write src/app/my-activities/activity-calendar.tsx` which formatted the file successfully.
- Ran `pnpm lint` which completed successfully and reported an unrelated Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts` that was not introduced by this change.
- Ran `git diff --check` and no issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb94d9aae08328a7b231946fb5f0af)