### PR TITLE
Redirigir post-login a 'Mis actividades' cuando el usuario tiene inscripciones

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -123,7 +123,7 @@ export default function LoginPage() {
 
           <Button
             className="w-full flex items-center justify-center gap-2 bg-white border border-border text-foreground hover:bg-muted"
-            onClick={() => signIn('google', { callbackUrl: '/' })}
+            onClick={() => signIn('google', { callbackUrl: '/post-login' })}
           >
             <Image src="/google.svg" alt="Google logo" width={18} height={18} />
             {t.signInWithGoogle}

--- a/src/app/post-login/page.tsx
+++ b/src/app/post-login/page.tsx
@@ -1,11 +1,9 @@
 import { getServerSession } from 'next-auth';
-import { NextResponse } from 'next/server';
+import { redirect } from 'next/navigation';
 import { authOptions } from '@/lib/auth';
 import { getPostLoginRedirectUrl } from '@/lib/post-login-redirect';
 
-export async function GET() {
+export default async function PostLoginPage() {
   const session = await getServerSession(authOptions);
-  const redirectUrl = await getPostLoginRedirectUrl(session);
-
-  return NextResponse.json({ redirectUrl }, { status: session ? 200 : 401 });
+  redirect(await getPostLoginRedirectUrl(session));
 }

--- a/src/lib/__tests__/post-login-redirect.test.ts
+++ b/src/lib/__tests__/post-login-redirect.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ */
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    activityParticipant: {
+      count: jest.fn(),
+    },
+    activityProfessor: {
+      count: jest.fn(),
+    },
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('@/lib/family-access', () => ({
+  getAccessibleChildOwnerIds: jest.fn(),
+}));
+
+import type { Session } from 'next-auth';
+import { prisma } from '@/lib/prisma';
+import { getAccessibleChildOwnerIds } from '@/lib/family-access';
+import { getPostLoginRedirectUrl } from '../post-login-redirect';
+
+const mockPrisma = prisma as unknown as {
+  activityParticipant: { count: jest.Mock };
+  activityProfessor: { count: jest.Mock };
+  user: { findUnique: jest.Mock };
+};
+
+const mockGetAccessibleChildOwnerIds = getAccessibleChildOwnerIds as jest.Mock;
+
+function buildSession(overrides: Partial<Session['user']> = {}): Session {
+  return {
+    expires: '2026-12-31T00:00:00.000Z',
+    user: {
+      id: 'user_1',
+      role: 'MEMBER',
+      activeRole: 'MEMBER',
+      roles: ['MEMBER'],
+      email: 'socio@hualas.test',
+      ...overrides,
+    },
+  };
+}
+
+describe('getPostLoginRedirectUrl', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAccessibleChildOwnerIds.mockResolvedValue(['user_1']);
+    mockPrisma.activityParticipant.count.mockResolvedValue(0);
+    mockPrisma.activityProfessor.count.mockResolvedValue(0);
+    mockPrisma.user.findUnique.mockResolvedValue({
+      name: 'Ana',
+      lastName: 'López',
+      dni: '12345678',
+      birthDate: new Date('1990-01-01T00:00:00.000Z'),
+      address: 'San Martín 123',
+      phone: '2944000000',
+    });
+  });
+
+  it('envía a Mis actividades cuando el usuario ya tiene inscripciones', async () => {
+    mockPrisma.activityParticipant.count.mockResolvedValue(1);
+
+    await expect(getPostLoginRedirectUrl(buildSession())).resolves.toBe(
+      '/my-activities'
+    );
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('incluye inscripciones de menores accesibles al decidir la pantalla inicial', async () => {
+    mockGetAccessibleChildOwnerIds.mockResolvedValue(['user_1', 'parent_2']);
+    mockPrisma.activityParticipant.count.mockResolvedValue(1);
+
+    await getPostLoginRedirectUrl(buildSession());
+
+    expect(mockPrisma.activityParticipant.count).toHaveBeenCalledWith({
+      where: {
+        OR: [
+          { userId: 'user_1' },
+          { child: { userId: { in: ['user_1', 'parent_2'] } } },
+        ],
+      },
+    });
+  });
+
+  it('mantiene el onboarding actual si no tiene actividades y el perfil está incompleto', async () => {
+    mockPrisma.user.findUnique.mockResolvedValue({
+      name: 'Ana',
+      lastName: null,
+      dni: null,
+      birthDate: null,
+      address: null,
+      phone: null,
+    });
+
+    await expect(getPostLoginRedirectUrl(buildSession())).resolves.toBe(
+      '/profile?onboarding=1'
+    );
+  });
+
+  it('mantiene el inicio actual si no tiene actividades y el perfil está completo', async () => {
+    await expect(getPostLoginRedirectUrl(buildSession())).resolves.toBe('/');
+  });
+
+  it('mantiene la ruta contable para usuarios de mostrador', async () => {
+    await expect(
+      getPostLoginRedirectUrl(buildSession({ role: 'COUNTER' }))
+    ).resolves.toBe('/accounting');
+    expect(mockPrisma.activityParticipant.count).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/post-login-redirect.ts
+++ b/src/lib/post-login-redirect.ts
@@ -1,0 +1,53 @@
+import type { Session } from 'next-auth';
+import { isCounterRole } from '@/lib/accounting';
+import { getAccessibleChildOwnerIds } from '@/lib/family-access';
+import { checkUserProfile } from '@/lib/participant-profile-check';
+import { prisma } from '@/lib/prisma';
+
+export async function getPostLoginRedirectUrl(session: Session | null) {
+  if (!session) {
+    return '/login';
+  }
+
+  if (isCounterRole(session.user.role)) {
+    return '/accounting';
+  }
+
+  const userId = session.user.id;
+  const accessibleChildOwnerIds = await getAccessibleChildOwnerIds(userId);
+
+  const [participantCount, professorCount] = await Promise.all([
+    prisma.activityParticipant.count({
+      where: {
+        OR: [
+          { userId },
+          { child: { userId: { in: accessibleChildOwnerIds } } },
+        ],
+      },
+    }),
+    prisma.activityProfessor.count({ where: { userId } }),
+  ]);
+
+  const hasActivities = participantCount > 0 || professorCount > 0;
+  if (hasActivities) {
+    return '/my-activities';
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      name: true,
+      lastName: true,
+      dni: true,
+      birthDate: true,
+      address: true,
+      phone: true,
+    },
+  });
+
+  if (user && !checkUserProfile(user).valid) {
+    return '/profile?onboarding=1';
+  }
+
+  return '/';
+}


### PR DESCRIPTION
### Motivation
- Mejorar la experiencia al iniciar sesión haciendo que la primera página sea “Mis actividades” cuando el usuario ya tiene inscripciones (propias o de menores accesibles) o asignaciones como profesor, sin romper el flujo existente.

### Description
- Extraje la lógica de decisión de destino post-login a `getPostLoginRedirectUrl` en `src/lib/post-login-redirect.ts` y la implementé para priorizar `/my-activities`, mantener `/profile?onboarding=1` si el perfil está incompleto, y conservar `/` como fallback.
- Actualicé el endpoint `GET /api/auth/post-login-redirect` para reutilizar el helper y devolver `{ redirectUrl }` con el status adecuado en `src/app/api/auth/post-login-redirect/route.ts`.
- Añadí una página server-side `/post-login` en `src/app/post-login/page.tsx` y cambié el `callbackUrl` del botón de Google en el login a `/post-login` para que OAuth también respete la misma lógica.
- Agregué tests unitarios en `src/lib/__tests__/post-login-redirect.test.ts` que cubren usuarios con inscripciones, inscripciones de menores accesibles, onboarding por perfil incompleto, flujo home y rol `COUNTER`.

### Testing
- Ejecuté `pnpm test -- src/lib/__tests__/post-login-redirect.test.ts` y todos los tests del nuevo archivo pasaron (5 tests, 1 suite: passed).
- Ejecuté `pnpm lint` que terminó con exit code 0; el repo sigue mostrando warnings de Prettier en archivos no relacionados pero no bloqueantes.
- Ejecuté `pnpm exec tsc --noEmit` que falló por errores de tipos preexistentes en otras áreas del repo (no relacionados con este cambio).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfaef90188328925ec6dfbe4a8cab)