### PR TITLE
Redirect new registrations to profile onboarding

### DIFF
--- a/src/app/api/auth/post-login-redirect/route.ts
+++ b/src/app/api/auth/post-login-redirect/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { authOptions } from '@/lib/auth';
 import { isCounterRole } from '@/lib/accounting';
 import { prisma } from '@/lib/prisma';
+import { checkUserProfile } from '@/lib/participant-profile-check';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
@@ -17,7 +18,18 @@ export async function GET() {
 
   const userId = session.user.id;
 
-  const [participantCount, professorCount] = await Promise.all([
+  const [user, participantCount, professorCount] = await Promise.all([
+    prisma.user.findUnique({
+      where: { id: userId },
+      select: {
+        name: true,
+        lastName: true,
+        dni: true,
+        birthDate: true,
+        address: true,
+        phone: true,
+      },
+    }),
     prisma.activityParticipant.count({
       where: {
         OR: [{ userId }, { child: { userId } }],
@@ -25,6 +37,10 @@ export async function GET() {
     }),
     prisma.activityProfessor.count({ where: { userId } }),
   ]);
+
+  if (user && !checkUserProfile(user).valid) {
+    return NextResponse.json({ redirectUrl: '/profile?onboarding=1' });
+  }
 
   const hasActivities = participantCount > 0 || professorCount > 0;
 

--- a/src/app/profile/form.tsx
+++ b/src/app/profile/form.tsx
@@ -152,38 +152,41 @@ export default function ProfileForm({
     <Form onSubmit={submit} className="space-y-3" autoComplete="on">
       <div className="grid grid-cols-2 gap-3">
         <label className="space-y-1 text-sm">
-          <span className="text-muted-foreground">Nombre</span>
+          <span className="text-muted-foreground">Nombre *</span>
           <input
             className={inputClass}
             name="given-name"
             autoComplete="given-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
+            required
           />
         </label>
         <label className="space-y-1 text-sm">
-          <span className="text-muted-foreground">Apellido</span>
+          <span className="text-muted-foreground">Apellido *</span>
           <input
             className={inputClass}
             name="family-name"
             autoComplete="family-name"
             value={lastName}
             onChange={(e) => setLastName(e.target.value)}
+            required
           />
         </label>
       </div>
       <label className="space-y-1 text-sm">
-        <span className="text-muted-foreground">DNI</span>
+        <span className="text-muted-foreground">DNI *</span>
         <input
           className={inputClass}
           name="national-id"
           autoComplete="off"
           value={dni}
           onChange={(e) => setDni(e.target.value)}
+          required
         />
       </label>
       <label className="space-y-1 text-sm">
-        <span className="text-muted-foreground">Fecha de nacimiento</span>
+        <span className="text-muted-foreground">Fecha de nacimiento *</span>
         <input
           className={inputClass}
           name="birth-date"
@@ -191,6 +194,7 @@ export default function ProfileForm({
           type="date"
           value={birthDate}
           onChange={(e) => setBirthDate(e.target.value)}
+          required
         />
       </label>
       <label className="space-y-1 text-sm">
@@ -209,17 +213,18 @@ export default function ProfileForm({
         </select>
       </label>
       <label className="space-y-1 text-sm">
-        <span className="text-muted-foreground">Domicilio</span>
+        <span className="text-muted-foreground">Domicilio *</span>
         <input
           className={inputClass}
           name="street-address"
           autoComplete="street-address"
           value={address}
           onChange={(e) => setAddress(e.target.value)}
+          required
         />
       </label>
       <label className="space-y-1 text-sm">
-        <span className="text-muted-foreground">Teléfono</span>
+        <span className="text-muted-foreground">Teléfono *</span>
         <input
           className={inputClass}
           name="tel"
@@ -227,6 +232,7 @@ export default function ProfileForm({
           autoComplete="tel"
           value={phone}
           onChange={(e) => setPhone(e.target.value)}
+          required
         />
       </label>
       <label className="space-y-1 text-sm">

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -4,11 +4,12 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import ProfileForm from './form';
 import ProfilePhotoUpload from './profile-photo-upload';
+import { checkUserProfile } from '@/lib/participant-profile-check';
 
 export default async function ProfilePage({
   searchParams,
 }: {
-  searchParams?: { returnTo?: string };
+  searchParams?: { returnTo?: string; onboarding?: string };
 }) {
   const session = await getServerSession(authOptions);
   if (!session) {
@@ -48,6 +49,10 @@ export default async function ProfilePage({
     searchParams.returnTo.startsWith('/')
       ? searchParams.returnTo
       : null;
+  const profileCheck = checkUserProfile(user);
+  const showOnboarding =
+    searchParams?.onboarding === '1' || !profileCheck.valid;
+
   return (
     <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
       <div className="rounded-2xl border bg-card p-6 shadow-sm">
@@ -67,6 +72,15 @@ export default async function ProfilePage({
           </div>
         </div>
       </div>
+      {showOnboarding && (
+        <div className="rounded-xl border border-primary/30 bg-primary/5 p-4 text-sm text-primary">
+          <p className="font-semibold">Completá tus datos obligatorios</p>
+          <p className="mt-1 text-primary/80">
+            Para terminar el alta, cargá nombre, apellido, DNI, fecha de
+            nacimiento, domicilio y teléfono.
+          </p>
+        </div>
+      )}
       <div className="rounded-xl border bg-card p-6 shadow-sm">
         <ProfileForm
           user={{

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { FormEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import Image from 'next/image';
 import { Button } from '@/components/ui/button';
@@ -16,6 +17,7 @@ export default function RegisterPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
+  const router = useRouter();
   const t = useTranslation().auth;
 
   const inputClass =
@@ -37,10 +39,26 @@ export default function RegisterPage() {
         body: JSON.stringify(parsed.data),
       });
       if (!res.ok) throw new Error('Request failed');
-      setSuccess('Registro exitoso');
+
+      const loginRes = await signIn('credentials', {
+        email: parsed.data.email.toLowerCase(),
+        password: parsed.data.password,
+        redirect: false,
+      });
+
+      if (loginRes?.error) {
+        setSuccess(
+          'Registro exitoso. Iniciá sesión para completar tu perfil obligatorio.'
+        );
+        router.push('/login');
+        return;
+      }
+
+      setSuccess('Registro exitoso. Te llevamos a completar tu perfil.');
       setEmail('');
       setPassword('');
       setName('');
+      router.push('/profile?onboarding=1');
     } catch (e) {
       setError('Registration failed');
     }
@@ -125,7 +143,9 @@ export default function RegisterPage() {
 
           <Button
             className="w-full flex items-center justify-center gap-2 bg-white border border-border text-foreground hover:bg-muted"
-            onClick={() => signIn('google', { callbackUrl: '/' })}
+            onClick={() =>
+              signIn('google', { callbackUrl: '/profile?onboarding=1' })
+            }
           >
             <Image src="/google.svg" alt="Google logo" width={18} height={18} />
             Registrarse con Google


### PR DESCRIPTION
### Motivation
- Forzar que usuarios nuevos completen los datos básicos obligatorios tras el registro para evitar perfiles incompletos al usar funcionalidades del sitio.  
- Que el flujo funcione tanto para registro por credenciales como por Google y que el redireccionamiento también ocurra tras el login si el perfil está incompleto.  

### Description
- After credential registration the app now signs in the user and redirects to `/profile?onboarding=1` to complete required profile fields, falling back to `/login` when automatic sign-in fails (`src/app/register/page.tsx`).  
- Google signup from the register page is routed to the onboarding callback (`/profile?onboarding=1`) so Google users land on the profile form after auth (`src/app/register/page.tsx`).  
- The post-login redirect endpoint now checks profile completeness using `checkUserProfile` and responds with a redirect to `/profile?onboarding=1` when required fields are missing (`src/app/api/auth/post-login-redirect/route.ts`).  
- The profile page shows an onboarding notice when the user arrives with `onboarding=1` or has an incomplete profile, and the profile form marks the basic fields (name, last name, DNI, birth date, address, phone) as required in the UI (`src/app/profile/page.tsx`, `src/app/profile/form.tsx`).  

### Testing
- Ran `git diff --check` (no issues).  
- Ran `pnpm lint` (passed; there is a preexisting Prettier warning in `src/app/api/users/[id]/children/[childId]/route.ts` unrelated to this change).  
- Ran `pnpm exec tsc --noEmit` which reported existing unrelated type errors in other parts of the repo (not caused by these changes) so full type-check did not pass.  
- Ran `pnpm test -- --runInBand` and observed failing test suites that are preexisting and unrelated to the edited files (pickup-notices/manual-payment/accounting/cart tests); the modified routes and profile form were exercised where applicable but global test suite fails prevent full green run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fba8b1430083288367acfe3b5b00f0)