### PR TITLE
Add activity media gallery

### DIFF
--- a/prisma/migrations/20260509000000_add_activity_media/migration.sql
+++ b/prisma/migrations/20260509000000_add_activity_media/migration.sql
@@ -1,0 +1,22 @@
+-- CreateEnum
+CREATE TYPE "ActivityMediaType" AS ENUM ('IMAGE', 'VIDEO');
+
+-- CreateTable
+CREATE TABLE "ActivityMedia" (
+    "id" TEXT NOT NULL,
+    "activityId" TEXT NOT NULL,
+    "url" TEXT NOT NULL,
+    "type" "ActivityMediaType" NOT NULL,
+    "fileName" TEXT,
+    "contentType" TEXT,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ActivityMedia_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ActivityMedia_activityId_sortOrder_idx" ON "ActivityMedia"("activityId", "sortOrder");
+
+-- AddForeignKey
+ALTER TABLE "ActivityMedia" ADD CONSTRAINT "ActivityMedia_activityId_fkey" FOREIGN KEY ("activityId") REFERENCES "Activity"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,12 +169,28 @@ model Activity {
   price        Int                   @default(0)
   participants ActivityParticipant[]
   participantPayments ActivityParticipantPayment[]
+  media        ActivityMedia[]
   news         News[]
   professors   ActivityProfessor[]
   groups       ActivityGroup[]
   days         ActivityDay[]
   createdAt    DateTime              @default(now())
   orderItems   OrderItem[]
+}
+
+model ActivityMedia {
+  id          String            @id @default(cuid())
+  activityId  String
+  url         String
+  type        ActivityMediaType
+  fileName    String?
+  contentType String?
+  sortOrder   Int               @default(0)
+  createdAt   DateTime          @default(now())
+
+  activity Activity @relation(fields: [activityId], references: [id], onDelete: Cascade)
+
+  @@index([activityId, sortOrder])
 }
 
 model ActivityParticipant {
@@ -685,6 +701,11 @@ enum ActivityFrequency {
   WEEKLY
   MONTHLY
   ONE_TIME
+}
+
+enum ActivityMediaType {
+  IMAGE
+  VIDEO
 }
 
 enum ActivityType {

--- a/src/app/activities/[id]/edit/page.tsx
+++ b/src/app/activities/[id]/edit/page.tsx
@@ -6,6 +6,7 @@ import { prisma } from '@/lib/prisma';
 import { gateAdmin } from '@/lib/role-guards';
 import EditActivityForm from './form';
 import ActivityImageUpload from '../../activity-image-upload';
+import ActivityMediaManager from '../../activity-media-manager';
 
 interface EditActivityPageProps {
   params: { id: string };
@@ -29,6 +30,7 @@ export default async function EditActivityPage({
     existingDayCount,
     firstAnnualDay,
     annualCalendarSample,
+    activityMedia,
   ] = await Promise.all([
     prisma.user.findMany({
       where: {
@@ -97,6 +99,16 @@ export default async function EditActivityPage({
         },
       },
     }),
+    prisma.activityMedia.findMany({
+      where: { activityId: params.id },
+      orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+      select: {
+        id: true,
+        type: true,
+        fileName: true,
+        sortOrder: true,
+      },
+    }),
   ]);
 
   const initialAnnualSchedules =
@@ -148,10 +160,20 @@ export default async function EditActivityPage({
         existingDayCount={existingDayCount}
       />
       <div className="mt-8 border-t pt-8">
-        <h2 className="mb-4 text-xl font-semibold">Imagen de la actividad</h2>
+        <h2 className="mb-4 text-xl font-semibold">Imagen de portada</h2>
+        <p className="mb-4 text-sm text-muted-foreground">
+          Esta imagen se usa como portada principal de la actividad.
+        </p>
         <ActivityImageUpload
           activityId={params.id}
           currentImageUrl={activity.image ?? undefined}
+        />
+      </div>
+      <div className="mt-8 border-t pt-8">
+        <h2 className="mb-4 text-xl font-semibold">Fotos y videos</h2>
+        <ActivityMediaManager
+          activityId={params.id}
+          initialMedia={activityMedia}
         />
       </div>
     </main>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -134,6 +134,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
     activityGroups,
     days,
     pickupNoticesByDay,
+    activityMedia,
   ] = await Promise.all([
     prisma.activityParticipant
       .findMany({
@@ -284,6 +285,16 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
       })
       .catch((error) => {
         console.error('[activity-page] pickup notices query failed', error);
+        return [];
+      }),
+    prisma.activityMedia
+      .findMany({
+        where: { activityId: activity.id },
+        orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+        select: { id: true, type: true, fileName: true },
+      })
+      .catch((error) => {
+        console.error('[activity-page] media query failed', error);
         return [];
       }),
   ]);
@@ -467,6 +478,49 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
                 </p>
               )}
             </div>
+
+            {activityMedia.length > 0 && (
+              <section className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
+                <div>
+                  <h2 className="font-heading text-xl font-semibold">
+                    Fotos y videos
+                  </h2>
+                  <p className="text-sm text-muted-foreground font-body">
+                    Mirá más imágenes y videos de la actividad antes de
+                    inscribirte.
+                  </p>
+                </div>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  {activityMedia.map((item) => {
+                    const mediaUrl = `/api/activities/${activity.id}/media/${item.id}`;
+                    return (
+                      <div
+                        key={item.id}
+                        className="overflow-hidden rounded-lg border bg-muted/30"
+                      >
+                        <div className="relative aspect-video">
+                          {item.type === 'IMAGE' ? (
+                            <Image
+                              src={mediaUrl}
+                              alt={item.fileName ?? activity.name}
+                              fill
+                              unoptimized
+                              className="object-cover"
+                            />
+                          ) : (
+                            <video
+                              src={mediaUrl}
+                              controls
+                              className="h-full w-full object-cover"
+                            />
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            )}
 
             <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto]">
               {activityProfessors.length > 0 && (

--- a/src/app/activities/activity-media-manager.tsx
+++ b/src/app/activities/activity-media-manager.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import Image from 'next/image';
+import { FileVideo, ImageUp, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+type ActivityMediaItem = {
+  id: string;
+  type: 'IMAGE' | 'VIDEO';
+  fileName: string | null;
+  sortOrder: number;
+};
+
+type Props = {
+  activityId: string;
+  initialMedia: ActivityMediaItem[];
+};
+
+export default function ActivityMediaManager({
+  activityId,
+  initialMedia,
+}: Props) {
+  const [media, setMedia] = useState(initialMedia);
+  const [error, setError] = useState('');
+  const [message, setMessage] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const [isDragging, setIsDragging] = useState(false);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function uploadFiles(files: FileList | File[]) {
+    const selectedFiles = Array.from(files).filter((file) => file.size > 0);
+    if (selectedFiles.length === 0) return;
+
+    setError('');
+    setMessage('');
+    setIsUploading(true);
+
+    try {
+      const formData = new FormData();
+      selectedFiles.forEach((file) => formData.append('media', file));
+
+      const response = await fetch(`/api/activities/${activityId}/media`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      const body = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(body?.error || 'No se pudieron subir los archivos');
+      }
+
+      setMedia((current) => [...current, ...(body?.media ?? [])]);
+      setMessage('Galería actualizada');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudieron subir los archivos'
+      );
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  async function deleteMedia(mediaId: string) {
+    setError('');
+    setMessage('');
+    setDeletingId(mediaId);
+
+    try {
+      const response = await fetch(
+        `/api/activities/${activityId}/media/${mediaId}`,
+        { method: 'DELETE' }
+      );
+      const body = await response.json().catch(() => null);
+      if (!response.ok) {
+        throw new Error(body?.error || 'No se pudo borrar el archivo');
+      }
+
+      setMedia((current) => current.filter((item) => item.id !== mediaId));
+      setMessage('Archivo eliminado');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo borrar el archivo'
+      );
+    } finally {
+      setDeletingId(null);
+    }
+  }
+
+  function handleDrop(event: React.DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+    setIsDragging(false);
+    uploadFiles(event.dataTransfer.files);
+  }
+
+  return (
+    <div className="space-y-4">
+      <div
+        onDrop={handleDrop}
+        onDragOver={(event) => {
+          event.preventDefault();
+          setIsDragging(true);
+        }}
+        onDragLeave={() => setIsDragging(false)}
+        className={`rounded-lg border-2 border-dashed p-6 transition ${
+          isDragging
+            ? 'border-primary bg-primary/5'
+            : 'border-border bg-muted/20'
+        }`}
+      >
+        <div className="flex flex-col items-center gap-3 text-center">
+          <div className="rounded-full bg-primary/10 p-3 text-primary">
+            <ImageUp className="h-6 w-6" />
+          </div>
+          <div>
+            <p className="font-medium">Sumá fotos y videos a la galería</p>
+            <p className="text-sm text-muted-foreground">
+              Arrastrá archivos acá o seleccioná varios desde tu dispositivo.
+              Imágenes hasta 8 MB y videos hasta 80 MB.
+            </p>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept="image/*,video/*"
+            className="hidden"
+            onChange={(event) => {
+              const files = event.target.files;
+              event.target.value = '';
+              if (files) uploadFiles(files);
+            }}
+          />
+          <Button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploading}
+          >
+            {isUploading ? 'Subiendo...' : 'Seleccionar archivos'}
+          </Button>
+        </div>
+      </div>
+
+      {message && <p className="text-sm text-success">{message}</p>}
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {media.length > 0 ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {media.map((item) => {
+            const mediaUrl = `/api/activities/${activityId}/media/${item.id}`;
+            return (
+              <article
+                key={item.id}
+                className="overflow-hidden rounded-lg border bg-card shadow-sm"
+              >
+                <div className="relative aspect-video bg-muted">
+                  {item.type === 'IMAGE' ? (
+                    <Image
+                      src={mediaUrl}
+                      alt={item.fileName ?? 'Imagen de actividad'}
+                      fill
+                      unoptimized
+                      className="object-cover"
+                    />
+                  ) : (
+                    <video
+                      src={mediaUrl}
+                      controls
+                      className="h-full w-full object-cover"
+                    />
+                  )}
+                </div>
+                <div className="flex items-center justify-between gap-3 p-3">
+                  <div className="min-w-0 text-sm">
+                    <p className="flex items-center gap-2 font-medium">
+                      {item.type === 'VIDEO' && (
+                        <FileVideo className="h-4 w-4" />
+                      )}
+                      <span className="truncate">
+                        {item.fileName ||
+                          (item.type === 'IMAGE' ? 'Imagen' : 'Video')}
+                      </span>
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {item.type === 'IMAGE' ? 'Foto' : 'Video'}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="destructive"
+                    className="px-3 py-2"
+                    onClick={() => deleteMedia(item.id)}
+                    disabled={deletingId === item.id}
+                    aria-label="Eliminar archivo"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-lg border bg-muted/20 p-4 text-sm text-muted-foreground">
+          Todavía no hay fotos ni videos adicionales para esta actividad.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/activities/join/[id]/page.tsx
+++ b/src/app/activities/join/[id]/page.tsx
@@ -43,6 +43,10 @@ export default async function ActivityJoinPage({
         price: true,
         createdAt: true,
         _count: { select: { participants: true } },
+        media: {
+          orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+          select: { id: true, type: true, fileName: true },
+        },
         groups: {
           select: {
             id: true,
@@ -175,6 +179,48 @@ export default async function ActivityJoinPage({
               )}
             </div>
           </div>
+
+          {activityData.media.length > 0 && (
+            <section className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
+              <div>
+                <h2 className="font-heading text-xl font-semibold">
+                  Fotos y videos
+                </h2>
+                <p className="text-sm text-muted-foreground font-body">
+                  Conocé la actividad con más fotos y videos antes de anotarte.
+                </p>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {activityData.media.map((item) => {
+                  const mediaUrl = `/api/activities/${activityData.id}/media/${item.id}`;
+                  return (
+                    <div
+                      key={item.id}
+                      className="overflow-hidden rounded-lg border bg-muted/30"
+                    >
+                      <div className="relative aspect-video">
+                        {item.type === 'IMAGE' ? (
+                          <Image
+                            src={mediaUrl}
+                            alt={item.fileName ?? activityData.name}
+                            fill
+                            unoptimized
+                            className="object-cover"
+                          />
+                        ) : (
+                          <video
+                            src={mediaUrl}
+                            controls
+                            className="h-full w-full object-cover"
+                          />
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
 
           <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
             <div className="rounded-lg border bg-card p-4">

--- a/src/app/api/activities/[id]/media/[mediaId]/route.ts
+++ b/src/app/api/activities/[id]/media/[mediaId]/route.ts
@@ -1,0 +1,68 @@
+import { del, get } from '@vercel/blob';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+function isAdminSession(session: unknown) {
+  const user = (
+    session as { user?: { activeRole?: string; role?: string } } | null
+  )?.user;
+  const role = user?.activeRole ?? user?.role;
+  return role === 'ADMIN' || role === 'SUPER_ADMIN';
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string; mediaId: string } }
+) {
+  const media = await prisma.activityMedia.findFirst({
+    where: { id: params.mediaId, activityId: params.id },
+    select: { url: true },
+  });
+
+  if (!media) {
+    return new NextResponse(null, { status: 404 });
+  }
+
+  try {
+    const blob = await get(media.url, { access: 'private' });
+    if (!blob || blob.statusCode !== 200) {
+      return new NextResponse(null, { status: 404 });
+    }
+
+    const headers = Object.fromEntries(blob.headers.entries());
+    headers['Cache-Control'] = 'public, max-age=300, stale-while-revalidate=60';
+
+    return new NextResponse(blob.stream, { headers });
+  } catch {
+    return new NextResponse(null, { status: 404 });
+  }
+}
+
+export async function DELETE(
+  _req: Request,
+  { params }: { params: { id: string; mediaId: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!isAdminSession(session)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const media = await prisma.activityMedia.findFirst({
+    where: { id: params.mediaId, activityId: params.id },
+    select: { id: true, url: true },
+  });
+
+  if (!media) {
+    return NextResponse.json(
+      { error: 'Archivo no encontrado' },
+      { status: 404 }
+    );
+  }
+
+  await del(media.url).catch(() => undefined);
+  await prisma.activityMedia.delete({ where: { id: media.id } });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/activities/[id]/media/route.ts
+++ b/src/app/api/activities/[id]/media/route.ts
@@ -1,0 +1,175 @@
+import { del, put } from '@vercel/blob';
+import { ActivityMediaType } from '@prisma/client';
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { extensionFor } from '@/lib/image-utils';
+import { prisma } from '@/lib/prisma';
+
+const MAX_IMAGE_SIZE = 8 * 1024 * 1024;
+const MAX_VIDEO_SIZE = 80 * 1024 * 1024;
+
+function isAdminSession(session: unknown) {
+  const user = (
+    session as { user?: { activeRole?: string; role?: string } } | null
+  )?.user;
+  const role = user?.activeRole ?? user?.role;
+  return role === 'ADMIN' || role === 'SUPER_ADMIN';
+}
+
+function getMediaType(file: File): ActivityMediaType | null {
+  if (file.type.startsWith('image/')) return 'IMAGE';
+  if (file.type.startsWith('video/')) return 'VIDEO';
+  return null;
+}
+
+function mediaExtensionFor(file: File) {
+  if (file.type.startsWith('image/')) return extensionFor(file);
+
+  const videoExtensions: Record<string, string> = {
+    'video/mp4': '.mp4',
+    'video/webm': '.webm',
+    'video/quicktime': '.mov',
+    'video/x-msvideo': '.avi',
+  };
+
+  const fallback = file.name.includes('.')
+    ? file.name.slice(file.name.lastIndexOf('.'))
+    : '';
+
+  return (videoExtensions[file.type] ?? fallback) || '.mp4';
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  const media = await prisma.activityMedia.findMany({
+    where: { activityId: params.id },
+    orderBy: [{ sortOrder: 'asc' }, { createdAt: 'asc' }],
+    select: {
+      id: true,
+      type: true,
+      fileName: true,
+      contentType: true,
+      sortOrder: true,
+      createdAt: true,
+    },
+  });
+
+  return NextResponse.json({ media });
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const session = await getServerSession(authOptions);
+  if (!isAdminSession(session)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const formData = await req.formData();
+  const files = formData
+    .getAll('media')
+    .filter((file): file is File => file instanceof File && file.size > 0);
+
+  if (files.length === 0) {
+    return NextResponse.json(
+      { error: 'No se recibieron archivos' },
+      { status: 400 }
+    );
+  }
+
+  const activity = await prisma.activity.findUnique({
+    where: { id: params.id },
+    select: { id: true },
+  });
+
+  if (!activity) {
+    return NextResponse.json(
+      { error: 'Actividad no encontrada' },
+      { status: 404 }
+    );
+  }
+
+  for (const file of files) {
+    const mediaType = getMediaType(file);
+    if (!mediaType) {
+      return NextResponse.json(
+        { error: 'Solo se permiten imágenes o videos' },
+        { status: 400 }
+      );
+    }
+
+    const maxSize = mediaType === 'IMAGE' ? MAX_IMAGE_SIZE : MAX_VIDEO_SIZE;
+    if (file.size > maxSize) {
+      return NextResponse.json(
+        {
+          error:
+            mediaType === 'IMAGE'
+              ? 'Cada imagen debe pesar menos de 8 MB'
+              : 'Cada video debe pesar menos de 80 MB',
+        },
+        { status: 400 }
+      );
+    }
+  }
+
+  const lastMedia = await prisma.activityMedia.findFirst({
+    where: { activityId: params.id },
+    orderBy: { sortOrder: 'desc' },
+    select: { sortOrder: true },
+  });
+  let nextSortOrder = (lastMedia?.sortOrder ?? -1) + 1;
+  const uploadedBlobUrls: string[] = [];
+  const createdMediaIds: string[] = [];
+
+  try {
+    const created = [];
+    for (const file of files) {
+      const mediaType = getMediaType(file)!;
+      const pathname = `activity-media/${params.id}/${crypto.randomUUID()}${mediaExtensionFor(file)}`;
+      const blob = await put(pathname, file, {
+        access: 'private',
+        contentType: file.type,
+      });
+      uploadedBlobUrls.push(blob.url);
+
+      const media = await prisma.activityMedia.create({
+        data: {
+          activityId: params.id,
+          url: blob.url,
+          type: mediaType,
+          fileName: file.name || null,
+          contentType: file.type || null,
+          sortOrder: nextSortOrder++,
+        },
+        select: {
+          id: true,
+          type: true,
+          fileName: true,
+          contentType: true,
+          sortOrder: true,
+          createdAt: true,
+        },
+      });
+      createdMediaIds.push(media.id);
+      created.push(media);
+    }
+
+    return NextResponse.json({ media: created });
+  } catch (error) {
+    await prisma.activityMedia
+      .deleteMany({ where: { id: { in: createdMediaIds } } })
+      .catch(() => undefined);
+    await Promise.all(
+      uploadedBlobUrls.map((url) => del(url).catch(() => undefined))
+    );
+    console.error('[activity-media] upload failed', error);
+    return NextResponse.json(
+      { error: 'No se pudieron guardar los archivos' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- Permitir que al editar una actividad el admin suba, gestione y muestre una galería de imágenes y videos además de la imagen de portada para que los usuarios puedan ver más contenido antes de entrar/inscribirse.

### Description
- Agrega modelo `ActivityMedia` y enum `ActivityMediaType` en `prisma/schema.prisma` y migración SQL para persistir medios por actividad, con índice por `activityId, sortOrder`.
- Añade endpoints API para listar/subir (`POST /api/activities/[id]/media`), servir (`GET /api/activities/[id]/media/[mediaId]`) y borrar medios (`DELETE /api/activities/[id]/media/[mediaId]`) usando Vercel Blob privado, con validación de rol admin y límites de tamaño (imágenes ≤ 8 MB, videos ≤ 80 MB).
- Implementa UI de administración `ActivityMediaManager` con drag & drop, multi-select, previews de imagen/video y eliminación; mantiene la `ActivityImageUpload` como imagen de portada separada y añade la sección de galería en la página de edición (`/activities/[id]/edit`).
- Muestra la galería en la vista de detalle (`/activities/[id]`) y en la página pública de inscripción (`/activities/join/[id]`).
- Archivos principales tocados: `prisma/schema.prisma`, `prisma/migrations/20260509000000_add_activity_media/migration.sql`, `src/app/api/activities/[id]/media/route.ts`, `src/app/api/activities/[id]/media/[mediaId]/route.ts`, `src/app/activities/activity-media-manager.tsx`, `src/app/activities/[id]/edit/page.tsx`, `src/app/activities/[id]/page.tsx`, `src/app/activities/join/[id]/page.tsx`.

### Testing
- Ejecutado `pnpm lint` — pasó (quedaron warnings de Prettier en archivos no relacionados ya existentes).
- Ejecutado `pnpm exec prisma validate` — pasó y el esquema Prisma es válido.
- Ejecutado `pnpm exec tsc --noEmit` — falló por errores de tipado preexistentes en `tests/api/pickup-notices.test.ts`; los cambios introducidos en esta PR no dejaron errores TypeScript propios que impidieran compilar en el último pase de verificación.
- Riesgos / notas pendientes: la entrega/serving de videos se proxy-a través del endpoint Next/Vercel Blob (actualmente privado); para contenidos grandes o alto tráfico conviene evaluar URLs firmadas, soporte de range requests o streaming optimizado; recordar ejecutar la migración de Prisma en despliegue (`prisma migrate deploy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5e95d81c832886dc81e09182f2ea)