### PR TITLE
Show current activity selector for accounting

### DIFF
--- a/src/app/accounting/movements/activities/page.tsx
+++ b/src/app/accounting/movements/activities/page.tsx
@@ -138,21 +138,25 @@ async function getActivitySummary(activityId: string) {
 }
 
 async function getActivityOptions(q: string) {
-  if (!q) return [];
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
 
-  const condition = buildAccountingSimilarityCondition(q, [
-    Prisma.sql`a."name"`,
-    Prisma.sql`a."description"`,
-  ]);
+  const searchCondition = q
+    ? buildAccountingSimilarityCondition(q, [
+        Prisma.sql`a."name"`,
+        Prisma.sql`a."description"`,
+      ])
+    : Prisma.sql`TRUE`;
 
   return prisma.$queryRaw<
     Array<{ id: string; name: string; date: Date; endDate: Date }>
   >`
     SELECT a."id", a."name", a."date", a."endDate"
     FROM "Activity" a
-    WHERE ${condition}
-    ORDER BY a."date" DESC, a."name" ASC
-    LIMIT 20
+    WHERE a."endDate" >= ${todayStart}
+      AND ${searchCondition}
+    ORDER BY a."date" ASC, a."name" ASC
+    LIMIT 50
   `;
 }
 
@@ -206,8 +210,8 @@ export default async function ActivityMovementsPage({
           </p>
         </div>
         <Button asChild variant="outline">
-          <Link href="/activities" prefetch={true}>
-            Ver actividades
+          <Link href="/accounting/movements/activities" prefetch={true}>
+            Ver actividades vigentes
             <ArrowRight className="ml-2 h-4 w-4" />
           </Link>
         </Button>
@@ -243,45 +247,45 @@ export default async function ActivityMovementsPage({
         <section className="rounded-2xl border bg-card p-4 shadow-sm">
           <h3 className="text-lg font-semibold">Elegí una actividad</h3>
           <p className="mt-1 text-sm text-muted-foreground">
-            Esta pantalla ya no muestra todas las actividades juntas. Usá el
-            buscador y seleccioná una actividad para abrir su caja.
+            Seleccioná una actividad vigente para abrir su caja. Si necesitás
+            acotar la lista, usá el buscador por nombre o descripción.
           </p>
 
-          {q ? (
-            <div className="mt-4 divide-y rounded-xl border">
-              {activityOptions.length === 0 ? (
-                <p className="p-4 text-sm text-muted-foreground">
-                  No hay actividades con ese criterio de búsqueda.
-                </p>
-              ) : (
-                activityOptions.map((activity) => (
-                  <div
-                    key={activity.id}
-                    className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
-                  >
-                    <div>
-                      <p className="font-medium">{activity.name}</p>
-                      <p className="text-sm text-muted-foreground">
-                        {formatActivityPeriod(activity.date, activity.endDate)}
-                      </p>
-                    </div>
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="self-start sm:self-auto"
-                    >
-                      <Link
-                        href={`/accounting/movements/activities?activityId=${activity.id}`}
-                        prefetch={true}
-                      >
-                        Ver caja
-                      </Link>
-                    </Button>
+          <div className="mt-4 divide-y rounded-xl border">
+            {activityOptions.length === 0 ? (
+              <p className="p-4 text-sm text-muted-foreground">
+                {q
+                  ? 'No hay actividades vigentes con ese criterio de búsqueda.'
+                  : 'No hay actividades vigentes para seleccionar.'}
+              </p>
+            ) : (
+              activityOptions.map((activity) => (
+                <div
+                  key={activity.id}
+                  className="flex flex-col gap-3 p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div>
+                    <p className="font-medium">{activity.name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      {formatActivityPeriod(activity.date, activity.endDate)}
+                    </p>
                   </div>
-                ))
-              )}
-            </div>
-          ) : null}
+                  <Button
+                    asChild
+                    variant="outline"
+                    className="self-start sm:self-auto"
+                  >
+                    <Link
+                      href={`/accounting/movements/activities?activityId=${activity.id}`}
+                      prefetch={true}
+                    >
+                      Seleccionar
+                    </Link>
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
         </section>
       )}
 


### PR DESCRIPTION
### Motivation
- Facilitar el trabajo de Contaduría mostrando y permitiendo seleccionar actividades vigentes directamente desde `/accounting/movements/activities` en lugar de enviar al contador a la lista de actividades de administración.

### Description
- Filtrado de actividades en servidor: `getActivityOptions` ahora devuelve actividades con `endDate >= hoy` y admite búsqueda opcional (busca por `name`/`description`), ordenadas por fecha ascendente y limitadas a 50 resultados.
- UI: el CTA que antes abría `/activities` ahora permanece en contaduría y muestra `Ver actividades vigentes`, y cada fila muestra un botón `Seleccionar` que pasa `activityId` a la misma ruta para abrir la caja de la actividad.
- Mensajes/estados vacíos actualizados para indicar que la lista muestra solo actividades vigentes y aclarar resultados de búsqueda.
- Archivo modificado: `src/app/accounting/movements/activities/page.tsx`.

### Testing
- Ejecuté `pnpm lint` y completó correctamente (reportó warnings de Prettier en archivos no relacionados). ✅
- Ejecuté `pnpm exec prettier --check src/app/accounting/movements/activities/page.tsx` y pasó sin cambios. ✅
- Ejecuté `pnpm exec tsc --noEmit`, que falló por errores TypeScript existentes en otras áreas del proyecto (tipos Prisma relacionados con `activityMedia` y tests de `pickup-notices`), por lo que no pude validar un `tsc` limpio en todo el repo. ❌

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffad4757f88328b8d2c5e795505321)