### PR TITLE
Restaurar botón 'Ver sesión' en calendario para profesores

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -59,6 +59,7 @@ interface ActivityDaysPanelProps {
   canManageDays: boolean;
   hideSessionDetails?: boolean;
   hideSessionList?: boolean;
+  canOpenSessionDetails?: boolean;
   professors: ProfessorOption[];
   groups: GroupOption[];
   defaultProfessorIds: string[];
@@ -70,6 +71,7 @@ export default function ActivityDaysPanel({
   activityId,
   canManageDays,
   hideSessionDetails = false,
+  canOpenSessionDetails = false,
   professors,
   groups,
   defaultProfessorIds,
@@ -152,6 +154,8 @@ export default function ActivityDaysPanel({
             {showCalendar && (
               <ActivityCalendar
                 activityDays={calendarDays}
+                enableSessionDetailLinks={canOpenSessionDetails}
+                sessionDetailLabel="Ver sesión"
                 onEdit={
                   canManageDays
                     ? (dayId) =>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -502,6 +502,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           <ActivityDaysPanel
             activityId={activity.id}
             canManageDays={canManageDays}
+            canOpenSessionDetails={isAdmin || isProfessor}
             hideSessionDetails={hideSessionDetails}
             hideSessionList={hideSessionList}
             professors={professorOptions}

--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -148,11 +148,15 @@ export default function ActivityCalendar({
   onDaySelect,
   onEdit,
   variant = 'month',
+  enableSessionDetailLinks = false,
+  sessionDetailLabel = 'Ver detalle',
 }: {
   activityDays: CalendarActivityDay[];
   onDaySelect?: (dayId: string | null) => void;
   onEdit?: (dayId: string) => void;
   variant?: CalendarVariant;
+  enableSessionDetailLinks?: boolean;
+  sessionDetailLabel?: string;
 }) {
   const today = useMemo(() => new Date(), []);
   const todayKey = toLocalDateKey(today);
@@ -398,6 +402,8 @@ export default function ActivityCalendar({
   }
 
   const selectedActivities = selectedKey ? (dayMap.get(selectedKey) ?? []) : [];
+  const shouldLinkToSessionPage =
+    variant === 'professor-agenda' || enableSessionDetailLinks || !!onEdit;
 
   return (
     <div className="space-y-3">
@@ -534,7 +540,7 @@ export default function ActivityCalendar({
                                       prefetch={true}
                                       className="inline-flex text-xs font-semibold text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary"
                                     >
-                                      Ver detalle
+                                      {sessionDetailLabel}
                                     </Link>
                                   )}
                                 </div>
@@ -770,7 +776,7 @@ export default function ActivityCalendar({
                       </p>
                     </div>
                   </div>
-                  {(variant !== 'month' || onEdit) && (
+                  {(variant !== 'month' || shouldLinkToSessionPage) && (
                     <div className="mt-2 flex gap-2">
                       {variant === 'member-agenda' ? (
                         <button
@@ -786,7 +792,7 @@ export default function ActivityCalendar({
                           prefetch={true}
                           className="shrink-0 rounded-full border border-primary px-3 py-1 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
                         >
-                          Ver detalle
+                          {sessionDetailLabel}
                         </Link>
                       )}
                       {onEdit && (

--- a/src/app/my-activities/page.tsx
+++ b/src/app/my-activities/page.tsx
@@ -292,6 +292,7 @@ export default async function MyActivitiesPage() {
       <ActivityCalendar
         activityDays={calendarDays}
         variant={isProfessorView ? 'professor-agenda' : 'member-agenda'}
+        sessionDetailLabel={isProfessorView ? 'Ver sesión' : 'Ver detalle'}
       />
     </main>
   );


### PR DESCRIPTION
### Motivation

- Los profesores perdieron el acceso directo desde el calendario a la pantalla completa de la sesión donde están `Asistencia`, `Observación y planificación`, `Descripción` e `Información`, por lo que es necesario restaurar el CTA que abre la vista de sesión.
- Restaurar el comportamiento para que la agenda de profesor muestre explícitamente “Ver sesión” mientras que la vista de socios mantiene el modal/“Ver detalle”.

### Description

- Añadí propiedades configurables a `ActivityCalendar` (`enableSessionDetailLinks`, `sessionDetailLabel`) y calculo `shouldLinkToSessionPage` para decidir cuándo mostrar un enlace a la pantalla de sesión en lugar del modal de detalle. (fichero `src/app/my-activities/activity-calendar.tsx`).
- Hice que `ActivityDaysPanel` acepte `canOpenSessionDetails` y que, cuando corresponda, le pase `enableSessionDetailLinks` y la etiqueta `sessionDetailLabel` al calendario para habilitar el CTA «Ver sesión». (fichero `src/app/activities/[id]/activity-days-panel.tsx`).
- Pasé la etiqueta `sessionDetailLabel` desde la página `My Activities` para usar `“Ver sesión”` en la vista de profesor y mantener `“Ver detalle”` para socios. (fichero `src/app/my-activities/page.tsx`).
- Habilité `canOpenSessionDetails` en la página de actividad para administradores y profesores, de modo que la agenda de la actividad muestre el CTA correcto cuando corresponda. (fichero `src/app/activities/[id]/page.tsx`).

### Testing

- Ejecuté `pnpm lint` y la comprobación pasó; quedó registrada una advertencia preexistente de Prettier en `src/app/api/users/[id]/children/[childId]/route.ts`.
- Ejecuté `pnpm exec tsc --noEmit` y falló por errores de TypeScript preexistentes en otras áreas del proyecto (notificaciones y tests de pickup notices) que no están relacionados con este cambio.
- Verifiqué el diff localmente y corregí conflictos de formato; no se introdujeron advertencias nuevas en los archivos modificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbabf6a62c832889b88678003ac570)