### PR TITLE
Add reports tab to student history (professor view)

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -45,18 +45,22 @@ export default async function ProfessorStudentsPage() {
   if (!session) redirect('/login');
 
   const activeRole = session.user.activeRole ?? session.user.role;
-  if (activeRole !== 'PROFESSOR') redirect('/my-activities');
+  const isProfessor = activeRole === 'PROFESSOR';
+  const isAdmin = activeRole === 'ADMIN' || activeRole === 'SUPER_ADMIN';
+  if (!isProfessor && !isAdmin) redirect('/my-activities');
 
   const professorId = session.user.id;
 
-  const professorActivities = await prisma.activityProfessor.findMany({
-    where: { userId: professorId },
-    select: { activityId: true },
-  });
+  const professorActivities = isProfessor
+    ? await prisma.activityProfessor.findMany({
+        where: { userId: professorId },
+        select: { activityId: true },
+      })
+    : [];
 
   const activityIds = professorActivities.map((a) => a.activityId);
 
-  if (activityIds.length === 0) {
+  if (isProfessor && activityIds.length === 0) {
     return (
       <main className="mx-auto max-w-4xl px-4 py-8 space-y-4">
         <h1 className="text-2xl font-semibold tracking-tight">Mis alumnos</h1>
@@ -67,19 +71,28 @@ export default async function ProfessorStudentsPage() {
     );
   }
 
-  const assignedGroupDays = await prisma.activityDay.findMany({
-    where: {
-      activityId: { in: activityIds },
-      activityGroupId: { not: null },
-      professors: { some: { userId: professorId } },
-    },
-    select: { activityGroupId: true },
-    distinct: ['activityGroupId'],
-  });
-
-  const assignedGroupIds = assignedGroupDays
-    .map((day) => day.activityGroupId)
-    .filter((groupId): groupId is string => Boolean(groupId));
+  const assignedGroupIds = isAdmin
+    ? await prisma.activityGroupMember
+        .findMany({
+          select: { activityGroupId: true },
+          distinct: ['activityGroupId'],
+        })
+        .then((rows) => rows.map((row) => row.activityGroupId))
+    : await prisma.activityDay
+        .findMany({
+          where: {
+            activityId: { in: activityIds },
+            activityGroupId: { not: null },
+            professors: { some: { userId: professorId } },
+          },
+          select: { activityGroupId: true },
+          distinct: ['activityGroupId'],
+        })
+        .then((days) =>
+          days
+            .map((day) => day.activityGroupId)
+            .filter((groupId): groupId is string => Boolean(groupId))
+        );
 
   const groupMembers = await prisma.activityGroupMember.findMany({
     where: {
@@ -100,6 +113,9 @@ export default async function ProfessorStudentsPage() {
                   date: true,
                   schedule: true,
                   cancelled: true,
+                  planificacion: true,
+                  devolucion: true,
+                  activityGroupId: true,
                   activityGroup: { select: { name: true } },
                 },
               },
@@ -236,7 +252,26 @@ export default async function ProfessorStudentsPage() {
         confirmedAt: attendance.confirmedAt?.toISOString() ?? null,
         cancelled: attendance.activityDay.cancelled,
         groupName: attendance.activityDay.activityGroup?.name ?? null,
+        planificacion: attendance.activityDay.planificacion,
+        devolucion: attendance.activityDay.devolucion,
       })),
+      reports: participant.attendances
+        .filter(
+          (attendance) =>
+            attendance.activityDay.activityGroupId === gm.activityGroupId &&
+            Boolean(
+              attendance.activityDay.planificacion ||
+              attendance.activityDay.devolucion
+            )
+        )
+        .map((attendance) => ({
+          date: attendance.activityDay.date.toISOString(),
+          schedule: attendance.activityDay.schedule,
+          cancelled: attendance.activityDay.cancelled,
+          groupName: attendance.activityDay.activityGroup?.name ?? null,
+          planificacion: attendance.activityDay.planificacion,
+          devolucion: attendance.activityDay.devolucion,
+        })),
     };
   }
 

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -24,6 +24,16 @@ type StudentHistoryEntry = {
     confirmedAt: string | null;
     cancelled: boolean;
     groupName: string | null;
+    planificacion: string | null;
+    devolucion: string | null;
+  }[];
+  reports: {
+    date: string;
+    schedule: string;
+    cancelled: boolean;
+    groupName: string | null;
+    planificacion: string | null;
+    devolucion: string | null;
   }[];
 };
 
@@ -259,6 +269,9 @@ export default function StudentsSearch({
   const [schedulesExpanded, setSchedulesExpanded] = useState(false);
   const [historyStudent, setHistoryStudent] = useState<StudentEntry | null>(
     null
+  );
+  const [historyTab, setHistoryTab] = useState<'attendances' | 'reports'>(
+    'attendances'
   );
 
   const visible = useMemo(() => {
@@ -509,7 +522,10 @@ export default function StudentsSearch({
                             </Link>
                             <button
                               type="button"
-                              onClick={() => setHistoryStudent(student)}
+                              onClick={() => {
+                                setHistoryStudent(student);
+                                setHistoryTab('attendances');
+                              }}
                               className="inline-flex h-9 items-center gap-1.5 rounded-full border px-3 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                             >
                               <History className="h-4 w-4" />
@@ -868,8 +884,8 @@ export default function StudentsSearch({
                   {getStudentFullName(historyStudent)}
                 </h2>
                 <p className="text-sm text-muted-foreground">
-                  Actividades, grupos y asistencias registradas para este
-                  participante.
+                  Actividades, grupos, asistencias y reportes registrados para
+                  este participante.
                 </p>
               </div>
               <button
@@ -883,11 +899,44 @@ export default function StudentsSearch({
             </div>
 
             <div className="mt-5 space-y-4">
+              <div
+                className="flex flex-wrap gap-2 rounded-xl border bg-muted/30 p-1"
+                role="tablist"
+                aria-label="Secciones del historial"
+              >
+                <button
+                  type="button"
+                  onClick={() => setHistoryTab('attendances')}
+                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                    historyTab === 'attendances'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
+                  }`}
+                  role="tab"
+                  aria-selected={historyTab === 'attendances'}
+                >
+                  Asistencias
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setHistoryTab('reports')}
+                  className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
+                    historyTab === 'reports'
+                      ? 'bg-background text-foreground shadow-sm'
+                      : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
+                  }`}
+                  role="tab"
+                  aria-selected={historyTab === 'reports'}
+                >
+                  Reportes
+                </button>
+              </div>
+
               {historyStudent.history.length === 0 ? (
                 <p className="rounded-xl bg-muted p-4 text-sm text-muted-foreground">
                   No hay historial cargado para este participante.
                 </p>
-              ) : (
+              ) : historyTab === 'attendances' ? (
                 historyStudent.history.map((entry) => (
                   <section
                     key={entry.participantId}
@@ -943,6 +992,87 @@ export default function StudentsSearch({
                                 {formatHistoryDate(attendance.confirmedAt)}
                               </p>
                             )}
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+                ))
+              ) : historyStudent.history.every(
+                  (entry) => entry.reports.length === 0
+                ) ? (
+                <p className="rounded-xl bg-muted p-4 text-sm text-muted-foreground">
+                  No hay reportes cargados para este participante.
+                </p>
+              ) : (
+                historyStudent.history.map((entry) => (
+                  <section
+                    key={`${entry.participantId}-reports`}
+                    className="rounded-xl border bg-card p-4"
+                  >
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <h3 className="font-medium">{entry.activityName}</h3>
+                        <p className="text-sm text-muted-foreground">
+                          Grupo: {entry.groupName}
+                        </p>
+                      </div>
+                      <span className="rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+                        {entry.reports.length} reporte
+                        {entry.reports.length === 1 ? '' : 's'}
+                      </span>
+                    </div>
+
+                    {entry.reports.length === 0 ? (
+                      <p className="mt-3 text-sm text-muted-foreground">
+                        Sin reportes registrados en esta actividad.
+                      </p>
+                    ) : (
+                      <ul className="mt-3 space-y-3">
+                        {entry.reports.map((report) => (
+                          <li
+                            key={`${entry.participantId}-report-${report.date}-${report.schedule}`}
+                            className="rounded-lg bg-muted/60 p-3 text-sm"
+                          >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                              <span className="font-medium capitalize">
+                                {formatHistoryDate(report.date)}
+                              </span>
+                              {report.cancelled && (
+                                <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                                  Cancelado
+                                </span>
+                              )}
+                            </div>
+                            <p className="text-muted-foreground">
+                              {report.schedule}
+                              {report.groupName &&
+                              report.groupName !== entry.groupName
+                                ? ` · ${report.groupName}`
+                                : ''}
+                            </p>
+                            <div className="mt-3 space-y-3">
+                              {report.planificacion && (
+                                <div>
+                                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Planificación
+                                  </p>
+                                  <p className="mt-1 whitespace-pre-wrap text-foreground">
+                                    {report.planificacion}
+                                  </p>
+                                </div>
+                              )}
+                              {report.devolucion && (
+                                <div>
+                                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                    Devolución
+                                  </p>
+                                  <p className="mt-1 whitespace-pre-wrap text-foreground">
+                                    {report.devolucion}
+                                  </p>
+                                </div>
+                              )}
+                            </div>
                           </li>
                         ))}
                       </ul>


### PR DESCRIPTION
### Motivation
- Provide professors and admins a way to see day-level planning/devolution notes (reportes) alongside attendance in the participant history modal so session notes are discoverable per participant and per group.

### Description
- Allow `ADMIN` and `SUPER_ADMIN` to open the professor students page while keeping `PROFESSOR` users restricted to their assigned groups, and load professor activity IDs only for professors. (auth gating + conditional queries). (files: `src/app/professor/students/page.tsx`)
- Expand the history query to include `planificacion` and `devolucion` from `activityDay` and build a per-participant `reports` array filtered to the participant's group. (files: `src/app/professor/students/page.tsx`)
- Add an Asistencias/Reportes tab in the Historial modal, default the modal to the Asistencias tab when opened, and render report details (planificación / devolución) with empty-state handling. (files: `src/app/professor/students/students-search.tsx`)
- Minor UI/UX: reset history tab to `attendances` on modal open and expose reports only for the group where the participant is enrolled.

### Testing
- Ran `pnpm exec prettier --check src/app/professor/students/page.tsx src/app/professor/students/students-search.tsx` which passed for the modified files. (success)
- Ran project lint `pnpm lint`; linter completed but there are existing unrelated Prettier warnings elsewhere in the repo (no new lint errors from these changes). (completed with unrelated warnings)
- Ran TypeScript check `pnpm exec tsc --noEmit` which failed due to pre-existing test typing issues in `tests/api/pickup-notices.test.ts` not introduced by this PR, so full repo typecheck is blocked by unrelated tests. (failed — unrelated)
- Verified code formatting with `prettier --write` for edited files and committed the changes. (success)

Files touched:
- `src/app/professor/students/page.tsx`
- `src/app/professor/students/students-search.tsx

Unresolved risks:
- Global typechecking is failing due to unrelated test type errors, so CI type checks may fail until those are fixed.
- No browser/manual visual verification was performed in this environment, so small UI tweaks or styling adjustments may be needed after manual review.
- Loading `planificacion`/`devolucion` from many days could increase query size for very large activity histories; consider pagination or limiting scope if performance issues appear.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd5e5812608328a0c9af56f021051a)