### PR TITLE
Permitir seleccionar desde galería al subir fotos de DNI de hijos

### DIFF
--- a/src/app/admin/users/[id]/child-enrollment/children.tsx
+++ b/src/app/admin/users/[id]/child-enrollment/children.tsx
@@ -214,7 +214,6 @@ export default function AdminChildrenManager({ userId }: { userId: string }) {
                 className={inputClass}
                 type="file"
                 accept="image/*"
-                capture="environment"
                 required={documentType === 'DNI'}
                 onChange={async (e) => {
                   const file = e.target.files?.[0];
@@ -229,7 +228,6 @@ export default function AdminChildrenManager({ userId }: { userId: string }) {
                 className={inputClass}
                 type="file"
                 accept="image/*"
-                capture="environment"
                 required={documentType === 'DNI'}
                 onChange={async (e) => {
                   const file = e.target.files?.[0];

--- a/src/app/admin/users/[id]/children/[childId]/edit/form.tsx
+++ b/src/app/admin/users/[id]/children/[childId]/edit/form.tsx
@@ -203,7 +203,6 @@ export default function EditChildForm({
             className={inputClass}
             type="file"
             accept="image/*"
-            capture="environment"
             onChange={async (e) => {
               const file = e.target.files?.[0];
               if (!file) return;
@@ -217,7 +216,6 @@ export default function EditChildForm({
             className={inputClass}
             type="file"
             accept="image/*"
-            capture="environment"
             onChange={async (e) => {
               const file = e.target.files?.[0];
               if (!file) return;

--- a/src/app/profile/children.tsx
+++ b/src/app/profile/children.tsx
@@ -277,7 +277,6 @@ export default function ChildrenManager({
               className={inputClass}
               type="file"
               accept="image/*"
-              capture="environment"
               required={
                 form.documentType === 'DNI' &&
                 !editingId &&
@@ -299,7 +298,6 @@ export default function ChildrenManager({
               className={inputClass}
               type="file"
               accept="image/*"
-              capture="environment"
               required={
                 form.documentType === 'DNI' &&
                 !editingId &&

--- a/src/app/profile/children/add-child-form.tsx
+++ b/src/app/profile/children/add-child-form.tsx
@@ -198,7 +198,6 @@ export default function AddChildForm({ userAddress }: { userAddress: string }) {
             className={inputClass}
             type="file"
             accept="image/*"
-            capture="environment"
             onChange={async (e) => {
               const file = e.target.files?.[0];
               if (!file) return;
@@ -215,7 +214,6 @@ export default function AddChildForm({ userAddress }: { userAddress: string }) {
             className={inputClass}
             type="file"
             accept="image/*"
-            capture="environment"
             onChange={async (e) => {
               const file = e.target.files?.[0];
               if (!file) return;


### PR DESCRIPTION
### Motivation
- En móviles el atributo `capture="environment"` forzaba abrir la cámara y evitaba que el usuario pudiera elegir una imagen desde la galería; esto rompe el flujo de agregar hijo desde dispositivos donde el usuario quiere usar una foto existente.

### Description
- Eliminé el atributo `capture="environment"` de los inputs `type="file" accept="image/*"` usados para las fotos delantera/trasera del DNI en los formularios de alta/edición de hijos y en el flujo admin, dejando que el navegador ofrezca cámara o galería según el dispositivo. 
- Archivos modificados: `src/app/profile/children/add-child-form.tsx`, `src/app/profile/children.tsx`, `src/app/admin/users/[id]/child-enrollment/children.tsx`, `src/app/admin/users/[id]/children/[childId]/edit/form.tsx`.

### Testing
- Ejecuté `pnpm lint` y la tarea terminó correctamente con warnings de Prettier en archivos no relacionados (warnings preexistentes). 
- Verifiqué `git diff --check` y el commit se creó con el mensaje `Allow gallery upload for child documents`.
- Riesgo no resuelto: no se probó en un dispositivo móvil físico desde este entorno, por lo que queda pendiente validar la experiencia en iOS/Android reales para confirmar que el selector muestra galería y cámara según lo esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba4d3c008832893410fc535b28cda)