### PR TITLE
Route enrolled users home to Mis actividades

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,18 @@
 import Link from 'next/link';
+import { getServerSession } from 'next-auth';
+import { redirect } from 'next/navigation';
 import { listActivitiesWithParticipantCount } from '@/lib/activities/activity-records';
 import { formatAmount } from '@/lib/accounting';
+import { authOptions } from '@/lib/auth';
+import { shouldUseMyActivitiesAsHome } from '@/lib/post-login-redirect';
 
 export default async function Home() {
+  const session = await getServerSession(authOptions);
+
+  if (await shouldUseMyActivitiesAsHome(session)) {
+    redirect('/my-activities');
+  }
+
   let activities: Awaited<
     ReturnType<typeof listActivitiesWithParticipantCount>
   > = [];

--- a/src/lib/__tests__/post-login-redirect.test.ts
+++ b/src/lib/__tests__/post-login-redirect.test.ts
@@ -23,7 +23,10 @@ jest.mock('@/lib/family-access', () => ({
 import type { Session } from 'next-auth';
 import { prisma } from '@/lib/prisma';
 import { getAccessibleChildOwnerIds } from '@/lib/family-access';
-import { getPostLoginRedirectUrl } from '../post-login-redirect';
+import {
+  getPostLoginRedirectUrl,
+  shouldUseMyActivitiesAsHome,
+} from '../post-login-redirect';
 
 const mockPrisma = prisma as unknown as {
   activityParticipant: { count: jest.Mock };
@@ -86,6 +89,32 @@ describe('getPostLoginRedirectUrl', () => {
         ],
       },
     });
+  });
+
+  it('envía siempre al profesor a Mis actividades aunque no tenga actividades asignadas', async () => {
+    await expect(
+      getPostLoginRedirectUrl(
+        buildSession({
+          role: 'PROFESSOR',
+          activeRole: 'PROFESSOR',
+          roles: ['MEMBER', 'PROFESSOR'],
+        })
+      )
+    ).resolves.toBe('/my-activities');
+
+    expect(mockGetAccessibleChildOwnerIds).not.toHaveBeenCalled();
+    expect(mockPrisma.activityParticipant.count).not.toHaveBeenCalled();
+    expect(mockPrisma.activityProfessor.count).not.toHaveBeenCalled();
+    expect(mockPrisma.user.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('detecta Mis actividades como home principal cuando un hijo accesible tiene inscripciones', async () => {
+    mockGetAccessibleChildOwnerIds.mockResolvedValue(['user_1', 'parent_2']);
+    mockPrisma.activityParticipant.count.mockResolvedValue(1);
+
+    await expect(shouldUseMyActivitiesAsHome(buildSession())).resolves.toBe(
+      true
+    );
   });
 
   it('mantiene el onboarding actual si no tiene actividades y el perfil está incompleto', async () => {

--- a/src/lib/post-login-redirect.ts
+++ b/src/lib/post-login-redirect.ts
@@ -4,6 +4,30 @@ import { getAccessibleChildOwnerIds } from '@/lib/family-access';
 import { checkUserProfile } from '@/lib/participant-profile-check';
 import { prisma } from '@/lib/prisma';
 
+export async function shouldUseMyActivitiesAsHome(session: Session | null) {
+  if (!session) {
+    return false;
+  }
+
+  if (session.user.role === 'PROFESSOR') {
+    return true;
+  }
+
+  if (session.user.role !== 'MEMBER') {
+    return false;
+  }
+
+  const userId = session.user.id;
+  const accessibleChildOwnerIds = await getAccessibleChildOwnerIds(userId);
+  const participantCount = await prisma.activityParticipant.count({
+    where: {
+      OR: [{ userId }, { child: { userId: { in: accessibleChildOwnerIds } } }],
+    },
+  });
+
+  return participantCount > 0;
+}
+
 export async function getPostLoginRedirectUrl(session: Session | null) {
   if (!session) {
     return '/login';
@@ -13,26 +37,11 @@ export async function getPostLoginRedirectUrl(session: Session | null) {
     return '/accounting';
   }
 
-  const userId = session.user.id;
-  const accessibleChildOwnerIds = await getAccessibleChildOwnerIds(userId);
-
-  const [participantCount, professorCount] = await Promise.all([
-    prisma.activityParticipant.count({
-      where: {
-        OR: [
-          { userId },
-          { child: { userId: { in: accessibleChildOwnerIds } } },
-        ],
-      },
-    }),
-    prisma.activityProfessor.count({ where: { userId } }),
-  ]);
-
-  const hasActivities = participantCount > 0 || professorCount > 0;
-  if (hasActivities) {
+  if (await shouldUseMyActivitiesAsHome(session)) {
     return '/my-activities';
   }
 
+  const userId = session.user.id;
   const user = await prisma.user.findUnique({
     where: { id: userId },
     select: {


### PR DESCRIPTION
### Motivation
- Ensure the app respects product rules: if a user or any accessible child is already enrolled in an activity their primary Home should be “Mis actividades”, and professors should always land on “Mis actividades”.
- Centralize the decision logic for post-login/home routing so the same rule is reused by the `/` page and the post-login redirect flow.

### Description
- Added `shouldUseMyActivitiesAsHome(session)` to `src/lib/post-login-redirect.ts` to encapsulate the rule that professors always use `my-activities` and members use it when they or an accessible child have activity registrations. 
- Updated `getPostLoginRedirectUrl` in `src/lib/post-login-redirect.ts` to call the new helper and return `/my-activities` when appropriate.
- Updated the public home page `src/app/page.tsx` to load the server session and redirect to `/my-activities` when `shouldUseMyActivitiesAsHome` is true before rendering public activities.
- Extended unit tests in `src/lib/__tests__/post-login-redirect.test.ts` to cover: member with registrations, accessible child registrations, and professor sessions (professors always go to `my-activities`).

### Testing
- Ran unit tests: `pnpm test -- src/lib/__tests__/post-login-redirect.test.ts --runInBand` (all tests passed).
- Ran linter: `pnpm lint` (completed; repository shows unrelated Prettier warnings in other files but no new failures from this change).
- Ran Prettier check on changed files: `pnpm exec prettier --check src/app/page.tsx src/lib/post-login-redirect.ts src/lib/__tests__/post-login-redirect.test.ts` (passed).
- Type check: `pnpm exec tsc --noEmit` surfaced unrelated existing TypeScript errors in other parts of the codebase (Prisma/notifications/mobile typing); those are preexisting and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff588746348328a2b2f8dbd0522a0b)