### PR TITLE
Add per-day participant reports with UI and API

### DIFF
--- a/prisma/migrations/20260508120000_add_activity_participant_reports/migration.sql
+++ b/prisma/migrations/20260508120000_add_activity_participant_reports/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "ActivityParticipantReport" (
+    "id" TEXT NOT NULL,
+    "activityDayId" TEXT NOT NULL,
+    "activityParticipantId" TEXT NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "body" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "ActivityParticipantReport_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ActivityParticipantReport_activityDayId_activityParticipantId_key" ON "ActivityParticipantReport"("activityDayId", "activityParticipantId");
+
+-- CreateIndex
+CREATE INDEX "ActivityParticipantReport_activityParticipantId_idx" ON "ActivityParticipantReport"("activityParticipantId");
+
+-- CreateIndex
+CREATE INDEX "ActivityParticipantReport_createdById_idx" ON "ActivityParticipantReport"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipantReport" ADD CONSTRAINT "ActivityParticipantReport_activityDayId_fkey" FOREIGN KEY ("activityDayId") REFERENCES "ActivityDay"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipantReport" ADD CONSTRAINT "ActivityParticipantReport_activityParticipantId_fkey" FOREIGN KEY ("activityParticipantId") REFERENCES "ActivityParticipant"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ActivityParticipantReport" ADD CONSTRAINT "ActivityParticipantReport_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -66,6 +66,7 @@ model User {
   professorProfile            ProfessorProfile?
   professorPaymentsCreated    ProfessorPayment[]           @relation("ProfessorPaymentCreatedBy")
   professorInvoices           ProfessorInvoice[]           @relation("ProfessorInvoices")
+  createdParticipantReports   ActivityParticipantReport[]   @relation("ActivityParticipantReportCreatedBy")
   roleAssignments             UserRoleAssignment[]         @relation("UserRoleAssignmentUser")
   roleAssignmentsGranted      UserRoleAssignment[]         @relation("UserRoleAssignmentAssignedBy")
 }
@@ -189,6 +190,7 @@ model ActivityParticipant {
   groupMembership ActivityGroupMember?
   attendances     ActivityDayAttendance[]
   payments         ActivityParticipantPayment[]
+  reports          ActivityParticipantReport[]
 }
 
 model ActivityParticipantPayment {
@@ -285,6 +287,7 @@ model ActivityDay {
   professors         ActivityDayProfessor[]
   pickupNotices      PickupNotice[]
   participantPayments ActivityParticipantPayment[]
+  participantReports  ActivityParticipantReport[]
 
   @@index([activityId, date])
   @@index([activityGroupId])
@@ -316,6 +319,23 @@ model ActivityDayAttendance {
 
   @@unique([activityDayId, activityParticipantId])
   @@index([activityParticipantId])
+}
+
+model ActivityParticipantReport {
+  id                    String              @id @default(cuid())
+  activityDayId         String
+  activityParticipantId String
+  createdById           String
+  body                  String
+  createdAt             DateTime            @default(now())
+  updatedAt             DateTime            @updatedAt
+  activityDay           ActivityDay         @relation(fields: [activityDayId], references: [id], onDelete: Cascade)
+  activityParticipant   ActivityParticipant @relation(fields: [activityParticipantId], references: [id], onDelete: Cascade)
+  createdBy             User                @relation("ActivityParticipantReportCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
+
+  @@unique([activityDayId, activityParticipantId])
+  @@index([activityParticipantId])
+  @@index([createdById])
 }
 
 model PickupNotice {

--- a/src/app/activities/[id]/days/[dayId]/informacion/day-participant-contact-card.tsx
+++ b/src/app/activities/[id]/days/[dayId]/informacion/day-participant-contact-card.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { MessageCircle, X } from 'lucide-react';
+
+type ParticipantContact = {
+  id: string;
+  displayName: string;
+  isChild: boolean;
+  contactName: string;
+  contactUserId: string;
+  email: string | null;
+  phone: string | null;
+  existingReport: string | null;
+};
+
+function getWhatsAppHref(phone: string | null) {
+  if (!phone) return null;
+  const digits = phone.replace(/\D/g, '');
+  if (!digits) return null;
+  const withCountry = digits.startsWith('54') ? digits : `54${digits}`;
+  return `https://wa.me/${withCountry}`;
+}
+
+function WhatsAppLineIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.7}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M5.2 18.8 6.1 15A7.6 7.6 0 1 1 9 17.9l-3.8.9Z" />
+      <path d="M9.2 8.7c.2-.4.4-.4.7-.4h.5c.2 0 .4.1.5.4l.6 1.4c.1.2.1.4-.1.6l-.4.5c.5.9 1.2 1.6 2.2 2.1l.5-.5c.2-.2.4-.2.6-.1l1.4.7c.3.1.4.3.4.6v.4c0 .3-.1.5-.4.7-.4.3-1 .5-1.7.4-2.9-.4-5.1-2.6-5.5-5.4-.1-.6.1-1.2.4-1.6Z" />
+    </svg>
+  );
+}
+
+export default function DayParticipantContactCard({
+  activityId,
+  dayId,
+  participant,
+}: {
+  activityId: string;
+  dayId: string;
+  participant: ParticipantContact;
+}) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [body, setBody] = useState(participant.existingReport ?? '');
+  const [savedBody, setSavedBody] = useState(participant.existingReport ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const whatsappHref = getWhatsAppHref(participant.phone);
+
+  async function saveReport() {
+    const trimmed = body.trim();
+    if (!trimmed) {
+      setError('Escribí el reporte antes de guardar.');
+      setSuccess('');
+      return;
+    }
+
+    setSaving(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const res = await fetch(
+        `/api/activities/${activityId}/days/${dayId}/reports`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            activityParticipantId: participant.id,
+            body: trimmed,
+          }),
+        }
+      );
+
+      if (!res.ok) {
+        const payload = await res.json().catch(() => null);
+        throw new Error(payload?.error || 'No se pudo guardar el reporte.');
+      }
+
+      setSavedBody(trimmed);
+      setBody(trimmed);
+      setSuccess('Reporte guardado en el historial del participante.');
+      setIsOpen(false);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo guardar el reporte.'
+      );
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl border bg-card px-5 py-4 space-y-3">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <p className="font-semibold text-sm">{participant.displayName}</p>
+          {participant.isChild && participant.contactName && (
+            <p className="text-xs text-muted-foreground">
+              Responsable: {participant.contactName}
+            </p>
+          )}
+          <div className="flex flex-col gap-1">
+            {participant.email && (
+              <a
+                href={`mailto:${participant.email}`}
+                className="text-xs text-link hover:underline underline-offset-4"
+              >
+                {participant.email}
+              </a>
+            )}
+            {participant.phone && (
+              <a
+                href={`tel:${participant.phone}`}
+                className="text-xs text-link hover:underline underline-offset-4"
+              >
+                {participant.phone}
+              </a>
+            )}
+            {!participant.email && !participant.phone && (
+              <p className="text-xs text-muted-foreground italic">
+                Sin datos de contacto
+              </p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap gap-2 sm:justify-end">
+          {whatsappHref ? (
+            <a
+              href={whatsappHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={`Contactar por WhatsApp a ${participant.contactName || participant.displayName}`}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-emerald-500/30 text-emerald-700 transition-colors hover:bg-emerald-500/10"
+            >
+              <WhatsAppLineIcon className="h-4 w-4" />
+            </a>
+          ) : (
+            <span
+              aria-label="Sin teléfono para WhatsApp"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border text-muted-foreground opacity-40"
+            >
+              <WhatsAppLineIcon className="h-4 w-4" />
+            </span>
+          )}
+          <Link
+            href={`/chat?with=${participant.contactUserId}`}
+            aria-label={`Chatear con ${participant.contactName || participant.displayName}`}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-full border text-primary transition-colors hover:bg-primary/10"
+          >
+            <MessageCircle className="h-4 w-4" />
+          </Link>
+          <button
+            type="button"
+            onClick={() => {
+              setBody(savedBody);
+              setError('');
+              setSuccess('');
+              setIsOpen(true);
+            }}
+            className="inline-flex h-9 items-center rounded-full border px-3 text-xs font-medium text-primary transition-colors hover:bg-primary/10"
+          >
+            Hacer reporte
+          </button>
+        </div>
+      </div>
+
+      {savedBody && (
+        <p className="rounded-lg bg-muted/60 px-3 py-2 text-xs text-muted-foreground">
+          Ya hay un reporte guardado para este día. Podés abrirlo para editarlo.
+        </p>
+      )}
+      {success && <p className="text-xs text-emerald-700">{success}</p>}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={`report-title-${participant.id}`}
+        >
+          <div className="w-full max-w-lg rounded-2xl border bg-card p-5 shadow-xl">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <p
+                  id={`report-title-${participant.id}`}
+                  className="font-heading text-lg font-semibold"
+                >
+                  Hacer reporte
+                </p>
+                <p className="text-sm text-muted-foreground">
+                  {participant.displayName}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-full p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                aria-label="Cerrar reporte"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+
+            <label
+              className="mt-4 block text-sm font-medium"
+              htmlFor={`report-body-${participant.id}`}
+            >
+              Reporte del día
+            </label>
+            <textarea
+              id={`report-body-${participant.id}`}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              className="mt-2 min-h-40 w-full rounded-xl border bg-background px-3 py-2 text-sm outline-none focus:border-primary"
+              placeholder="Escribí observaciones, evolución o comentarios importantes..."
+            />
+            {error && <p className="mt-2 text-xs text-destructive">{error}</p>}
+            <div className="mt-4 flex flex-wrap justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="rounded-full border px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={saveReport}
+                disabled={saving}
+                className="rounded-full bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-opacity disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {saving ? 'Guardando...' : 'Guardar reporte'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/activities/[id]/days/[dayId]/informacion/page.tsx
+++ b/src/app/activities/[id]/days/[dayId]/informacion/page.tsx
@@ -4,6 +4,7 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { gateActiveRole } from '@/lib/role-guards';
 import Link from 'next/link';
+import DayParticipantContactCard from './day-participant-contact-card';
 
 export default async function DayGroupInfoPage({
   params,
@@ -14,7 +15,8 @@ export default async function DayGroupInfoPage({
   const block = gateActiveRole(session, ['ADMIN', 'PROFESSOR']);
   if (block) return block;
 
-  const isProfessor = session!.user.role === 'PROFESSOR';
+  const activeRole = session!.user.activeRole ?? session!.user.role;
+  const isProfessor = activeRole === 'PROFESSOR';
 
   const day = await prisma.activityDay.findUnique({
     where: { id: params.dayId },
@@ -44,18 +46,35 @@ export default async function DayGroupInfoPage({
     where: { activityId: params.id },
     include: {
       user: {
-        select: { name: true, lastName: true, email: true, phone: true },
+        select: {
+          id: true,
+          name: true,
+          lastName: true,
+          email: true,
+          phone: true,
+        },
       },
       child: {
         select: {
           name: true,
           lastName: true,
           user: {
-            select: { name: true, lastName: true, email: true, phone: true },
+            select: {
+              id: true,
+              name: true,
+              lastName: true,
+              email: true,
+              phone: true,
+            },
           },
         },
       },
       groupMembership: { select: { activityGroupId: true } },
+      reports: {
+        where: { activityDayId: params.dayId },
+        select: { body: true },
+        take: 1,
+      },
     },
     orderBy: { id: 'asc' },
   });
@@ -127,40 +146,21 @@ export default async function DayGroupInfoPage({
               `${contact.name ?? ''}${contact.lastName ? ` ${contact.lastName}` : ''}`.trim();
 
             return (
-              <div
+              <DayParticipantContactCard
                 key={p.id}
-                className="rounded-xl border bg-card px-5 py-4 space-y-2"
-              >
-                <p className="font-semibold text-sm">{displayName}</p>
-                {isChild && contactName && (
-                  <p className="text-xs text-muted-foreground">
-                    Responsable: {contactName}
-                  </p>
-                )}
-                <div className="flex flex-col gap-1">
-                  {contact.email && (
-                    <a
-                      href={`mailto:${contact.email}`}
-                      className="text-xs text-link hover:underline underline-offset-4"
-                    >
-                      {contact.email}
-                    </a>
-                  )}
-                  {contact.phone && (
-                    <a
-                      href={`tel:${contact.phone}`}
-                      className="text-xs text-link hover:underline underline-offset-4"
-                    >
-                      {contact.phone}
-                    </a>
-                  )}
-                  {!contact.email && !contact.phone && (
-                    <p className="text-xs text-muted-foreground italic">
-                      Sin datos de contacto
-                    </p>
-                  )}
-                </div>
-              </div>
+                activityId={day.activity.id}
+                dayId={day.id}
+                participant={{
+                  id: p.id,
+                  displayName,
+                  isChild,
+                  contactName,
+                  contactUserId: contact.id,
+                  email: contact.email,
+                  phone: contact.phone,
+                  existingReport: p.reports[0]?.body ?? null,
+                }}
+              />
             );
           })}
         </div>

--- a/src/app/api/activities/[id]/days/[dayId]/reports/route.ts
+++ b/src/app/api/activities/[id]/days/[dayId]/reports/route.ts
@@ -1,0 +1,114 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { getActiveRole, hasAdminCapability } from '@/lib/roles';
+
+const reportSchema = z.object({
+  activityParticipantId: z.string().min(1),
+  body: z.string().trim().min(1, 'El reporte no puede estar vacío').max(5000),
+});
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string; dayId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const activeRole = getActiveRole(session);
+  const isAdmin = activeRole === 'ADMIN' && hasAdminCapability(session);
+  const isProfessor = activeRole === 'PROFESSOR';
+  if (!isAdmin && !isProfessor) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const parsed = reportSchema.safeParse(await req.json());
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message ?? 'Datos inválidos' },
+      { status: 400 }
+    );
+  }
+  const data = parsed.data;
+
+  const day = await prisma.activityDay.findFirst({
+    where: { id: params.dayId, activityId: params.id },
+    select: {
+      id: true,
+      activityGroupId: true,
+      professors: { select: { userId: true } },
+    },
+  });
+
+  if (!day) {
+    return NextResponse.json(
+      { error: 'Día de actividad no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  if (
+    isProfessor &&
+    !day.professors.some((professor) => professor.userId === session.user.id)
+  ) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const participant = await prisma.activityParticipant.findFirst({
+    where: {
+      id: data.activityParticipantId,
+      activityId: params.id,
+    },
+    select: {
+      id: true,
+      groupMembership: { select: { activityGroupId: true } },
+    },
+  });
+
+  if (!participant) {
+    return NextResponse.json(
+      { error: 'Participante no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  if (
+    day.activityGroupId &&
+    participant.groupMembership?.activityGroupId !== day.activityGroupId
+  ) {
+    return NextResponse.json(
+      { error: 'El participante no pertenece al grupo de este día' },
+      { status: 400 }
+    );
+  }
+
+  const report = await prisma.activityParticipantReport.upsert({
+    where: {
+      activityDayId_activityParticipantId: {
+        activityDayId: day.id,
+        activityParticipantId: participant.id,
+      },
+    },
+    create: {
+      activityDayId: day.id,
+      activityParticipantId: participant.id,
+      createdById: session.user.id,
+      body: data.body,
+    },
+    update: {
+      body: data.body,
+      createdById: session.user.id,
+    },
+    select: {
+      id: true,
+      body: true,
+      updatedAt: true,
+    },
+  });
+
+  return NextResponse.json(report);
+}

--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -103,6 +103,27 @@ export default async function ProfessorStudentsPage() {
       activityParticipant: {
         include: {
           activity: { select: { name: true } },
+          reports: {
+            orderBy: { activityDay: { date: 'desc' } },
+            select: {
+              id: true,
+              body: true,
+              createdAt: true,
+              updatedAt: true,
+              activityDay: {
+                select: {
+                  date: true,
+                  schedule: true,
+                  cancelled: true,
+                  activityGroupId: true,
+                  activityGroup: { select: { name: true } },
+                },
+              },
+              createdBy: {
+                select: { name: true, lastName: true, email: true },
+              },
+            },
+          },
           attendances: {
             orderBy: { activityDay: { date: 'desc' } },
             select: {
@@ -255,23 +276,56 @@ export default async function ProfessorStudentsPage() {
         planificacion: attendance.activityDay.planificacion,
         devolucion: attendance.activityDay.devolucion,
       })),
-      reports: participant.attendances
-        .filter(
-          (attendance) =>
-            attendance.activityDay.activityGroupId === gm.activityGroupId &&
-            Boolean(
-              attendance.activityDay.planificacion ||
-              attendance.activityDay.devolucion
-            )
-        )
-        .map((attendance) => ({
-          date: attendance.activityDay.date.toISOString(),
-          schedule: attendance.activityDay.schedule,
-          cancelled: attendance.activityDay.cancelled,
-          groupName: attendance.activityDay.activityGroup?.name ?? null,
-          planificacion: attendance.activityDay.planificacion,
-          devolucion: attendance.activityDay.devolucion,
-        })),
+      reports: [
+        ...participant.reports
+          .filter(
+            (report) =>
+              !report.activityDay.activityGroupId ||
+              report.activityDay.activityGroupId === gm.activityGroupId
+          )
+          .map((report) => ({
+            id: report.id,
+            type: 'participant' as const,
+            date: report.activityDay.date.toISOString(),
+            schedule: report.activityDay.schedule,
+            cancelled: report.activityDay.cancelled,
+            groupName: report.activityDay.activityGroup?.name ?? null,
+            body: report.body,
+            createdAt: report.createdAt.toISOString(),
+            updatedAt: report.updatedAt.toISOString(),
+            author:
+              [report.createdBy.name, report.createdBy.lastName]
+                .filter(Boolean)
+                .join(' ') || report.createdBy.email,
+            planificacion: null,
+            devolucion: null,
+          })),
+        ...participant.attendances
+          .filter(
+            (attendance) =>
+              (!attendance.activityDay.activityGroupId ||
+                attendance.activityDay.activityGroupId ===
+                  gm.activityGroupId) &&
+              Boolean(
+                attendance.activityDay.planificacion ||
+                attendance.activityDay.devolucion
+              )
+          )
+          .map((attendance) => ({
+            id: `${participant.id}-${attendance.activityDay.date.toISOString()}-${attendance.activityDay.schedule}`,
+            type: 'day' as const,
+            date: attendance.activityDay.date.toISOString(),
+            schedule: attendance.activityDay.schedule,
+            cancelled: attendance.activityDay.cancelled,
+            groupName: attendance.activityDay.activityGroup?.name ?? null,
+            body: null,
+            createdAt: null,
+            updatedAt: null,
+            author: null,
+            planificacion: attendance.activityDay.planificacion,
+            devolucion: attendance.activityDay.devolucion,
+          })),
+      ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
     };
   }
 

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -28,10 +28,16 @@ type StudentHistoryEntry = {
     devolucion: string | null;
   }[];
   reports: {
+    id: string;
+    type: 'participant' | 'day';
     date: string;
     schedule: string;
     cancelled: boolean;
     groupName: string | null;
+    body: string | null;
+    createdAt: string | null;
+    updatedAt: string | null;
+    author: string | null;
     planificacion: string | null;
     devolucion: string | null;
   }[];
@@ -1031,48 +1037,71 @@ export default function StudentsSearch({
                       <ul className="mt-3 space-y-3">
                         {entry.reports.map((report) => (
                           <li
-                            key={`${entry.participantId}-report-${report.date}-${report.schedule}`}
-                            className="rounded-lg bg-muted/60 p-3 text-sm"
+                            key={`${entry.participantId}-report-${report.id}`}
                           >
-                            <div className="flex flex-wrap items-center justify-between gap-2">
-                              <span className="font-medium capitalize">
-                                {formatHistoryDate(report.date)}
-                              </span>
-                              {report.cancelled && (
-                                <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
-                                  Cancelado
+                            <details className="group rounded-lg bg-muted/60 text-sm">
+                              <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 px-3 py-3">
+                                <span className="font-medium capitalize">
+                                  Reporte ({formatHistoryDate(report.date)})
                                 </span>
-                              )}
-                            </div>
-                            <p className="text-muted-foreground">
-                              {report.schedule}
-                              {report.groupName &&
-                              report.groupName !== entry.groupName
-                                ? ` · ${report.groupName}`
-                                : ''}
-                            </p>
-                            <div className="mt-3 space-y-3">
-                              {report.planificacion && (
-                                <div>
-                                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                    Planificación
+                                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                                  {report.cancelled && (
+                                    <span className="rounded-full border border-destructive/30 bg-destructive/10 px-2 py-0.5 font-medium text-destructive">
+                                      Cancelado
+                                    </span>
+                                  )}
+                                  <span className="transition-transform group-open:rotate-180">
+                                    ↓
+                                  </span>
+                                </span>
+                              </summary>
+                              <div className="border-t px-3 py-3">
+                                <p className="text-muted-foreground">
+                                  {report.schedule}
+                                  {report.groupName &&
+                                  report.groupName !== entry.groupName
+                                    ? ` · ${report.groupName}`
+                                    : ''}
+                                </p>
+                                {report.author && (
+                                  <p className="mt-1 text-xs text-muted-foreground">
+                                    Cargado por {report.author}
                                   </p>
-                                  <p className="mt-1 whitespace-pre-wrap text-foreground">
-                                    {report.planificacion}
-                                  </p>
+                                )}
+                                <div className="mt-3 space-y-3">
+                                  {report.body && (
+                                    <div>
+                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        Reporte
+                                      </p>
+                                      <p className="mt-1 whitespace-pre-wrap text-foreground">
+                                        {report.body}
+                                      </p>
+                                    </div>
+                                  )}
+                                  {report.planificacion && (
+                                    <div>
+                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        Planificación
+                                      </p>
+                                      <p className="mt-1 whitespace-pre-wrap text-foreground">
+                                        {report.planificacion}
+                                      </p>
+                                    </div>
+                                  )}
+                                  {report.devolucion && (
+                                    <div>
+                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                                        Devolución
+                                      </p>
+                                      <p className="mt-1 whitespace-pre-wrap text-foreground">
+                                        {report.devolucion}
+                                      </p>
+                                    </div>
+                                  )}
                                 </div>
-                              )}
-                              {report.devolucion && (
-                                <div>
-                                  <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                    Devolución
-                                  </p>
-                                  <p className="mt-1 whitespace-pre-wrap text-foreground">
-                                    {report.devolucion}
-                                  </p>
-                                </div>
-                              )}
-                            </div>
+                              </div>
+                            </details>
                           </li>
                         ))}
                       </ul>


### PR DESCRIPTION
### Motivation
- Support professors/admins adding a short per-participant report for a specific activity day that is stored on the participant's history and shown in "Mis alumnos" as minimized report tabs.
- Provide quick contact actions (WhatsApp / internal chat) next to each participant and a small UX to create/edit the day's report from the activity day "Información" view.

### Description
- Added a new Prisma model `ActivityParticipantReport` and migration to persist one report per participant/day and relations to `ActivityDay`, `ActivityParticipant`, and `User` (author). Files: `prisma/schema.prisma`, `prisma/migrations/20260508120000_add_activity_participant_reports/migration.sql`.
- Created a secured API endpoint `POST /api/activities/[id]/days/[dayId]/reports` that validates role (professor/admin active role), professor-day assignment, participant->activity match and group membership, and upserts the report; file: `src/app/api/activities/[id]/days/[dayId]/reports/route.ts`.
- Added a reusable client component `DayParticipantContactCard` with WhatsApp, chat link and a "Hacer reporte" button that opens a modal to write/save the report; file: `src/app/activities/[id]/days/[dayId]/informacion/day-participant-contact-card.tsx`.
- Updated the activity day information page to load each participant's contact and existing report and render the new contact card; file: `src/app/activities/[id]/days/[dayId]/informacion/page.tsx`.
- Surface participant reports in the professor "Mis alumnos" history UI by fetching reports and showing them under the "Reportes" section as minimized entries titled `Reporte (día que corresponda)` alongside existing planificación/devolución entries; files: `src/app/professor/students/page.tsx`, `src/app/professor/students/students-search.tsx`.
- Generated Prisma client after schema changes and added the migration SQL to the repository.

### Testing
- Ran schema validation with `DATABASE_URL='postgresql://user:pass@localhost:5432/db' pnpm exec prisma validate` (succeeded).
- Ran `pnpm prisma:generate` to refresh the client (succeeded).
- Ran `pnpm lint` (Next lint) which completed; repo contains unrelated Prettier warnings outside the touched files.
- Attempted TypeScript check `pnpm exec tsc --noEmit` which fails due to pre-existing test typing errors in `tests/api/pickup-notices.test.ts` unrelated to these changes, so compilation check is blocked by those test issues (not introduced by this PR).
- Verified the new API route logic by code inspection and ran `pnpm exec prettier` / formatting steps for touched files where applicable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd60563bb483289f0784c6e7799383)