### PR TITLE
Show accounting activity cashbox by selection

### DIFF
--- a/src/app/accounting/movements/activities/page.tsx
+++ b/src/app/accounting/movements/activities/page.tsx
@@ -3,13 +3,18 @@ import { Prisma } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
-import { formatAccountingDate, formatAmount } from '@/lib/accounting';
+import {
+  formatAccountingDate,
+  formatAmount,
+  formatPersonName,
+} from '@/lib/accounting';
 import { Button } from '@/components/ui/button';
 import { ArrowRight, Search } from 'lucide-react';
 import { buildAccountingSimilarityCondition } from '@/lib/accounting-search';
 import MovementTabs from '../movement-tabs';
 
 type SearchParams = {
+  activityId?: string;
   q?: string;
 };
 
@@ -30,6 +35,14 @@ type ActivitySummaryRow = {
   lastPaidAt: Date | null;
 };
 
+type ActivityPayment = Prisma.ActivityParticipantPaymentGetPayload<{
+  include: {
+    user: { select: { name: true; lastName: true; email: true } };
+    child: { select: { name: true; lastName: true } };
+    activityDay: { select: { date: true; schedule: true } };
+  };
+}>;
+
 const activityTypeLabels: Record<string, string> = {
   ANNUAL: 'Anual',
   TEMPORARY: 'Temporal',
@@ -42,6 +55,11 @@ const frequencyLabels: Record<string, string> = {
   MONTHLY: 'Mensual',
 };
 
+const paymentTypeLabels: Record<string, string> = {
+  MONTHLY: 'Mensual',
+  SESSION: 'Por salida',
+};
+
 function formatActivityPeriod(start: Date, end: Date) {
   const formattedStart = formatAccountingDate(start);
   const formattedEnd = formatAccountingDate(end);
@@ -51,32 +69,32 @@ function formatActivityPeriod(start: Date, end: Date) {
     : `${formattedStart} al ${formattedEnd}`;
 }
 
-export default async function ActivityMovementsPage({
-  searchParams,
-}: {
-  searchParams?: SearchParams;
-}) {
-  // Auth gating happens in the parent /accounting layout.
-  await getServerSession(authOptions);
-
-  const q = searchParams?.q?.trim() ?? '';
-  const filters: Prisma.Sql[] = [];
-
-  if (q) {
-    filters.push(
-      buildAccountingSimilarityCondition(q, [
-        Prisma.sql`a."name"`,
-        Prisma.sql`a."description"`,
-      ])
-    );
+function getPaymentConcept(payment: ActivityPayment) {
+  if (
+    payment.paymentType === 'MONTHLY' &&
+    payment.periodMonth &&
+    payment.periodYear
+  ) {
+    return `Período ${String(payment.periodMonth).padStart(2, '0')}/${payment.periodYear}`;
   }
 
-  const whereSql =
-    filters.length > 0
-      ? Prisma.sql`WHERE ${Prisma.join(filters, ' AND ')}`
-      : Prisma.empty;
+  if (payment.activityDay) {
+    return `Salida ${formatAccountingDate(payment.activityDay.date)} · ${payment.activityDay.schedule}`;
+  }
 
-  const activities = await prisma.$queryRaw<ActivitySummaryRow[]>`
+  return paymentTypeLabels[payment.paymentType] ?? payment.paymentType;
+}
+
+function getPayerName(payment: ActivityPayment) {
+  const userName = formatPersonName(payment.user);
+
+  if (!payment.child) return userName;
+
+  return `${formatPersonName(payment.child)} · Responsable: ${userName}`;
+}
+
+async function getActivitySummary(activityId: string) {
+  const rows = await prisma.$queryRaw<ActivitySummaryRow[]>`
     SELECT
       a."id" AS "id",
       a."name" AS "name",
@@ -112,22 +130,66 @@ export default async function ActivityMovementsPage({
       FROM "ActivityParticipantPayment" app
       GROUP BY app."activityId"
     ) payments ON payments."activityId" = a."id"
-    ${whereSql}
-    ORDER BY a."date" DESC, a."name" ASC
+    WHERE a."id" = ${activityId}
+    LIMIT 1
   `;
 
-  const totalCollected = activities.reduce(
-    (sum, activity) => sum + activity.totalCollected,
-    0
-  );
-  const totalParticipants = activities.reduce(
-    (sum, activity) => sum + activity.participantCount,
-    0
-  );
-  const totalPayments = activities.reduce(
-    (sum, activity) => sum + activity.paymentCount,
-    0
-  );
+  return rows[0] ?? null;
+}
+
+async function getActivityOptions(q: string) {
+  if (!q) return [];
+
+  const condition = buildAccountingSimilarityCondition(q, [
+    Prisma.sql`a."name"`,
+    Prisma.sql`a."description"`,
+  ]);
+
+  return prisma.$queryRaw<
+    Array<{ id: string; name: string; date: Date; endDate: Date }>
+  >`
+    SELECT a."id", a."name", a."date", a."endDate"
+    FROM "Activity" a
+    WHERE ${condition}
+    ORDER BY a."date" DESC, a."name" ASC
+    LIMIT 20
+  `;
+}
+
+export default async function ActivityMovementsPage({
+  searchParams,
+}: {
+  searchParams?: SearchParams;
+}) {
+  // Auth gating happens in the parent /accounting layout.
+  await getServerSession(authOptions);
+
+  const q = searchParams?.q?.trim() ?? '';
+  const selectedActivityId = searchParams?.activityId?.trim() ?? '';
+  const [activityOptions, selectedActivity] = await Promise.all([
+    selectedActivityId ? Promise.resolve([]) : getActivityOptions(q),
+    selectedActivityId ? getActivitySummary(selectedActivityId) : null,
+  ]);
+
+  const payments = selectedActivity
+    ? await prisma.activityParticipantPayment.findMany({
+        where: { activityId: selectedActivity.id },
+        orderBy: [{ paidAt: 'desc' }, { createdAt: 'desc' }],
+        include: {
+          user: { select: { name: true, lastName: true, email: true } },
+          child: { select: { name: true, lastName: true } },
+          activityDay: { select: { date: true, schedule: true } },
+        },
+      })
+    : [];
+
+  const pendingParticipants = selectedActivity
+    ? Math.max(
+        selectedActivity.participantCount -
+          selectedActivity.paidParticipantCount,
+        0
+      )
+    : 0;
 
   return (
     <div className="space-y-6">
@@ -136,10 +198,10 @@ export default async function ActivityMovementsPage({
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h2 className="text-2xl font-bold tracking-tight">
-            Movimientos por actividad
+            Caja por actividad
           </h2>
           <p className="text-sm text-muted-foreground">
-            Resumen contable de cada actividad con inscripciones, pagos
+            Buscá y elegí una actividad para ver únicamente su caja, pagos
             registrados y recaudación acumulada.
           </p>
         </div>
@@ -150,26 +212,6 @@ export default async function ActivityMovementsPage({
           </Link>
         </Button>
       </div>
-
-      <section className="grid gap-3 md:grid-cols-3">
-        <div className="rounded-2xl border bg-card p-4 shadow-sm">
-          <p className="text-sm text-muted-foreground">Actividades</p>
-          <p className="mt-2 text-2xl font-bold">{activities.length}</p>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 shadow-sm">
-          <p className="text-sm text-muted-foreground">Inscriptos</p>
-          <p className="mt-2 text-2xl font-bold">{totalParticipants}</p>
-        </div>
-        <div className="rounded-2xl border bg-card p-4 shadow-sm">
-          <p className="text-sm text-muted-foreground">Recaudado</p>
-          <p className="mt-2 text-2xl font-bold">
-            {formatAmount(totalCollected)}
-          </p>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {totalPayments} pagos registrados
-          </p>
-        </div>
-      </section>
 
       <form className="rounded-2xl border bg-card p-4 shadow-sm">
         <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-end">
@@ -197,111 +239,175 @@ export default async function ActivityMovementsPage({
         </div>
       </form>
 
-      <div className="overflow-x-auto rounded-2xl border bg-card shadow-sm">
-        <table className="min-w-full text-sm">
-          <thead className="border-b bg-muted/20 text-left text-muted-foreground">
-            <tr>
-              <th className="px-4 py-3 font-medium">Actividad</th>
-              <th className="px-4 py-3 font-medium">Período</th>
-              <th className="px-4 py-3 font-medium">Tipo</th>
-              <th className="px-4 py-3 font-medium">Inscriptos</th>
-              <th className="px-4 py-3 font-medium">Pagaron</th>
-              <th className="px-4 py-3 font-medium">Pagos</th>
-              <th className="px-4 py-3 font-medium">Precio</th>
-              <th className="px-4 py-3 font-medium">Recaudado</th>
-              <th className="px-4 py-3 font-medium">Último pago</th>
-              <th className="px-4 py-3 font-medium">Acción</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y">
-            {activities.length === 0 ? (
-              <tr>
-                <td
-                  colSpan={10}
-                  className="px-4 py-10 text-center text-muted-foreground"
-                >
-                  No hay actividades con esos filtros.
-                </td>
-              </tr>
-            ) : (
-              activities.map((activity) => {
-                const pendingParticipants = Math.max(
-                  activity.participantCount - activity.paidParticipantCount,
-                  0
-                );
+      {!selectedActivity && (
+        <section className="rounded-2xl border bg-card p-4 shadow-sm">
+          <h3 className="text-lg font-semibold">Elegí una actividad</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Esta pantalla ya no muestra todas las actividades juntas. Usá el
+            buscador y seleccioná una actividad para abrir su caja.
+          </p>
 
-                return (
-                  <tr key={activity.id} className="align-top">
-                    <td className="px-4 py-3">
-                      <p className="font-medium text-foreground">
-                        {activity.name}
+          {q ? (
+            <div className="mt-4 divide-y rounded-xl border">
+              {activityOptions.length === 0 ? (
+                <p className="p-4 text-sm text-muted-foreground">
+                  No hay actividades con ese criterio de búsqueda.
+                </p>
+              ) : (
+                activityOptions.map((activity) => (
+                  <div
+                    key={activity.id}
+                    className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                  >
+                    <div>
+                      <p className="font-medium">{activity.name}</p>
+                      <p className="text-sm text-muted-foreground">
+                        {formatActivityPeriod(activity.date, activity.endDate)}
                       </p>
-                    </td>
-                    <td className="px-4 py-3">
-                      {formatActivityPeriod(activity.date, activity.endDate)}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="space-y-1">
-                        <p>
-                          {activityTypeLabels[activity.activityType] ??
-                            activity.activityType}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {frequencyLabels[activity.frequency] ??
-                            activity.frequency}
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 font-semibold">
-                      {activity.participantCount}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="space-y-1">
-                        <p className="font-semibold">
-                          {activity.paidParticipantCount}
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          {pendingParticipants} sin pagos registrados
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="space-y-1">
-                        <p className="font-semibold">{activity.paymentCount}</p>
-                        <p className="text-xs text-muted-foreground">
-                          {activity.monthlyPaymentCount} mensuales ·{' '}
-                          {activity.sessionPaymentCount} por salida
-                        </p>
-                      </div>
-                    </td>
-                    <td className="px-4 py-3">
-                      {formatAmount(activity.price)}
-                    </td>
-                    <td className="px-4 py-3 font-semibold">
-                      {formatAmount(activity.totalCollected)}
-                    </td>
-                    <td className="px-4 py-3">
-                      {activity.lastPaidAt
-                        ? formatAccountingDate(activity.lastPaidAt)
-                        : '-'}
-                    </td>
-                    <td className="px-4 py-3">
-                      <Button asChild variant="outline" className="px-3 py-2">
-                        <Link
-                          href={`/activities/${activity.id}`}
-                          prefetch={true}
-                        >
-                          Ver detalle
-                        </Link>
-                      </Button>
+                    </div>
+                    <Button
+                      asChild
+                      variant="outline"
+                      className="self-start sm:self-auto"
+                    >
+                      <Link
+                        href={`/accounting/movements/activities?activityId=${activity.id}`}
+                        prefetch={true}
+                      >
+                        Ver caja
+                      </Link>
+                    </Button>
+                  </div>
+                ))
+              )}
+            </div>
+          ) : null}
+        </section>
+      )}
+
+      {selectedActivity && (
+        <>
+          <section className="rounded-2xl border bg-card p-4 shadow-sm">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <div>
+                <p className="text-sm text-muted-foreground">Caja de</p>
+                <h3 className="text-xl font-bold">{selectedActivity.name}</h3>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {formatActivityPeriod(
+                    selectedActivity.date,
+                    selectedActivity.endDate
+                  )}{' '}
+                  ·{' '}
+                  {activityTypeLabels[selectedActivity.activityType] ??
+                    selectedActivity.activityType}{' '}
+                  ·{' '}
+                  {frequencyLabels[selectedActivity.frequency] ??
+                    selectedActivity.frequency}
+                </p>
+              </div>
+              <Button asChild variant="outline">
+                <Link href="/accounting/movements/activities" prefetch={true}>
+                  Elegir otra actividad
+                </Link>
+              </Button>
+            </div>
+          </section>
+
+          <section className="grid gap-3 md:grid-cols-4">
+            <div className="rounded-2xl border bg-card p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Inscriptos</p>
+              <p className="mt-2 text-2xl font-bold">
+                {selectedActivity.participantCount}
+              </p>
+            </div>
+            <div className="rounded-2xl border bg-card p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Pagaron</p>
+              <p className="mt-2 text-2xl font-bold">
+                {selectedActivity.paidParticipantCount}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {pendingParticipants} sin pagos registrados
+              </p>
+            </div>
+            <div className="rounded-2xl border bg-card p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Pagos</p>
+              <p className="mt-2 text-2xl font-bold">
+                {selectedActivity.paymentCount}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {selectedActivity.monthlyPaymentCount} mensuales ·{' '}
+                {selectedActivity.sessionPaymentCount} por salida
+              </p>
+            </div>
+            <div className="rounded-2xl border bg-card p-4 shadow-sm">
+              <p className="text-sm text-muted-foreground">Recaudado</p>
+              <p className="mt-2 text-2xl font-bold">
+                {formatAmount(selectedActivity.totalCollected)}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Precio base: {formatAmount(selectedActivity.price)}
+              </p>
+            </div>
+          </section>
+
+          <div className="overflow-x-auto rounded-2xl border bg-card shadow-sm">
+            <table className="min-w-full text-sm">
+              <thead className="border-b bg-muted/20 text-left text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-3 font-medium">Fecha</th>
+                  <th className="px-4 py-3 font-medium">Participante</th>
+                  <th className="px-4 py-3 font-medium">Concepto</th>
+                  <th className="px-4 py-3 font-medium">Referencia</th>
+                  <th className="px-4 py-3 font-medium">Importe</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {payments.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-4 py-10 text-center text-muted-foreground"
+                    >
+                      Esta actividad todavía no tiene pagos registrados.
                     </td>
                   </tr>
-                );
-              })
-            )}
-          </tbody>
-        </table>
-      </div>
+                ) : (
+                  payments.map((payment) => (
+                    <tr key={payment.id} className="align-top">
+                      <td className="px-4 py-3">
+                        {formatAccountingDate(payment.paidAt)}
+                      </td>
+                      <td className="px-4 py-3">
+                        <p className="font-medium text-foreground">
+                          {getPayerName(payment)}
+                        </p>
+                        {!payment.child && payment.user.email ? (
+                          <p className="text-xs text-muted-foreground">
+                            {payment.user.email}
+                          </p>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3">
+                        <div className="space-y-1">
+                          <p>{getPaymentConcept(payment)}</p>
+                          <p className="text-xs text-muted-foreground">
+                            {paymentTypeLabels[payment.paymentType] ??
+                              payment.paymentType}
+                          </p>
+                        </div>
+                      </td>
+                      <td className="px-4 py-3">{payment.paymentReference}</td>
+                      <td className="px-4 py-3 font-semibold">
+                        {formatAmount(payment.amount)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Evitar que `/accounting/movements/activities` muestre todas las actividades juntas y permitir al contador elegir una sola actividad para ver su caja y pagos asociados.
- Mejorar la usabilidad del panel contable para enfocarse en la recaudación y pagos de una actividad concreta en lugar de un listado global.

### Description
- Reemplacé la vista que listaba todas las actividades por un flujo de búsqueda/selección que exige un `activityId` antes de mostrar la caja (archivo modificado: `src/app/accounting/movements/activities/page.tsx`).
- Añadí soporte para el parámetro `activityId` en `searchParams` y funciones servidor-side `getActivityOptions` y `getActivitySummary` para búsqueda y carga de la actividad seleccionada.
- Cuando hay una actividad seleccionada se consulta `ActivityParticipantPayment` y se renderiza la caja de la actividad con tarjetas resumen (inscriptos, pagaron, pagos, recaudado) y una tabla detallada de pagos (fecha, participante, concepto, referencia, importe).
- Ajustes de texto/UX: título cambió a "Caja por actividad" y la pantalla muestra ahora un estado instructivo pidiendo seleccionar una actividad antes de mostrar datos.

### Testing
- Ejecuté `pnpm lint`; la tarea de lint terminó correctamente pero siguen apareciendo warnings de Prettier en archivos no relacionados.
- Ejecuté `pnpm exec tsc --noEmit`; el chequeo TypeScript falló por errores preexistentes en el repo (relacionados con activity media y tests) que no son introducidos por este cambio.
- Verifiqué el diff con `git diff --check` y realicé el commit de los cambios (`Show accounting activity cashbox by selection`).

Unresolved risks
- `tsc --noEmit` falla por errores existentes en el repositorio, por lo que la verificación TypeScript completa queda pendiente hasta resolver esos problemas base.
- No se validó visualmente en un entorno con datos reales durante este cambio; recomendar probar la ruta en el entorno local con datos de actividad.
- Posibles ajustes menores de estilo/formatting pendientes (Prettier warnings en archivos ajenos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6127868083288ecd4bffdcf9afbd)