### PR TITLE
Store activity/payment amounts in centavos and show pesos in UI

### DIFF
--- a/prisma/migrations/20260508130000_store_activity_amounts_in_cents/migration.sql
+++ b/prisma/migrations/20260508130000_store_activity_amounts_in_cents/migration.sql
@@ -1,0 +1,20 @@
+-- Normalize activity-related amounts that were historically persisted in pesos.
+-- Amount columns are integer centavos across accounting models.
+UPDATE "Activity"
+SET "price" = "price" * 100
+WHERE "price" > 0;
+
+UPDATE "ActivityParticipantPayment"
+SET "amount" = "amount" * 100
+WHERE "amount" > 0;
+
+UPDATE "OrderItem" oi
+SET
+  "unitPrice" = oi."unitPrice" * 100,
+  "total" = oi."total" * 100
+FROM "BillableConcept" bc
+WHERE oi."billableConceptId" = bc."id"
+  AND (
+    (bc."code" = 'ACTIVITY_FEE' AND oi."activityId" IS NOT NULL)
+    OR bc."code" = 'DISCOUNT'
+  );

--- a/src/app/accounting/page.tsx
+++ b/src/app/accounting/page.tsx
@@ -155,7 +155,7 @@ export default async function AccountingDashboardPage({
       0
     );
   const totalMp = monthPayments.reduce(
-    (sum, payment) => sum + payment.activity.price * 100,
+    (sum, payment) => sum + payment.activity.price,
     0
   );
   const totalMovementIncome = monthMovements
@@ -438,7 +438,7 @@ export default async function AccountingDashboardPage({
                       </p>
                     </div>
                     <p className="font-semibold">
-                      {formatAmount(payment.activity.price * 100)}
+                      {formatAmount(payment.activity.price)}
                     </p>
                   </div>
                   <div className="mt-2 flex items-center justify-between gap-3 text-xs text-muted-foreground">

--- a/src/app/accounting/payments/page.tsx
+++ b/src/app/accounting/payments/page.tsx
@@ -247,7 +247,7 @@ export default async function PaymentsPage({
                     </PersonLink>
                   </td>
                   <td className="px-4 py-3">
-                    {formatAmount(payment.activity.price * 100)}
+                    {formatAmount(payment.activity.price)}
                   </td>
                   <td className="px-4 py-3">{payment.receipt ?? '-'}</td>
                   <td className="px-4 py-3">

--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Form } from '@/components/ui/form';
 import { SPORT_ICONS } from '@/lib/sport-icons';
+import { centsToPesos, pesosToCents } from '@/lib/accounting';
 import ProfessorPicker from '../../professor-picker';
 
 type ProfessorOption = {
@@ -106,7 +107,7 @@ export default function EditActivityForm({
     activity.activityType
   );
   const [description, setDescription] = useState(activity.description || '');
-  const [price, setPrice] = useState(String(activity.price));
+  const [price, setPrice] = useState(String(centsToPesos(activity.price)));
   const [professorIds, setProfessorIds] = useState<string[]>(
     activity.professorIds
   );
@@ -353,7 +354,7 @@ export default function EditActivityForm({
           endDate,
           activityType,
           description: description || undefined,
-          price: Number(price),
+          price: pesosToCents(Number(price)),
           professorIds,
           annualSchedules: normalizedSchedules,
           geoLocation:
@@ -468,11 +469,12 @@ export default function EditActivityForm({
         />
         <input
           type="number"
-          placeholder="Precio"
+          placeholder="Precio en pesos"
           value={price}
           onChange={(e) => setPrice(e.target.value)}
           className={inputClass}
           min={0}
+          step="0.01"
           required
         />
 

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { MessageCircle, Phone } from 'lucide-react';
+import { formatAmount } from '@/lib/accounting';
 
 interface ActivityPageProps {
   params: { id: string };
@@ -463,7 +464,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                           Precio
                         </p>
                         <p className="mt-1 text-lg font-semibold">
-                          ${activity.price}
+                          {formatAmount(activity.price)}
                         </p>
                       </div>
                       <div>

--- a/src/app/activities/activities-tabs.tsx
+++ b/src/app/activities/activities-tabs.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import Link from 'next/link';
 import DeleteActivityButton from './delete-activity-button';
+import { formatAmount } from '@/lib/accounting';
 
 type ActivityItem = {
   id: string;
@@ -45,7 +46,7 @@ function ActivitiesList({ activities }: { activities: ActivityItem[] }) {
             <div className="mt-1 flex flex-wrap gap-3 text-sm text-muted-foreground">
               <span>{formatDateRange(activity.date, activity.endDate)}</span>
               <span>·</span>
-              <span>${activity.price}</span>
+              <span>{formatAmount(activity.price)}</span>
               <span>·</span>
               <span>
                 {activity.capacity

--- a/src/app/activities/cart/page.tsx
+++ b/src/app/activities/cart/page.tsx
@@ -43,7 +43,11 @@ type QuoteResponse = {
 };
 
 function formatMoney(amount: number) {
-  return `$${Number(amount).toLocaleString('es-AR')}`;
+  return new Intl.NumberFormat('es-AR', {
+    style: 'currency',
+    currency: 'ARS',
+    maximumFractionDigits: 0,
+  }).format(amount / 100);
 }
 
 export default function ActivitiesCartPage() {

--- a/src/app/activities/join/[id]/join-enrollment-panel.tsx
+++ b/src/app/activities/join/[id]/join-enrollment-panel.tsx
@@ -8,6 +8,7 @@ import { ACTIVITY_CART_STORAGE_KEY, ActivityCartItem } from '@/lib/cart';
 import RegisterButton from '@/components/register-button';
 import GroupScheduleCalendar from './group-schedule-calendar';
 import PersonPicker, { Avatar } from './person-picker';
+import { formatAmount } from '@/lib/accounting';
 
 type Group = {
   id: string;
@@ -598,7 +599,7 @@ export default function JoinEnrollmentPanel({
             Inscripción
           </p>
           <p className="font-heading text-2xl font-semibold">
-            ${activity.price}
+            {formatAmount(activity.price)}
           </p>
           {hasCapacity && (
             <p

--- a/src/app/activities/join/[id]/page.tsx
+++ b/src/app/activities/join/[id]/page.tsx
@@ -5,6 +5,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import JoinEnrollmentPanel from './join-enrollment-panel';
+import { formatAmount } from '@/lib/accounting';
 
 interface ActivityJoinPageProps {
   params: { id: string };
@@ -181,7 +182,7 @@ export default async function ActivityJoinPage({
                 Precio
               </p>
               <p className="font-heading text-lg font-semibold">
-                ${activityData.price}
+                {formatAmount(activityData.price)}
               </p>
             </div>
 

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { SPORT_ICONS } from '@/lib/sport-icons';
+import { pesosToCents } from '@/lib/accounting';
 import ProfessorPicker from '../professor-picker';
 
 type ProfessorOption = {
@@ -267,7 +268,7 @@ export default function CreateActivityForm({
           endDate,
           activityType,
           description: description || undefined,
-          price: Number(price),
+          price: pesosToCents(Number(price)),
           professorIds,
           groups: groups.map((group) => ({
             tempId: group.tempId,
@@ -373,11 +374,12 @@ export default function CreateActivityForm({
 
       <input
         type="number"
-        placeholder="Precio"
+        placeholder="Precio en pesos"
         value={price}
         onChange={(e) => setPrice(e.target.value)}
         className={inputClass}
         min={0}
+        step="0.01"
         required
       />
 

--- a/src/app/admin/users/[id]/children/[childId]/view/page.tsx
+++ b/src/app/admin/users/[id]/children/[childId]/view/page.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import ChildInfoSection from '@/components/child-info-section';
+import { formatAmount } from '@/lib/accounting';
 
 export default async function ViewChildPage({
   params,
@@ -320,8 +321,8 @@ export default async function ViewChildPage({
               <li key={ap.id} className="py-2 text-sm">
                 <span className="font-medium">{ap.activity.name}</span>
                 <span className="text-muted-foreground text-xs block mt-0.5">
-                  {ap.activity.date.toLocaleDateString('es-AR')} · $
-                  {ap.activity.price}
+                  {ap.activity.date.toLocaleDateString('es-AR')} ·{' '}
+                  {formatAmount(ap.activity.price)}
                 </span>
               </li>
             ))}

--- a/src/app/admin/users/[id]/view/page.tsx
+++ b/src/app/admin/users/[id]/view/page.tsx
@@ -551,8 +551,8 @@ export default async function ViewUserPage({
                 <span>
                   <span className="font-medium">{ap.activity.name}</span>
                   <span className="text-muted-foreground ml-2">
-                    {ap.activity.date.toLocaleDateString()} · $
-                    {ap.activity.price}
+                    {ap.activity.date.toLocaleDateString()} ·{' '}
+                    {formatAmount(ap.activity.price)}
                     {ap.child && ` · ${ap.child.name}`}
                   </span>
                 </span>
@@ -620,7 +620,7 @@ export default async function ViewUserPage({
                         </td>
                         <td className="px-4 py-3">{payment.receipt ?? '—'}</td>
                         <td className="px-4 py-3 text-right font-medium">
-                          {formatAmount(payment.activity.price * 100)}
+                          {formatAmount(payment.activity.price)}
                         </td>
                       </tr>
                     );

--- a/src/app/api/accounting/reports/route.ts
+++ b/src/app/api/accounting/reports/route.ts
@@ -130,7 +130,7 @@ export async function GET(request: Request) {
   const reportMpPayments = mpPayments.map((payment) => ({
     id: payment.id,
     receiptDate: payment.receiptDate,
-    amount: payment.activity.price * 100,
+    amount: payment.activity.price,
     participantName: payment.child
       ? `${payment.child.name} ${payment.child.lastName ?? ''}`.trim()
       : `${payment.user.name ?? ''} ${payment.user.lastName ?? ''}`.trim(),
@@ -181,7 +181,7 @@ export async function GET(request: Request) {
       receiptDate: p.receiptDate,
       receipt: p.receipt,
       activityName: p.activity.name,
-      amount: p.activity.price * 100,
+      amount: p.activity.price,
       participantName: p.child
         ? `${p.child.name} ${p.child.lastName ?? ''}`.trim()
         : `${p.user.name ?? ''} ${p.user.lastName ?? ''}`.trim(),

--- a/src/app/api/activities/[id]/checkout/route.ts
+++ b/src/app/api/activities/[id]/checkout/route.ts
@@ -20,6 +20,7 @@ import {
   checkChildProfile,
 } from '@/lib/participant-profile-check';
 import { getAccessibleChildrenWhere } from '@/lib/family-access';
+import { centsToPesos } from '@/lib/accounting';
 
 type CheckoutItem = {
   activityId: string;
@@ -194,7 +195,8 @@ export async function GET(
     }
   }
 
-  const unitPrice = Number(activity.price);
+  const unitPriceCents = Number(activity.price);
+  const unitPrice = centsToPesos(unitPriceCents);
 
   const participant = normalizeSocialFeeParticipant({
     userId: (session.user as any).id,
@@ -205,7 +207,7 @@ export async function GET(
   const socialFeeAmount = shouldChargeSocialFee
     ? await getSocialFeeAmount()
     : 0;
-  if (!unitPrice || unitPrice <= 0) {
+  if (!unitPriceCents || unitPriceCents <= 0) {
     return NextResponse.json(
       { error: 'El precio de la actividad no es válido.' },
       { status: 400 }
@@ -252,20 +254,21 @@ export async function GET(
         title: 'Cuota social mensual',
         description: 'Cuota social mensual, individual y obligatoria.',
         quantity: 1,
-        unit_price: socialFeeAmount,
+        unit_price: centsToPesos(socialFeeAmount),
         currency_id: 'ARS',
         category_id: 'services',
       });
     }
 
-    const mpFeeAmount = Math.round((unitPrice + socialFeeAmount) * 0.1);
+    const mpFeeAmount = Math.round((unitPriceCents + socialFeeAmount) * 0.1);
+    const mpFeePrice = centsToPesos(mpFeeAmount);
     if (mpFeeAmount > 0) {
       items.push({
         id: 'mp-fee',
         title: 'Cargos de servicios externos Mercado Libre',
         description: 'Cargos de servicios externos Mercado Libre',
         quantity: 1,
-        unit_price: mpFeeAmount,
+        unit_price: mpFeePrice,
         currency_id: 'ARS',
         category_id: 'services',
       });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import { listActivitiesWithParticipantCount } from '@/lib/activities/activity-records';
+import { formatAmount } from '@/lib/accounting';
 
 export default async function Home() {
   let activities: Awaited<
@@ -106,8 +107,8 @@ export default async function Home() {
                         {activity.capacity
                           ? `${Math.max(Number(activity.capacity) - Number(activity.participantCount), 0)} cupos disponibles`
                           : `${activity.participantCount} inscriptos`}
-                        {' · $'}
-                        {activity.price}
+                        {' · '}
+                        {formatAmount(activity.price)}
                       </div>
                     </div>
                   </div>

--- a/src/app/profile/children/[childId]/page.tsx
+++ b/src/app/profile/children/[childId]/page.tsx
@@ -8,6 +8,7 @@ import ChildInfoSection from '@/components/child-info-section';
 import ChildProfilePhotoUpload from './child-profile-photo-upload';
 import { gateActiveRole } from '@/lib/role-guards';
 import { getAccessibleChildOwnerIds } from '@/lib/family-access';
+import { formatAmount } from '@/lib/accounting';
 
 export default async function ViewMyChildPage({
   params,
@@ -344,7 +345,7 @@ export default async function ViewMyChildPage({
                 <span className="font-medium">{ap.activity.name}</span>
                 <span className="text-muted-foreground text-xs block mt-0.5">
                   {ap.activity.date.toLocaleDateString('es-AR')} · $
-                  {ap.activity.price}
+                  {formatAmount(ap.activity.price)}
                 </span>
               </li>
             ))}
@@ -361,7 +362,7 @@ export default async function ViewMyChildPage({
                 <span className="font-medium">{ap.activity.name}</span>
                 <span className="text-muted-foreground text-xs block mt-0.5">
                   {ap.activity.date.toLocaleDateString('es-AR')} · $
-                  {ap.activity.price}
+                  {formatAmount(ap.activity.price)}
                 </span>
               </li>
             ))}

--- a/src/app/profile/payments/page.tsx
+++ b/src/app/profile/payments/page.tsx
@@ -150,7 +150,7 @@ export default async function ProfilePaymentsPage() {
                       </td>
                       <td className="px-3 py-2">{payment.receipt ?? '-'}</td>
                       <td className="px-3 py-2 text-right font-medium">
-                        {formatCurrency(payment.activity.price)}
+                        {formatAmount(payment.activity.price)}
                       </td>
                     </tr>
                   );

--- a/src/components/checkout/manual-payment-form.tsx
+++ b/src/components/checkout/manual-payment-form.tsx
@@ -10,6 +10,7 @@ import {
   MANUAL_PAYMENT_BANK_DETAILS,
   validateManualPaymentFile,
 } from '@/lib/manual-payment-ui';
+import { formatAmount } from '@/lib/accounting';
 
 type ManualPaymentFormProps = {
   endpoint: string;
@@ -25,14 +26,6 @@ type ManualPaymentFormProps = {
   activitySummary?: string;
   childId?: string | null;
 };
-
-function formatAmount(amount: number) {
-  return new Intl.NumberFormat('es-AR', {
-    style: 'currency',
-    currency: 'ARS',
-    maximumFractionDigits: 0,
-  }).format(amount);
-}
 
 const MANUAL_PAYMENT_BANK_COPY_TEXT = [
   'Transferencia bancaria manual',

--- a/src/lib/accounting.ts
+++ b/src/lib/accounting.ts
@@ -28,6 +28,16 @@ export const MOVEMENT_CATEGORIES = [
 
 export type MovementCategory = (typeof MOVEMENT_CATEGORIES)[number];
 
+export function pesosToCents(pesos: number): number {
+  if (!Number.isFinite(pesos)) return 0;
+  return Math.round(pesos * 100);
+}
+
+export function centsToPesos(centavos: number): number {
+  if (!Number.isFinite(centavos)) return 0;
+  return centavos / 100;
+}
+
 export function formatAmount(centavos: number): string {
   return new Intl.NumberFormat('es-AR', {
     style: 'currency',

--- a/src/lib/cart-checkout.ts
+++ b/src/lib/cart-checkout.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
+import { centsToPesos } from '@/lib/accounting';
 import { getActivityParticipantKey } from '@/lib/activity-participants';
 import { getAccessibleChildrenWhere } from '@/lib/family-access';
 import {
@@ -551,7 +552,7 @@ export function toMercadoPagoItems(quote: CartQuote) {
     id: line.id,
     title: line.name,
     quantity: 1,
-    unit_price: line.amount,
+    unit_price: centsToPesos(line.amount),
     currency_id: 'ARS' as const,
     category_id: 'services' as const,
   }));
@@ -560,7 +561,7 @@ export function toMercadoPagoItems(quote: CartQuote) {
     id: `social-fee:${line.participant.userId}:${line.participant.childId ?? 'self'}`,
     title: line.label,
     quantity: 1,
-    unit_price: line.amount,
+    unit_price: centsToPesos(line.amount),
     currency_id: 'ARS' as const,
     category_id: 'services' as const,
   }));
@@ -569,7 +570,7 @@ export function toMercadoPagoItems(quote: CartQuote) {
     id: `discount:${index}`,
     title: line.label,
     quantity: 1,
-    unit_price: -line.amount,
+    unit_price: -centsToPesos(line.amount),
     currency_id: 'ARS' as const,
     category_id: 'services' as const,
   }));
@@ -578,7 +579,7 @@ export function toMercadoPagoItems(quote: CartQuote) {
     id: `mp-fee:${index}`,
     title: line.label,
     quantity: 1,
-    unit_price: line.amount,
+    unit_price: centsToPesos(line.amount),
     currency_id: 'ARS' as const,
     category_id: 'services' as const,
   }));

--- a/src/lib/services/manual-payment-service.ts
+++ b/src/lib/services/manual-payment-service.ts
@@ -157,30 +157,37 @@ function buildManualPaymentUploadPath(paymentId: string, fileName: string) {
   return `manual-payments/${dateSegment}/${paymentId}/${sanitizeFileName(fileName)}`;
 }
 
-function mapPaymentToReview(payment: {
-  id: string;
-  orderId: string;
-  status: PaymentStatus;
-  amount: number;
-  currency: string;
-  paidAt: Date | null;
-  createdAt: Date;
-  updatedAt: Date;
-  payerName: string | null;
-  payerEmail: string | null;
-  receiptUrl: string | null;
-  rawData: Prisma.JsonValue | null;
-  order: {
-    responsibleUserId: string | null;
-    responsibleName: string;
-    responsibleEmail: string;
-    items: Array<{
-      billableConcept: { code: string };
-      activity: { id: string; name: string; description: string | null } | null;
-      description: string;
-    }>;
-  };
-}, childNameById: Map<string, string>): ManualPaymentSummary {
+function mapPaymentToReview(
+  payment: {
+    id: string;
+    orderId: string;
+    status: PaymentStatus;
+    amount: number;
+    currency: string;
+    paidAt: Date | null;
+    createdAt: Date;
+    updatedAt: Date;
+    payerName: string | null;
+    payerEmail: string | null;
+    receiptUrl: string | null;
+    rawData: Prisma.JsonValue | null;
+    order: {
+      responsibleUserId: string | null;
+      responsibleName: string;
+      responsibleEmail: string;
+      items: Array<{
+        billableConcept: { code: string };
+        activity: {
+          id: string;
+          name: string;
+          description: string | null;
+        } | null;
+        description: string;
+      }>;
+    };
+  },
+  childNameById: Map<string, string>
+): ManualPaymentSummary {
   const rawData = getManualPaymentRawData(payment.rawData);
   const reviews = getManualPaymentReviews(payment.rawData);
   const validatedItems = rawData.validatedItems ?? [];
@@ -193,9 +200,7 @@ function mapPaymentToReview(payment: {
       const targetId =
         source?.target && source.target !== 'self' ? source.target : null;
       const participantName = targetId
-        ? childNameById.get(targetId) ??
-          source?.targetLabel ??
-          'Menor'
+        ? (childNameById.get(targetId) ?? source?.targetLabel ?? 'Menor')
         : 'Titular';
 
       return {
@@ -355,7 +360,9 @@ export async function listManualPayments({
 
   return {
     total: countRows[0]?.count ?? 0,
-    items: payments.map((payment) => mapPaymentToReview(payment, childNameById)),
+    items: payments.map((payment) =>
+      mapPaymentToReview(payment, childNameById)
+    ),
   };
 }
 
@@ -575,7 +582,7 @@ export async function createManualPaymentCheckout(input: {
           orderId: order.id,
           provider: 'MANUAL_TRANSFER',
           providerPaymentId: null,
-          amount: input.quote.totalAmount * 100,
+          amount: input.quote.totalAmount,
           currency: 'ARS',
           status: 'PENDING',
           payerName:


### PR DESCRIPTION
### Motivation
- Normalize money handling so amounts are stored as integer centavos in the DB while the UI always displays pesos, fixing mismatched pesos/centavos persisted for activities and related payments.
- Ensure Mercado Pago checkout items receive prices in pesos while internal accounting and DB use centavos for precision and consistency.

### Description
- Added helper functions `pesosToCents` and `centsToPesos` and preserved `formatAmount` to format centavos as ARS pesos in `src/lib/accounting.ts`.
- Updated activity create/edit forms to show prices in pesos and convert to centavos before sending to the API (`src/app/activities/new/form.tsx`, `src/app/activities/[id]/edit/form.tsx`).
- Treated `Activity.price`, order items and activity-related payments as centavos across the backend and adjusted checkout/cart shims to convert to pesos for Mercado Pago item `unit_price` (`src/lib/cart-checkout.ts`, `src/app/api/activities/[id]/checkout/route.ts`, `src/lib/services/mercado-pago-accounting-service.ts` where applicable).
- Fixed manual payment handling to avoid double-multiplying totals and to store the payment `amount` consistently in centavos (`src/lib/services/manual-payment-service.ts`, `src/components/checkout/manual-payment-form.tsx`).
- Updated UI views and reports to format activity/payment prices from centavos (`src/app/*` pages and components touched, and `src/app/api/accounting/reports/route.ts`).
- Added a DB migration `prisma/migrations/20260508130000_store_activity_amounts_in_cents/migration.sql` that multiplies historical Activity.price, ActivityParticipantPayment.amount, and relevant OrderItem unit/total values by 100 to normalize existing data.

### Testing
- Ran `pnpm lint` which completed (result: success, with unrelated Prettier warnings in mobile files retained). 
- Ran `pnpm exec tsc --noEmit`; Type-checking failed due to pre-existing test/type issues in `tests/api/pickup-notices.test.ts` not introduced by this change (files modified in the app no longer report type errors after the fixes). 
- Ran `git diff --check` and repository checks (`rg`) to verify no remaining references to the old pesos multiplications; results OK for modified code paths. 
- Performed local verification of checkout/cart flows and manual payment flows by tracing code paths and updating Mercado Pago item creation to use pesos while storing centavos internally (manual verification, no end-to-end payment executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0b78d2c08328b6e9ae2d1e34cb7f)