### PR TITLE
Allow enrolled members to browse home activities

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,8 @@
 import Link from 'next/link';
-import { getServerSession } from 'next-auth';
-import { redirect } from 'next/navigation';
 import { listActivitiesWithParticipantCount } from '@/lib/activities/activity-records';
 import { formatAmount } from '@/lib/accounting';
-import { authOptions } from '@/lib/auth';
-import { shouldUseMyActivitiesAsHome } from '@/lib/post-login-redirect';
 
 export default async function Home() {
-  const session = await getServerSession(authOptions);
-
-  if (await shouldUseMyActivitiesAsHome(session)) {
-    redirect('/my-activities');
-  }
-
   let activities: Awaited<
     ReturnType<typeof listActivitiesWithParticipantCount>
   > = [];


### PR DESCRIPTION
### Motivation
- Permitir que un padre/socio que ya tenga al menos una actividad contratada pueda seguir navegando en la página principal para contratar actividades adicionales; antes la home redirigía automáticamente a `/my-activities` y eso impedía explorar el catálogo.

### Description
- Se eliminó la redirección automática desde `src/app/page.tsx` (quitado `getServerSession` / `shouldUseMyActivitiesAsHome` + `redirect('/my-activities')`) de modo que `/` vuelva a listar las "Próximas actividades"; la lógica de post-login en `src/lib/post-login-redirect.ts` se mantuvo sin cambios para seguir enviando a `/my-activities` tras el inicio de sesión cuando corresponde; archivo modificado: `src/app/page.tsx`. Unresolved risks: usuarios que esperan ser llevados automáticamente a "Mis actividades" al visitar `/` verán el catálogo en su lugar, que es el comportamiento intencional pero puede requerir aclaración en la UX.

### Testing
- Ejecutados `pnpm test -- src/lib/__tests__/post-login-redirect.test.ts --runInBand` y todos los tests pasaron (`7 passed`).
- Ejecutado `pnpm lint` y finalizó correctamente; la corrida muestra warnings de Prettier en archivos no relacionados pero no bloquea el cambio.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa7364de88328a65e8b5bc6d64118)