### PR TITLE
Agregar tag “Actividades” en la navegación de Contaduría

### DIFF
--- a/src/app/accounting/layout.tsx
+++ b/src/app/accounting/layout.tsx
@@ -7,6 +7,7 @@ import { gateAccounting } from '@/lib/role-guards';
 const links = [
   { href: '/accounting', label: 'Resumen' },
   { href: '/accounting/social-fee', label: 'Cuota social' },
+  { href: '/accounting/movements/activities', label: 'Actividades' },
   { href: '/accounting/debt-by-family', label: 'Deuda familiar' },
   { href: '/accounting/movements', label: 'Movimientos' },
   { href: '/accounting/professors', label: 'Profesores' },


### PR DESCRIPTION
### Motivation
- Facilitar el acceso al resumen contable por actividad desde la página `/accounting` mostrando un tag "Actividades" inmediatamente después de "Cuota social" para exponer la ruta `/accounting/movements/activities`.

### Description
- Inserta un enlace de navegación con label `Actividades` y `href: '/accounting/movements/activities'` en `src/app/accounting/layout.tsx` justo después de la entrada `Cuota social`.

### Testing
- Ejecuté `pnpm lint` (pasó; mostró advertencias de Prettier en archivos no modificados) y verifiqué con `git diff --check` y `git status --short` para confirmar el cambio en `src/app/accounting/layout.tsx`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb0283f78832881f82e0d65894fc9)