### PR TITLE
Hacer 'Días y horarios' minimizable y mostrar resumen de asistencia por participante

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -139,6 +139,12 @@ export default async function ProfessorStudentsPage() {
               },
             },
           },
+          attendances: {
+            select: {
+              activityParticipantId: true,
+              status: true,
+            },
+          },
         },
       },
       members: {
@@ -341,7 +347,36 @@ export default async function ProfessorStudentsPage() {
       }
     >();
 
+    const attendanceSummaryByParticipantId = new Map<
+      string,
+      { attended: number; missed: number }
+    >();
+
     for (const day of group.days) {
+      for (const attendance of day.attendances) {
+        if (
+          attendance.status !== 'GOING' &&
+          attendance.status !== 'NOT_GOING'
+        ) {
+          continue;
+        }
+
+        const summary = attendanceSummaryByParticipantId.get(
+          attendance.activityParticipantId
+        ) ?? { attended: 0, missed: 0 };
+
+        if (attendance.status === 'GOING') {
+          summary.attended += 1;
+        } else {
+          summary.missed += 1;
+        }
+
+        attendanceSummaryByParticipantId.set(
+          attendance.activityParticipantId,
+          summary
+        );
+      }
+
       for (const professor of day.professors) {
         const existing = professorsById.get(professor.userId);
         if (existing) {
@@ -392,6 +427,12 @@ export default async function ProfessorStudentsPage() {
               name: formatFullName(participant.child),
               age: calculateAge(participant.child.birthDate),
               responsibleName: formatFullName(participant.user),
+              attendanceSummary: attendanceSummaryByParticipantId.get(
+                participant.id
+              ) ?? {
+                attended: 0,
+                missed: 0,
+              },
             };
           }
 
@@ -401,6 +442,12 @@ export default async function ProfessorStudentsPage() {
             name: formatFullName(participant.user),
             age: calculateAge(participant.user.birthDate),
             responsibleName: null,
+            attendanceSummary: attendanceSummaryByParticipantId.get(
+              participant.id
+            ) ?? {
+              attended: 0,
+              missed: 0,
+            },
           };
         })
         .sort((a, b) => a.name.localeCompare(b.name, 'es')),

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -41,6 +41,10 @@ export type ProfessorGroupEntry = {
     name: string;
     age: number | null;
     responsibleName: string | null;
+    attendanceSummary: {
+      attended: number;
+      missed: number;
+    };
   }[];
 };
 
@@ -168,6 +172,7 @@ export default function StudentsSearch({
   const [query, setQuery] = useState('');
   const [participantsExpanded, setParticipantsExpanded] = useState(false);
   const [professorsExpanded, setProfessorsExpanded] = useState(false);
+  const [schedulesExpanded, setSchedulesExpanded] = useState(false);
 
   const visible = useMemo(() => {
     const q = query.trim();
@@ -181,6 +186,7 @@ export default function StudentsSearch({
   useEffect(() => {
     setParticipantsExpanded(false);
     setProfessorsExpanded(false);
+    setSchedulesExpanded(false);
   }, [selectedGroupId]);
 
   return (
@@ -521,7 +527,22 @@ export default function StudentsSearch({
                                   </p>
                                 )}
                               </div>
-                              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                              <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                                <span
+                                  className="inline-flex items-center rounded-md border bg-background px-2 py-0.5 font-semibold"
+                                  aria-label={`${participant.attendanceSummary.attended} sesiones asistidas y ${participant.attendanceSummary.missed} inasistencias`}
+                                  title="Asistió / no vino"
+                                >
+                                  <span className="text-emerald-600">
+                                    {participant.attendanceSummary.attended}
+                                  </span>
+                                  <span className="mx-1 text-muted-foreground">
+                                    /
+                                  </span>
+                                  <span className="text-destructive">
+                                    {participant.attendanceSummary.missed}
+                                  </span>
+                                </span>
                                 <span className="rounded-full bg-muted px-2 py-0.5">
                                   {participant.type === 'child'
                                     ? 'Alumno'
@@ -628,35 +649,71 @@ export default function StudentsSearch({
                   </div>
 
                   <div className="rounded-xl border bg-background p-4">
-                    <h3 className="font-medium">Días y horarios</h3>
-                    {selectedGroup.schedules.length === 0 ? (
-                      <p className="mt-2 text-sm text-muted-foreground">
-                        Este grupo todavía no tiene días cargados.
-                      </p>
-                    ) : (
-                      <ul className="mt-3 space-y-2">
-                        {selectedGroup.schedules.map((day) => (
-                          <li
-                            key={day.id}
-                            className="rounded-lg bg-muted/60 p-3 text-sm"
-                          >
-                            <div className="flex items-center justify-between gap-3">
-                              <span className="font-medium capitalize">
-                                {formatScheduleDay(day)}
-                              </span>
-                              {day.cancelled && (
-                                <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
-                                  Cancelado
+                    <button
+                      type="button"
+                      className="flex w-full items-center justify-between gap-3 text-left"
+                      onClick={() =>
+                        setSchedulesExpanded((expanded) => !expanded)
+                      }
+                      aria-expanded={schedulesExpanded}
+                      aria-controls="group-schedules-list"
+                    >
+                      <span className="font-medium">Días y horarios</span>
+                      <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                        {selectedGroup.schedules.length} día
+                        {selectedGroup.schedules.length === 1 ? '' : 's'}
+                        <svg
+                          className={`h-4 w-4 transition-transform ${
+                            schedulesExpanded ? 'rotate-180' : ''
+                          }`}
+                          xmlns="http://www.w3.org/2000/svg"
+                          fill="none"
+                          viewBox="0 0 24 24"
+                          strokeWidth={1.5}
+                          stroke="currentColor"
+                          aria-hidden="true"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            d="m19.5 8.25-7.5 7.5-7.5-7.5"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                    <div
+                      id="group-schedules-list"
+                      className={`${schedulesExpanded ? 'block' : 'hidden'}`}
+                    >
+                      {selectedGroup.schedules.length === 0 ? (
+                        <p className="mt-2 text-sm text-muted-foreground">
+                          Este grupo todavía no tiene días cargados.
+                        </p>
+                      ) : (
+                        <ul className="mt-3 space-y-2">
+                          {selectedGroup.schedules.map((day) => (
+                            <li
+                              key={day.id}
+                              className="rounded-lg bg-muted/60 p-3 text-sm"
+                            >
+                              <div className="flex items-center justify-between gap-3">
+                                <span className="font-medium capitalize">
+                                  {formatScheduleDay(day)}
                                 </span>
-                              )}
-                            </div>
-                            <p className="text-muted-foreground">
-                              {day.schedule}
-                            </p>
-                          </li>
-                        ))}
-                      </ul>
-                    )}
+                                {day.cancelled && (
+                                  <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                                    Cancelado
+                                  </span>
+                                )}
+                              </div>
+                              <p className="text-muted-foreground">
+                                {day.schedule}
+                              </p>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
                   </div>
                 </section>
               )}


### PR DESCRIPTION
### Motivation
- Mejorar la UX en la pestaña “Mis grupos” de profesores haciendo el panel de “Días y horarios” consistente con los paneles ya minimizables de Participantes y Profesores, y mostrar rápidamente el historial de asistencia por participante (asistió / no vino). 

### Description
- Hice collapsible el recuadro "Días y horarios" en `/professor/students` usando el mismo patrón de botón, contador y flecha rotatoria que los paneles de Participantes y Profesores. 
- Añadí un resumen de asistencia por participante en el modelo pasado al cliente con la forma `{ attended, missed }` y mostré ese dato como un pequeño recuadro con el formato verde/rojo (asistió / no vino) al lado de la etiqueta de tipo/edad. 
- Incluí `attendances` en la consulta de `activityGroup.days` y agregué la lógica en el servidor para contar `GOING` como asistencias y `NOT_GOING` como inasistencias por `activityParticipantId`. 
- Files touched: `src/app/professor/students/page.tsx` and `src/app/professor/students/students-search.tsx`.

### Testing
- Ejecuté `pnpm exec prettier --check src/app/professor/students/page.tsx src/app/professor/students/students-search.tsx` y pasó correctamente. 
- Ejecuté `pnpm lint` y terminó sin errores de compilación (muestra advertencias Prettier en otros archivos no modificados). 
- Ejecuté `pnpm exec tsc --noEmit` y la compilación falla por errores de tipado en tests existentes (`tests/api/pickup-notices.test.ts`) que son previos a este cambio y no relacionados con la modificación actual. 
- Riesgos no resueltos: no hay captura visual porque requiere sesión de profesor y datos reales de grupos/asistencia, y los conteos sólo consideran `GOING`/`NOT_GOING` (ignoran `PENDING`) por diseño actual del sistema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd56992f148328ab67567e77151a4f)