### PR TITLE
Fix professor student report history

### DIFF
--- a/src/app/professor/students/page.tsx
+++ b/src/app/professor/students/page.tsx
@@ -134,8 +134,6 @@ export default async function ProfessorStudentsPage() {
                   date: true,
                   schedule: true,
                   cancelled: true,
-                  planificacion: true,
-                  devolucion: true,
                   activityGroupId: true,
                   activityGroup: { select: { name: true } },
                 },
@@ -275,8 +273,6 @@ export default async function ProfessorStudentsPage() {
         confirmedAt: attendance.confirmedAt?.toISOString() ?? null,
         cancelled: attendance.activityDay.cancelled,
         groupName: attendance.activityDay.activityGroup?.name ?? null,
-        planificacion: attendance.activityDay.planificacion,
-        devolucion: attendance.activityDay.devolucion,
       })),
       reports: [
         ...participant.reports
@@ -299,33 +295,6 @@ export default async function ProfessorStudentsPage() {
               [report.createdBy.name, report.createdBy.lastName]
                 .filter(Boolean)
                 .join(' ') || report.createdBy.email,
-            planificacion: null,
-            devolucion: null,
-          })),
-        ...participant.attendances
-          .filter(
-            (attendance) =>
-              (!attendance.activityDay.activityGroupId ||
-                attendance.activityDay.activityGroupId ===
-                  gm.activityGroupId) &&
-              Boolean(
-                attendance.activityDay.planificacion ||
-                attendance.activityDay.devolucion
-              )
-          )
-          .map((attendance) => ({
-            id: `${participant.id}-${attendance.activityDay.date.toISOString()}-${attendance.activityDay.schedule}`,
-            type: 'day' as const,
-            date: attendance.activityDay.date.toISOString(),
-            schedule: attendance.activityDay.schedule,
-            cancelled: attendance.activityDay.cancelled,
-            groupName: attendance.activityDay.activityGroup?.name ?? null,
-            body: null,
-            createdAt: null,
-            updatedAt: null,
-            author: null,
-            planificacion: attendance.activityDay.planificacion,
-            devolucion: attendance.activityDay.devolucion,
           })),
       ].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
     };

--- a/src/app/professor/students/students-search.tsx
+++ b/src/app/professor/students/students-search.tsx
@@ -24,12 +24,9 @@ type StudentHistoryEntry = {
     confirmedAt: string | null;
     cancelled: boolean;
     groupName: string | null;
-    planificacion: string | null;
-    devolucion: string | null;
   }[];
   reports: {
     id: string;
-    type: 'participant' | 'day';
     date: string;
     schedule: string;
     cancelled: boolean;
@@ -38,8 +35,6 @@ type StudentHistoryEntry = {
     createdAt: string | null;
     updatedAt: string | null;
     author: string | null;
-    planificacion: string | null;
-    devolucion: string | null;
   }[];
 };
 
@@ -1188,26 +1183,6 @@ export default function StudentsSearch({
                                       </p>
                                       <p className="mt-1 whitespace-pre-wrap text-foreground">
                                         {report.body}
-                                      </p>
-                                    </div>
-                                  )}
-                                  {report.planificacion && (
-                                    <div>
-                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                        Planificación
-                                      </p>
-                                      <p className="mt-1 whitespace-pre-wrap text-foreground">
-                                        {report.planificacion}
-                                      </p>
-                                    </div>
-                                  )}
-                                  {report.devolucion && (
-                                    <div>
-                                      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-                                        Devolución
-                                      </p>
-                                      <p className="mt-1 whitespace-pre-wrap text-foreground">
-                                        {report.devolucion}
                                       </p>
                                     </div>
                                   )}


### PR DESCRIPTION
### Motivation
- The Reports tab on `/professor/students` was showing activity-day planning/devolution notes mixed into the student report history instead of only the reports created by professors.
- The goal is to keep the Reports view focused on `ActivityParticipantReport` entries and leave session planifications/devoluciones in the group notes UI.

### Description
- Remove attendance-derived day notes (planificacion/devolucion) from the assembled `history.reports` in `src/app/professor/students/page.tsx` so only saved participant reports are included.
- Stop selecting `planificacion`/`devolucion` from participant attendances when building the student history and keep those fields only for the group notes block.
- Simplify the client-side `StudentHistoryEntry` type and update the modal rendering in `src/app/professor/students/students-search.tsx` to expect only participant report fields and render only the saved report body.
- Files touched: `src/app/professor/students/page.tsx` and `src/app/professor/students/students-search.tsx`.

### Testing
- Ran `pnpm lint`, which completed successfully (only unrelated Prettier warnings reported elsewhere).
- Ran `pnpm exec next lint --file src/app/professor/students/page.tsx --file src/app/professor/students/students-search.tsx`, which reported no lint errors for the modified files.
- Ran `pnpm prisma:generate` successfully and then `pnpm exec tsc --noEmit`, which failed due to preexisting TypeScript test typing errors in `tests/api/pickup-notices.test.ts` that are unrelated to these changes.
- Performed a code review of the diff to confirm the Reports tab now lists only professor-created participant reports and that planifications/devoluciones remain rendered in the group notes panel where appropriate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd651ca05c832894372b41e708a408)