### PR TITLE
Move activity price below title and increase its size

### DIFF
--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -459,11 +459,11 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
           {/* Columna izquierda */}
           <div className="space-y-6">
             <div>
-              <div className="flex flex-wrap items-start gap-3">
+              <div className="space-y-3">
                 <h1 className="font-heading text-3xl sm:text-4xl font-semibold leading-tight">
                   {activity.name}
                 </h1>
-                <div className="rounded-full border border-primary/20 bg-primary/5 px-3 py-1.5 font-heading text-sm font-semibold text-primary shadow-sm">
+                <div className="font-heading text-4xl font-semibold leading-none text-primary sm:text-5xl">
                   {formatAmount(activity.price)}
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Make the activity price more prominent on the activity detail page so it is clearer than the title.

### Description
- Modify `src/app/activities/[id]/page.tsx` to place the price under the activity title and replace the small rounded badge with larger typographic styling (`text-4xl` / `sm:text-5xl`, `font-semibold`, `text-primary`) to increase visual prominence.

### Testing
- Ran `pnpm lint` (exit code 0) and `git diff --check`, both completed without blocking errors (note: the repo contains unrelated Prettier warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff61d427348328bdcf50ec5058bdda)