### PR TITLE
Add per-user news read status

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -62,7 +62,10 @@ Agents should check this before searching the codebase.
 
 - `/news` → Institutional news feed for members, professors, and admins
   - File: `src/app/news/page.tsx`
-  - Related component: `src/app/news/create-news-form.tsx`
+  - Related components:
+    - `src/app/news/create-news-form.tsx`
+    - `src/app/news/news-list.tsx`
+  - Read-state API: `POST /api/news/read`
 
 ### User
 

--- a/iphone/HualasMobile/APIClient.swift
+++ b/iphone/HualasMobile/APIClient.swift
@@ -312,6 +312,15 @@ final class APIClient {
     try await send(path: "/api/mobile/news", token: token)
   }
 
+  func markNewsRead(token: String, newsIds: [String]) async throws {
+    let _: EmptyResponse = try await send(
+      path: "/api/mobile/news/read",
+      method: "POST",
+      token: token,
+      body: MobileNewsReadRequest(newsIds: newsIds)
+    )
+  }
+
   func notifications(
     token: String,
     unreadOnly: Bool = false,
@@ -659,6 +668,10 @@ struct MobileSwitchRoleResponse: Codable {
   let ok: Bool
   let appRole: MobileRole
   let allowedRoles: [MobileRole]
+}
+
+struct MobileNewsReadRequest: Codable {
+  let newsIds: [String]
 }
 
 struct MobileAttendanceUpdateRequest: Codable {

--- a/iphone/HualasMobile/Models.swift
+++ b/iphone/HualasMobile/Models.swift
@@ -184,6 +184,8 @@ struct MobileHomeResponse: Codable {
     let activityName: String?
     let author: String
     let createdAt: String?
+    var isRead: Bool
+    let readAt: String?
     let media: [Media]
   }
 
@@ -659,6 +661,8 @@ struct MobileNewsResponse: Codable {
     let activityName: String?
     let author: String
     let createdAt: String?
+    var isRead: Bool
+    let readAt: String?
     let media: [Media]
   }
 

--- a/iphone/HualasMobile/Views/Member/NewsView.swift
+++ b/iphone/HualasMobile/Views/Member/NewsView.swift
@@ -3,18 +3,47 @@ import SwiftUI
 struct NewsView: View {
   @EnvironmentObject private var sessionStore: SessionStore
   @State private var news: [MobileNewsResponse.NewsItem] = []
+  @State private var isLoading = false
+  @State private var errorMessage: String?
+  @State private var pendingReadIds = Set<String>()
+  @State private var queuedReadIds = Set<String>()
+  @State private var readFlushTask: Task<Void, Never>?
 
   var body: some View {
-    List(news) { item in
-      VStack(alignment: .leading, spacing: 6) {
-        Text(item.title).font(.headline)
-        if let activityName = item.activityName {
-          Text(activityName).font(.footnote).foregroundStyle(.secondary)
-        }
-        Text(item.body)
-          .font(.subheadline)
+    List {
+      if isLoading && news.isEmpty {
+        ProgressView("Cargando noticias…")
       }
-      .padding(.vertical, 4)
+
+      if let errorMessage {
+        Text(errorMessage)
+          .font(.footnote)
+          .foregroundStyle(.red)
+      }
+
+      ForEach($news) { $item in
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 8) {
+            Text(item.title).font(.headline)
+            if !item.isRead {
+              Text("No leído")
+                .font(.caption2.weight(.semibold))
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .background(Color.orange.opacity(0.18), in: Capsule())
+                .foregroundStyle(.orange)
+            }
+          }
+
+          if let activityName = item.activityName {
+            Text(activityName).font(.footnote).foregroundStyle(.secondary)
+          }
+          Text(item.body)
+            .font(.subheadline)
+        }
+        .padding(.vertical, 4)
+        .onAppear { markReadIfNeeded(id: item.id) }
+      }
     }
     .navigationTitle("Noticias")
     .navigationBarTitleDisplayMode(.inline)
@@ -24,12 +53,63 @@ struct NewsView: View {
 
   private func load() async {
     guard let token = sessionStore.token else { return }
+    isLoading = true
+    errorMessage = nil
+
     do {
       let response = try await APIClient.shared.news(token: token)
       news = response.news
     } catch {
       guard !error.isCancellationError else { return }
+      errorMessage = "No pudimos cargar las noticias. Intentá de nuevo."
       print("[news] load failed", error)
+    }
+
+    isLoading = false
+  }
+
+  private func markReadIfNeeded(id: String) {
+    guard news.contains(where: { $0.id == id && !$0.isRead }) else { return }
+    guard !pendingReadIds.contains(id), !queuedReadIds.contains(id) else { return }
+
+    queuedReadIds.insert(id)
+    readFlushTask?.cancel()
+    readFlushTask = Task {
+      try? await Task.sleep(nanoseconds: 350_000_000)
+      guard !Task.isCancelled else { return }
+      await MainActor.run { flushReadQueue() }
+    }
+  }
+
+  private func flushReadQueue() {
+    guard let token = sessionStore.token else { return }
+    let ids = Array(queuedReadIds).filter { id in
+      news.contains(where: { $0.id == id && !$0.isRead })
+    }
+    queuedReadIds.removeAll()
+
+    guard !ids.isEmpty else { return }
+
+    ids.forEach { pendingReadIds.insert($0) }
+
+    Task {
+      do {
+        try await APIClient.shared.markNewsRead(token: token, newsIds: ids)
+        await MainActor.run {
+          for id in ids {
+            if let currentIndex = news.firstIndex(where: { $0.id == id }) {
+              news[currentIndex].isRead = true
+            }
+            pendingReadIds.remove(id)
+          }
+        }
+      } catch {
+        await MainActor.run {
+          ids.forEach { pendingReadIds.remove($0) }
+          errorMessage = "No pudimos actualizar el estado de lectura."
+        }
+        print("[news] mark read failed", error)
+      }
     }
   }
 }

--- a/iphone/README.md
+++ b/iphone/README.md
@@ -34,6 +34,7 @@ The app expects these endpoints:
 - `GET /api/mobile/activities?month=YYYY-MM&day=YYYY-MM-DD`
 - `GET /api/mobile/payments`
 - `GET /api/mobile/news`
+- `POST /api/mobile/news/read`
 - `GET /api/mobile/chat/contacts`
 - `GET /api/mobile/family-groups/current/members`
 - `POST /api/mobile/family-groups/current/members`

--- a/prisma/migrations/20260509130000_add_news_read_receipts/migration.sql
+++ b/prisma/migrations/20260509130000_add_news_read_receipts/migration.sql
@@ -1,0 +1,20 @@
+CREATE TABLE "NewsReadReceipt" (
+  "id" TEXT NOT NULL,
+  "newsId" TEXT NOT NULL,
+  "userId" TEXT NOT NULL,
+  "readAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "NewsReadReceipt_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "NewsReadReceipt_newsId_userId_key" ON "NewsReadReceipt"("newsId", "userId");
+CREATE INDEX "NewsReadReceipt_userId_readAt_idx" ON "NewsReadReceipt"("userId", "readAt");
+CREATE INDEX "NewsReadReceipt_newsId_idx" ON "NewsReadReceipt"("newsId");
+
+ALTER TABLE "NewsReadReceipt"
+  ADD CONSTRAINT "NewsReadReceipt_newsId_fkey"
+  FOREIGN KEY ("newsId") REFERENCES "News"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "NewsReadReceipt"
+  ADD CONSTRAINT "NewsReadReceipt_userId_fkey"
+  FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -59,6 +59,7 @@ model User {
   pickupNoticeAcknowledgments PickupNoticeAcknowledgment[]
   notifications               Notification[]
   createdNews                 News[]                       @relation("NewsCreatedBy")
+  newsReadReceipts            NewsReadReceipt[]
   pushAlertSubscriptions      PushAlertSubscription[]
   mobileSessions              MobileSession[]
   mobileDeviceTokens          MobileDeviceToken[]
@@ -765,13 +766,27 @@ model News {
   activity    Activity?   @relation(fields: [activityId], references: [id], onDelete: SetNull)
   createdById String
   createdBy   User        @relation("NewsCreatedBy", fields: [createdById], references: [id], onDelete: Cascade)
-  media       NewsMedia[]
-  createdAt   DateTime    @default(now())
-  updatedAt   DateTime    @updatedAt
+  media        NewsMedia[]
+  readReceipts NewsReadReceipt[]
+  createdAt    DateTime    @default(now())
+  updatedAt    DateTime    @updatedAt
 
   @@index([scope, createdAt])
   @@index([activityId, createdAt])
   @@index([createdById, createdAt])
+}
+
+model NewsReadReceipt {
+  id     String   @id @default(cuid())
+  newsId String
+  news   News     @relation(fields: [newsId], references: [id], onDelete: Cascade)
+  userId String
+  user   User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  readAt DateTime @default(now())
+
+  @@unique([newsId, userId])
+  @@index([userId, readAt])
+  @@index([newsId])
 }
 
 model NewsMedia {

--- a/src/app/api/mobile/home/route.ts
+++ b/src/app/api/mobile/home/route.ts
@@ -278,6 +278,11 @@ async function loadRecentMobileNews(
       createdAt: true,
       activity: { select: { id: true, name: true } },
       createdBy: { select: { name: true, lastName: true } },
+      readReceipts: {
+        where: { userId },
+        select: { readAt: true },
+        take: 1,
+      },
       media: {
         orderBy: { createdAt: 'asc' },
         select: {
@@ -302,6 +307,10 @@ async function loadRecentMobileNews(
     activityName: item.activity?.name ?? null,
     author: formatFullName(item.createdBy),
     createdAt: formatMobileDate(item.createdAt),
+    isRead: item.readReceipts.length > 0,
+    readAt: item.readReceipts[0]
+      ? formatMobileDate(item.readReceipts[0].readAt)
+      : null,
     media: item.media.map((media) => ({
       id: media.id,
       url: media.url,

--- a/src/app/api/mobile/news/read/route.ts
+++ b/src/app/api/mobile/news/read/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { getMobileSessionFromRequest } from '@/lib/mobile-auth';
+import { markReadableNewsAsRead } from '@/lib/news-read-status';
+
+const MAX_NEWS_PER_REQUEST = 50;
+
+function parseNewsIds(input: unknown) {
+  if (Array.isArray(input)) {
+    return input
+      .filter((id): id is string => typeof id === 'string')
+      .slice(0, MAX_NEWS_PER_REQUEST);
+  }
+
+  if (typeof input === 'string') return [input];
+
+  return [];
+}
+
+export async function POST(req: Request) {
+  const session = await getMobileSessionFromRequest(req);
+  if (!session) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'La solicitud no tiene un JSON válido' },
+      { status: 400 }
+    );
+  }
+
+  const newsIds = parseNewsIds(
+    (payload as { newsIds?: unknown; newsId?: unknown }).newsIds ??
+      (payload as { newsId?: unknown }).newsId
+  );
+
+  if (newsIds.length === 0) {
+    return NextResponse.json(
+      { error: 'Seleccioná al menos una noticia' },
+      { status: 400 }
+    );
+  }
+
+  const result = await markReadableNewsAsRead({
+    userId: session.userId,
+    role: session.appRole,
+    newsIds,
+  });
+
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/src/app/api/mobile/news/route.ts
+++ b/src/app/api/mobile/news/route.ts
@@ -34,6 +34,11 @@ export async function GET(req: Request) {
     include: {
       activity: { select: { id: true, name: true } },
       createdBy: { select: { name: true, lastName: true } },
+      readReceipts: {
+        where: { userId: session.userId },
+        select: { readAt: true },
+        take: 1,
+      },
       media: {
         orderBy: { createdAt: 'asc' },
         select: {
@@ -59,6 +64,10 @@ export async function GET(req: Request) {
       activityName: item.activity?.name ?? null,
       author: formatFullName(item.createdBy),
       createdAt: formatMobileDate(item.createdAt),
+      isRead: item.readReceipts.length > 0,
+      readAt: item.readReceipts[0]
+        ? formatMobileDate(item.readReceipts[0].readAt)
+        : null,
       media: item.media,
     })),
   });

--- a/src/app/api/news/read/route.ts
+++ b/src/app/api/news/read/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { markReadableNewsAsRead } from '@/lib/news-read-status';
+
+const MAX_NEWS_PER_REQUEST = 50;
+
+function parseNewsIds(input: unknown) {
+  if (Array.isArray(input)) {
+    return input
+      .filter((id): id is string => typeof id === 'string')
+      .slice(0, MAX_NEWS_PER_REQUEST);
+  }
+
+  if (typeof input === 'string') return [input];
+
+  return [];
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await req.json();
+  } catch {
+    return NextResponse.json(
+      { error: 'La solicitud no tiene un JSON válido' },
+      { status: 400 }
+    );
+  }
+
+  const newsIds = parseNewsIds(
+    (payload as { newsIds?: unknown; newsId?: unknown }).newsIds ??
+      (payload as { newsId?: unknown }).newsId
+  );
+
+  if (newsIds.length === 0) {
+    return NextResponse.json(
+      { error: 'Seleccioná al menos una noticia' },
+      { status: 400 }
+    );
+  }
+
+  const role = session.user.activeRole ?? session.user.role;
+  const result = await markReadableNewsAsRead({
+    userId: session.user.id,
+    role,
+    newsIds,
+  });
+
+  return NextResponse.json({ ok: true, ...result });
+}

--- a/src/app/news/news-list.tsx
+++ b/src/app/news/news-list.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type NewsMediaItem = {
+  id: string;
+  type: 'IMAGE' | 'VIDEO';
+  fileName: string | null;
+};
+
+export type NewsListItem = {
+  id: string;
+  title: string;
+  body: string;
+  scopeLabel: string;
+  createdAtLabel: string;
+  creatorLabel: string;
+  isRead: boolean;
+  media: NewsMediaItem[];
+};
+
+type NewsReadState = Record<string, boolean>;
+
+type NewsListProps = {
+  items: NewsListItem[];
+};
+
+const BATCH_DELAY_MS = 350;
+
+export default function NewsList({ items }: NewsListProps) {
+  const [readState, setReadState] = useState<NewsReadState>(() =>
+    Object.fromEntries(items.map((item) => [item.id, item.isRead]))
+  );
+  const [pendingIds, setPendingIds] = useState<Set<string>>(() => new Set());
+  const [error, setError] = useState<string | null>(null);
+  const observerRef = useRef<IntersectionObserver | null>(null);
+  const elementsRef = useRef(new Map<string, HTMLElement>());
+  const queuedIdsRef = useRef(new Set<string>());
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const readStateRef = useRef(readState);
+
+  useEffect(() => {
+    setReadState((current) => ({
+      ...current,
+      ...Object.fromEntries(
+        items.map((item) => [item.id, Boolean(current[item.id] || item.isRead)])
+      ),
+    }));
+  }, [items]);
+
+  useEffect(() => {
+    readStateRef.current = readState;
+  }, [readState]);
+
+  const flushQueue = useCallback(async () => {
+    timerRef.current = null;
+    const ids = Array.from(queuedIdsRef.current).filter(
+      (id) => !readStateRef.current[id]
+    );
+    queuedIdsRef.current.clear();
+
+    if (ids.length === 0) return;
+
+    setPendingIds((current) => {
+      const next = new Set(current);
+      ids.forEach((id) => next.add(id));
+      return next;
+    });
+    setError(null);
+
+    try {
+      const response = await fetch('/api/news/read', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ newsIds: ids }),
+      });
+
+      if (!response.ok) throw new Error('No se pudo marcar como leída');
+
+      const data = (await response.json()) as { readableIds?: string[] };
+      const markedIds = data.readableIds ?? ids;
+
+      setReadState((current) => ({
+        ...current,
+        ...Object.fromEntries(markedIds.map((id) => [id, true])),
+      }));
+    } catch (err) {
+      console.error('[news] mark read failed', err);
+      setError(
+        'No pudimos actualizar el estado de lectura. Probá actualizar la página.'
+      );
+    } finally {
+      setPendingIds((current) => {
+        const next = new Set(current);
+        ids.forEach((id) => next.delete(id));
+        return next;
+      });
+    }
+  }, []);
+
+  const queueRead = useCallback(
+    (id: string) => {
+      if (readStateRef.current[id]) return;
+      queuedIdsRef.current.add(id);
+
+      if (!timerRef.current) {
+        timerRef.current = setTimeout(flushQueue, BATCH_DELAY_MS);
+      }
+    },
+    [flushQueue]
+  );
+
+  const registerArticle = useCallback(
+    (id: string) => (node: HTMLElement | null) => {
+      const previous = elementsRef.current.get(id);
+      if (previous) observerRef.current?.unobserve(previous);
+
+      if (!node) {
+        elementsRef.current.delete(id);
+        return;
+      }
+
+      elementsRef.current.set(id, node);
+      observerRef.current?.observe(node);
+    },
+    []
+  );
+
+  useEffect(() => {
+    observerRef.current?.disconnect();
+
+    observerRef.current = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (!entry.isIntersecting) return;
+          const id = entry.target.getAttribute('data-news-id');
+          if (!id) return;
+          queueRead(id);
+          observerRef.current?.unobserve(entry.target);
+        });
+      },
+      { threshold: 0.55 }
+    );
+
+    elementsRef.current.forEach((element) =>
+      observerRef.current?.observe(element)
+    );
+
+    return () => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+    };
+  }, [queueRead]);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  return (
+    <section className="space-y-4" aria-label="Listado de noticias">
+      {error && (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {items.map((item) => {
+        const isRead = readState[item.id] ?? item.isRead;
+        const isPending = pendingIds.has(item.id);
+
+        return (
+          <article
+            id={item.id}
+            key={item.id}
+            ref={registerArticle(item.id)}
+            data-news-id={item.id}
+            className="scroll-mt-24 rounded-2xl border bg-card p-5 shadow-sm"
+          >
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="inline-flex rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                    {item.scopeLabel}
+                  </span>
+                  {!isRead && (
+                    <span className="inline-flex items-center gap-1 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+                      <span className="h-2 w-2 rounded-full bg-amber-500" />
+                      {isPending ? 'Marcando…' : 'No leído'}
+                    </span>
+                  )}
+                </div>
+                <h2 className="text-2xl font-semibold tracking-tight">
+                  {item.title}
+                </h2>
+              </div>
+              <p className="text-sm text-muted-foreground">
+                {item.createdAtLabel}
+              </p>
+            </div>
+
+            <p className="mt-2 text-sm text-muted-foreground">
+              Publicado por {item.creatorLabel}
+            </p>
+
+            <div className="mt-4 whitespace-pre-wrap leading-7 text-foreground/90">
+              {item.body}
+            </div>
+
+            {item.media.length > 0 && (
+              <div className="mt-5 grid gap-3 md:grid-cols-2">
+                {item.media.map((media) => {
+                  const src = `/api/news/${media.id}/media`;
+                  return media.type === 'IMAGE' ? (
+                    <div
+                      key={media.id}
+                      className="relative aspect-video overflow-hidden rounded-xl border bg-muted"
+                    >
+                      <Image
+                        src={src}
+                        alt={media.fileName ?? item.title}
+                        fill
+                        unoptimized
+                        className="object-cover"
+                        sizes="(min-width: 768px) 50vw, 100vw"
+                      />
+                    </div>
+                  ) : (
+                    <video
+                      key={media.id}
+                      src={src}
+                      controls
+                      className="aspect-video w-full rounded-xl border bg-black"
+                    >
+                      Tu navegador no puede reproducir este video.
+                    </video>
+                  );
+                })}
+              </div>
+            )}
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/src/app/news/page.tsx
+++ b/src/app/news/page.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import type { Prisma, Role } from '@prisma/client';
@@ -6,12 +5,14 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { getReadableActivityIds, isNewsAdminRole } from '@/lib/news-access';
 import CreateNewsForm from './create-news-form';
+import NewsList, { type NewsListItem } from './news-list';
 
 type NewsWithRelations = Prisma.NewsGetPayload<{
   include: {
     activity: { select: { name: true } };
     createdBy: { select: { name: true; lastName: true } };
     media: true;
+    readReceipts: { select: { readAt: true } };
   };
 }>;
 
@@ -21,7 +22,7 @@ type ActivityOption = {
 };
 
 type NewsPageData = {
-  news: NewsWithRelations[];
+  news: NewsListItem[];
   activities: ActivityOption[];
 };
 
@@ -72,6 +73,11 @@ async function loadNewsPageData({
         activity: { select: { name: true } },
         createdBy: { select: { name: true, lastName: true } },
         media: { orderBy: { createdAt: 'asc' } },
+        readReceipts: {
+          where: { userId },
+          select: { readAt: true },
+          take: 1,
+        },
       },
       orderBy: { createdAt: 'desc' },
       take: 50,
@@ -84,7 +90,26 @@ async function loadNewsPageData({
       : Promise.resolve([]),
   ]);
 
-  return { news, activities };
+  return {
+    news: news.map((item) => ({
+      id: item.id,
+      title: item.title,
+      body: item.body,
+      scopeLabel:
+        item.scope === 'CLUB'
+          ? 'Para todo el club'
+          : (item.activity?.name ?? 'Actividad'),
+      createdAtLabel: formatDate(item.createdAt),
+      creatorLabel: creatorName(item),
+      isRead: item.readReceipts.length > 0,
+      media: item.media.map((media) => ({
+        id: media.id,
+        type: media.type,
+        fileName: media.fileName,
+      })),
+    })),
+    activities,
+  };
 }
 
 export default async function NewsPage() {
@@ -144,71 +169,7 @@ export default async function NewsPage() {
           </p>
         </div>
       ) : (
-        <section className="space-y-4" aria-label="Listado de noticias">
-          {news.map((item) => (
-            <article
-              id={item.id}
-              key={item.id}
-              className="scroll-mt-24 rounded-2xl border bg-card p-5 shadow-sm"
-            >
-              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                <div className="space-y-1">
-                  <span className="inline-flex rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
-                    {item.scope === 'CLUB'
-                      ? 'Para todo el club'
-                      : (item.activity?.name ?? 'Actividad')}
-                  </span>
-                  <h2 className="text-2xl font-semibold tracking-tight">
-                    {item.title}
-                  </h2>
-                </div>
-                <p className="text-sm text-muted-foreground">
-                  {formatDate(item.createdAt)}
-                </p>
-              </div>
-
-              <p className="mt-2 text-sm text-muted-foreground">
-                Publicado por {creatorName(item)}
-              </p>
-
-              <div className="mt-4 whitespace-pre-wrap leading-7 text-foreground/90">
-                {item.body}
-              </div>
-
-              {item.media.length > 0 && (
-                <div className="mt-5 grid gap-3 md:grid-cols-2">
-                  {item.media.map((media) => {
-                    const src = `/api/news/${media.id}/media`;
-                    return media.type === 'IMAGE' ? (
-                      <div
-                        key={media.id}
-                        className="relative aspect-video overflow-hidden rounded-xl border bg-muted"
-                      >
-                        <Image
-                          src={src}
-                          alt={media.fileName ?? item.title}
-                          fill
-                          unoptimized
-                          className="object-cover"
-                          sizes="(min-width: 768px) 50vw, 100vw"
-                        />
-                      </div>
-                    ) : (
-                      <video
-                        key={media.id}
-                        src={src}
-                        controls
-                        className="aspect-video w-full rounded-xl border bg-black"
-                      >
-                        Tu navegador no puede reproducir este video.
-                      </video>
-                    );
-                  })}
-                </div>
-              )}
-            </article>
-          ))}
-        </section>
+        <NewsList items={news} />
       )}
     </main>
   );

--- a/src/lib/news-read-status.ts
+++ b/src/lib/news-read-status.ts
@@ -1,0 +1,82 @@
+import type { Prisma, Role } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import { getReadableActivityIds, isNewsAdminRole } from '@/lib/news-access';
+
+export function readableNewsWhereForUser({
+  userId,
+  role,
+  readableActivityIds,
+}: {
+  userId: string;
+  role: Role;
+  readableActivityIds: string[] | null;
+}): Prisma.NewsWhereInput {
+  if (isNewsAdminRole(role)) return {};
+
+  return {
+    OR: [
+      { scope: 'CLUB' },
+      ...(readableActivityIds && readableActivityIds.length > 0
+        ? [
+            {
+              scope: 'ACTIVITY' as const,
+              activityId: { in: readableActivityIds },
+            },
+          ]
+        : []),
+    ],
+  };
+}
+
+export async function getReadableNewsWhere(input: {
+  userId: string;
+  role: Role;
+}) {
+  const readableActivityIds = await getReadableActivityIds(input);
+  return readableNewsWhereForUser({ ...input, readableActivityIds });
+}
+
+export async function markReadableNewsAsRead(input: {
+  userId: string;
+  role: Role;
+  newsIds: string[];
+}) {
+  const uniqueIds = Array.from(
+    new Set(input.newsIds.map((id) => id.trim()))
+  ).filter(Boolean);
+
+  if (uniqueIds.length === 0) {
+    return { markedCount: 0, readableIds: [] as string[] };
+  }
+
+  const readableWhere = await getReadableNewsWhere({
+    userId: input.userId,
+    role: input.role,
+  });
+
+  const readableNews = await prisma.news.findMany({
+    where: {
+      AND: [{ id: { in: uniqueIds } }, readableWhere],
+    },
+    select: { id: true },
+  });
+
+  if (readableNews.length === 0) {
+    return { markedCount: 0, readableIds: [] as string[] };
+  }
+
+  const now = new Date();
+  const result = await prisma.newsReadReceipt.createMany({
+    data: readableNews.map((item) => ({
+      newsId: item.id,
+      userId: input.userId,
+      readAt: now,
+    })),
+    skipDuplicates: true,
+  });
+
+  return {
+    markedCount: result.count,
+    readableIds: readableNews.map((item) => item.id),
+  };
+}


### PR DESCRIPTION
### Motivation
- Añadir un estado persistente de “Leído / No leído” por usuario para la sección de noticias sin romper el sistema existente ni generar requests innecesarios. 
- Permitir que las noticias se marquen automáticamente como leídas cuando el usuario las visualiza y que ese estado se muestre en web y mobile.

### Description
- Se agregó el modelo Prisma `NewsReadReceipt` y una migración SQL para almacenar lecturas por `(newsId, userId)` con índices para consultas eficientes. (archivo: `prisma/schema.prisma`, migración: `prisma/migrations/20260509130000_add_news_read_receipts/migration.sql`).
- Se implementó el helper `markReadableNewsAsRead` con validación de acceso y `createMany(..., skipDuplicates)` para insertar en batch sin duplicados (archivo: `src/lib/news-read-status.ts`).
- Nuevos endpoints batch para marcar lecturas: `POST /api/news/read` y `POST /api/mobile/news/read` con validaciones simples y chequeo de sesión (archivos: `src/app/api/news/read/route.ts`, `src/app/api/mobile/news/read/route.ts`).
- Actualicé la lista de noticias en web para incluir el estado `isRead` en la misma consulta y moví el render cliente a `NewsList` que muestra badge “No leído”, indicador “Marcando…” y usa `IntersectionObserver` + batching para marcar automáticamente lecturas en vista (archivos: `src/app/news/page.tsx`, `src/app/news/news-list.tsx`).
- Extendí las APIs mobile (`/api/mobile/news` y `/api/mobile/home`) para devolver `isRead/readAt` y actualicé el cliente iOS (Swift) y documentación para soportar marcado en batch desde la app (archivos: `src/app/api/mobile/news/route.ts`, `src/app/api/mobile/home/route.ts`, `iphone/HualasMobile/*`, `iphone/README.md`).

### Testing
- Ejecuté `pnpm prisma:generate` y funcionó correctamente. ✅
- Ejecuté `pnpm exec prisma validate` y la schema Prisma es válida. ✅
- Ejecuté `pnpm lint` (Next.js ESLint); pasó pero el repo muestra warnings de Prettier existentes que no están relacionados con este cambio. ✅
- Ejecuté `pnpm exec tsc --noEmit` y la compilación TypeScript falló por errores de tipado en tests existentes (`tests/api/pickup-notices.test.ts`) que son ajenos a este cambio, por lo que no se consideró un error del PR. ❌ (fallido por problemas previos)
- Intenté compilar la app iOS con `xcodebuild` pero la herramienta no está disponible en este entorno, por lo que no se pudo validar el build nativo aquí. ⚠️

Unresolved risks
- No se pudo comprobar la compilación iOS localmente por ausencia de `xcodebuild` en el entorno. 
- `tsc --noEmit` muestra errores en tests del repositorio no relacionados; conviene ejecutar la suite de tests en CI para validar que no haya regresiones en entornos donde esos tests pasen.
- Si en el futuro se añade una pantalla de detalle para noticias, convendría mover el trigger de marcado desde el viewport al evento de apertura de detalle para evitar marcar lecturas prematuras.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff547d7a7c832887d9cdef52bd2dbd)