### PR TITLE
Allow tutors to leave family groups

### DIFF
--- a/src/app/api/family-groups/[id]/members/route.ts
+++ b/src/app/api/family-groups/[id]/members/route.ts
@@ -15,29 +15,59 @@ export async function DELETE(
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const familyGroup = await familyGroupService.getFamilyGroupByResponsible(
-    session.user.id
-  );
-  if (!familyGroup || familyGroup.id !== params.id) {
-    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-  }
-
-  const schema = z.object({ memberId: z.string() });
+  const schema = z
+    .object({
+      memberId: z.string().optional(),
+      leaveSelf: z.boolean().optional(),
+    })
+    .refine((data) => data.leaveSelf || data.memberId, {
+      message: 'Datos inválidos.',
+    });
   const parsed = schema.safeParse(await req.json());
   if (!parsed.success) {
     return NextResponse.json({ error: 'Datos inválidos.' }, { status: 400 });
   }
 
-  if (parsed.data.memberId === familyGroup.responsibleUserId) {
+  const group = await prisma.familyGroup.findUnique({
+    where: { id: params.id },
+    select: {
+      id: true,
+      responsibleUserId: true,
+      members: {
+        where: { memberId: session.user.id },
+        select: { memberId: true },
+      },
+    },
+  });
+
+  if (!group) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+
+  const isResponsible = group.responsibleUserId === session.user.id;
+  const isMember = group.members.length > 0;
+  const targetMemberId = parsed.data.leaveSelf
+    ? session.user.id
+    : parsed.data.memberId;
+
+  if (!targetMemberId) {
+    return NextResponse.json({ error: 'Datos inválidos.' }, { status: 400 });
+  }
+
+  if (targetMemberId === group.responsibleUserId) {
     return NextResponse.json(
       { error: 'No podés eliminar al responsable principal.' },
       { status: 400 }
     );
   }
 
+  if (!isResponsible && !(parsed.data.leaveSelf && isMember)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
   await familyGroupService.removeMemberFromFamilyGroup(
     params.id,
-    parsed.data.memberId
+    targetMemberId
   );
 
   return NextResponse.json({ ok: true });

--- a/src/app/profile/children/leave-family-group-button.tsx
+++ b/src/app/profile/children/leave-family-group-button.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function LeaveFamilyGroupButton({
+  familyGroupId,
+  groupName,
+  className,
+  label = 'Salir del grupo',
+  confirmLabel = 'Sí, salir',
+}: {
+  familyGroupId: string;
+  groupName: string;
+  className?: string;
+  label?: string;
+  confirmLabel?: string;
+}) {
+  const [isConfirming, setIsConfirming] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  async function handleLeave() {
+    setError('');
+    setIsLeaving(true);
+    try {
+      const res = await fetch(`/api/family-groups/${familyGroupId}/members`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ leaveSelf: true }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error ?? 'No se pudo salir del grupo familiar.');
+      }
+      setIsConfirming(false);
+      router.refresh();
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'No se pudo salir del grupo familiar.'
+      );
+    } finally {
+      setIsLeaving(false);
+    }
+  }
+
+  return (
+    <div className={className ?? 'space-y-2'}>
+      {isConfirming ? (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            ¿Salir de {groupName}?
+          </span>
+          <button
+            type="button"
+            onClick={handleLeave}
+            disabled={isLeaving}
+            className="inline-flex h-8 items-center justify-center rounded-full bg-destructive px-3 text-xs font-medium text-white hover:bg-destructive/90 disabled:opacity-50 transition-colors"
+          >
+            {isLeaving ? 'Saliendo...' : confirmLabel}
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setIsConfirming(false);
+              setError('');
+            }}
+            disabled={isLeaving}
+            className="inline-flex h-8 items-center justify-center rounded-full border border-border px-3 text-xs font-medium hover:bg-muted disabled:opacity-50 transition-colors"
+          >
+            Cancelar
+          </button>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => {
+            setError('');
+            setIsConfirming(true);
+          }}
+          className="inline-flex h-8 items-center justify-center rounded-full border border-destructive px-3 text-xs font-medium text-destructive hover:bg-destructive/10 transition-colors"
+        >
+          {label}
+        </button>
+      )}
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  );
+}

--- a/src/app/profile/children/page.tsx
+++ b/src/app/profile/children/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 import TutorsList from './tutors-list';
 import DeleteChildButton from './delete-child-button';
+import LeaveFamilyGroupButton from './leave-family-group-button';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { gateActiveRole } from '@/lib/role-guards';
@@ -61,6 +62,19 @@ export default async function ChildrenPage() {
 
   const familyMembers = activeFamilyGroup?.members ?? [];
   const isResponsible = activeFamilyGroup?.responsibleUserId === userId;
+  const otherFamilyGroups = familyGroups.filter(
+    (group) => group.id !== activeFamilyGroup?.id
+  );
+  const assignedFamilyGroupByChildOwner = new Map(
+    familyGroups
+      .filter(
+        (group) =>
+          group.responsibleUserId &&
+          group.responsibleUserId !== userId &&
+          group.members.some((member) => member.memberId === userId)
+      )
+      .map((group) => [group.responsibleUserId, group])
+  );
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-6">
@@ -76,22 +90,28 @@ export default async function ChildrenPage() {
         )}
       </div>
 
-      {familyGroups.length > 1 && (
-        <div className="rounded-xl border bg-card p-4 shadow-sm space-y-2">
+      {otherFamilyGroups.length > 0 && (
+        <div className="rounded-xl border bg-card p-4 shadow-sm space-y-3">
           <h2 className="text-sm font-semibold tracking-tight">
             Otros grupos familiares
           </h2>
-          <div className="flex flex-wrap gap-2 text-xs">
-            {familyGroups
-              .filter((group) => group.id !== activeFamilyGroup?.id)
-              .map((group) => (
-                <span
-                  key={group.id}
-                  className="rounded-full bg-muted px-3 py-1 text-muted-foreground"
-                >
-                  {group.name}
-                </span>
-              ))}
+          <div className="space-y-2">
+            {otherFamilyGroups.map((group) => (
+              <div
+                key={group.id}
+                className="flex flex-wrap items-center justify-between gap-2 rounded-lg border bg-muted/30 px-3 py-2"
+              >
+                <span className="text-sm font-medium">{group.name}</span>
+                {group.responsibleUserId !== userId && (
+                  <LeaveFamilyGroupButton
+                    familyGroupId={group.id}
+                    groupName={group.name}
+                    label="Salir"
+                    className="flex-shrink-0"
+                  />
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )}
@@ -102,13 +122,19 @@ export default async function ChildrenPage() {
             <h2 className="text-lg font-semibold tracking-tight">
               Grupo familiar
             </h2>
-            {isResponsible && (
+            {isResponsible ? (
               <Link
                 href="/profile/children/add-tutor"
                 className="inline-flex h-8 items-center justify-center rounded-full border border-primary px-4 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
               >
                 + Agregar tutor
               </Link>
+            ) : (
+              <LeaveFamilyGroupButton
+                familyGroupId={activeFamilyGroup.id}
+                groupName={activeFamilyGroup.name}
+                className="flex-shrink-0"
+              />
             )}
           </div>
 
@@ -178,108 +204,133 @@ export default async function ChildrenPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {children.map((child) => (
-            <div
-              key={child.id}
-              className="rounded-xl border bg-card p-4 shadow-sm space-y-3"
-            >
-              <div className="flex items-center gap-3">
-                <div className="flex-shrink-0 h-12 w-12 overflow-hidden rounded-full border bg-muted/30">
-                  {child.profilePhoto ? (
-                    <div className="relative h-full w-full">
-                      <Image
-                        src={`/api/children/${child.id}/photo`}
-                        alt={child.name}
-                        fill
-                        unoptimized
-                        className="object-cover"
-                        sizes="48px"
-                      />
-                    </div>
-                  ) : (
-                    <div className="flex h-full w-full items-center justify-center">
-                      <span className="text-sm font-bold text-muted-foreground">
-                        {`${child.name[0]}${child.lastName?.[0] ?? ''}`.trim()}
+          {children.map((child) => {
+            const assignedFamilyGroup =
+              child.userId === userId
+                ? null
+                : assignedFamilyGroupByChildOwner.get(child.userId);
+
+            return (
+              <div
+                key={child.id}
+                className="rounded-xl border bg-card p-4 shadow-sm space-y-3"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex-shrink-0 h-12 w-12 overflow-hidden rounded-full border bg-muted/30">
+                    {child.profilePhoto ? (
+                      <div className="relative h-full w-full">
+                        <Image
+                          src={`/api/children/${child.id}/photo`}
+                          alt={child.name}
+                          fill
+                          unoptimized
+                          className="object-cover"
+                          sizes="48px"
+                        />
+                      </div>
+                    ) : (
+                      <div className="flex h-full w-full items-center justify-center">
+                        <span className="text-sm font-bold text-muted-foreground">
+                          {`${child.name[0]}${child.lastName?.[0] ?? ''}`.trim()}
+                        </span>
+                      </div>
+                    )}
+                  </div>
+                  <div className="space-y-0.5 min-w-0">
+                    <h2 className="font-semibold truncate">
+                      {child.name} {child.lastName}
+                    </h2>
+                    {child.birthDate && (
+                      <p className="text-xs text-muted-foreground">
+                        {(() => {
+                          const today = new Date();
+                          const birth = new Date(child.birthDate);
+                          let age = today.getFullYear() - birth.getFullYear();
+                          const m = today.getMonth() - birth.getMonth();
+                          if (
+                            m < 0 ||
+                            (m === 0 && today.getDate() < birth.getDate())
+                          )
+                            age--;
+                          return age;
+                        })()}{' '}
+                        años
+                      </p>
+                    )}
+                    {child.userId !== userId && (
+                      <p className="text-xs text-muted-foreground">
+                        Grupo familiar
+                      </p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="bg-muted/30 rounded-lg p-3 space-y-1 text-xs">
+                  {child.bloodGroup && (
+                    <p className="text-muted-foreground">
+                      <span className="font-medium">Grupo sanguíneo:</span>{' '}
+                      {child.bloodGroup}
+                    </p>
+                  )}
+                  {child.allergies && (
+                    <p className="text-muted-foreground">
+                      <span className="font-medium">Alergias:</span>{' '}
+                      {child.allergies.substring(0, 50)}
+                      {child.allergies.length > 50 ? '...' : ''}
+                    </p>
+                  )}
+                  {child.primaryDoctor && (
+                    <p className="text-muted-foreground">
+                      <span className="font-medium">Médico:</span>{' '}
+                      {child.primaryDoctor}
+                    </p>
+                  )}
+                </div>
+
+                <div className="flex gap-2 pt-2">
+                  <Link
+                    href={`/profile/children/${child.id}`}
+                    className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-border px-3 text-xs font-medium hover:bg-muted transition-colors"
+                  >
+                    Ver
+                  </Link>
+                  <Link
+                    href={`/profile/children/${child.id}/edit?returnTo=/profile/children`}
+                    className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-primary px-3 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
+                  >
+                    Editar
+                  </Link>
+                </div>
+                {child.userId === userId &&
+                  child._count.activityParticipants === 0 && (
+                    <DeleteChildButton
+                      childId={child.id}
+                      childName={[child.name, child.lastName]
+                        .filter(Boolean)
+                        .join(' ')}
+                    />
+                  )}
+                {assignedFamilyGroup && (
+                  <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-3 space-y-2">
+                    <p className="text-xs text-muted-foreground">
+                      Este hijo/a aparece porque sos tutor/a en{' '}
+                      <span className="font-medium text-foreground">
+                        {assignedFamilyGroup.name}
                       </span>
-                    </div>
-                  )}
-                </div>
-                <div className="space-y-0.5 min-w-0">
-                  <h2 className="font-semibold truncate">
-                    {child.name} {child.lastName}
-                  </h2>
-                  {child.birthDate && (
-                    <p className="text-xs text-muted-foreground">
-                      {(() => {
-                        const today = new Date();
-                        const birth = new Date(child.birthDate);
-                        let age = today.getFullYear() - birth.getFullYear();
-                        const m = today.getMonth() - birth.getMonth();
-                        if (
-                          m < 0 ||
-                          (m === 0 && today.getDate() < birth.getDate())
-                        )
-                          age--;
-                        return age;
-                      })()}{' '}
-                      años
+                      . Si salís del grupo, dejarás de ver todos los hijos de
+                      esa familia.
                     </p>
-                  )}
-                  {child.userId !== userId && (
-                    <p className="text-xs text-muted-foreground">
-                      Grupo familiar
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              <div className="bg-muted/30 rounded-lg p-3 space-y-1 text-xs">
-                {child.bloodGroup && (
-                  <p className="text-muted-foreground">
-                    <span className="font-medium">Grupo sanguíneo:</span>{' '}
-                    {child.bloodGroup}
-                  </p>
-                )}
-                {child.allergies && (
-                  <p className="text-muted-foreground">
-                    <span className="font-medium">Alergias:</span>{' '}
-                    {child.allergies.substring(0, 50)}
-                    {child.allergies.length > 50 ? '...' : ''}
-                  </p>
-                )}
-                {child.primaryDoctor && (
-                  <p className="text-muted-foreground">
-                    <span className="font-medium">Médico:</span>{' '}
-                    {child.primaryDoctor}
-                  </p>
+                    <LeaveFamilyGroupButton
+                      familyGroupId={assignedFamilyGroup.id}
+                      groupName={assignedFamilyGroup.name}
+                      label="Quitar de mi perfil"
+                      confirmLabel="Sí, quitar"
+                    />
+                  </div>
                 )}
               </div>
-
-              <div className="flex gap-2 pt-2">
-                <Link
-                  href={`/profile/children/${child.id}`}
-                  className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-border px-3 text-xs font-medium hover:bg-muted transition-colors"
-                >
-                  Ver
-                </Link>
-                <Link
-                  href={`/profile/children/${child.id}/edit?returnTo=/profile/children`}
-                  className="flex-1 inline-flex h-8 items-center justify-center rounded-full border border-primary px-3 text-xs font-medium text-primary hover:bg-primary/5 transition-colors"
-                >
-                  Editar
-                </Link>
-              </div>
-              {child.userId === userId &&
-                child._count.activityParticipants === 0 && (
-                  <DeleteChildButton
-                    childId={child.id}
-                    childName={[child.name, child.lastName]
-                      .filter(Boolean)
-                      .join(' ')}
-                  />
-                )}
-            </div>
-          ))}
+            );
+          })}
         </div>
       )}
 


### PR DESCRIPTION
### Motivation
- Provide tutors an explicit way to leave family groups so children they see because they were added as tutors can be removed from their profile. 
- Preserve existing rules: only the family `responsible` can remove other members and the responsible cannot be removed.

### Description
- Extend the family-group members DELETE endpoint to accept `{ leaveSelf: true }` and validate that leaving is allowed; keep existing responsible-only logic for removing other members in `src/app/api/family-groups/[id]/members/route.ts`.
- Add a client component `LeaveFamilyGroupButton` that shows inline confirmation, loading and error states and calls the DELETE endpoint in `src/app/profile/children/leave-family-group-button.tsx`.
- Update the `/profile/children` UI to list other family groups and show leave actions for tutors, render a leave button for the active group when the user is not the responsible, and show a per-child block to explain tutor-assigned children with a `Quitar de mi perfil` action that triggers leaving the source group in `src/app/profile/children/page.tsx`.
- Files touched: `src/app/api/family-groups/[id]/members/route.ts`, `src/app/profile/children/page.tsx`, `src/app/profile/children/leave-family-group-button.tsx`.

### Testing
- Ran `pnpm lint`; command completed and reported existing Prettier warnings outside the touched files (no new lint errors introduced by this change).
- Ran `git diff --check` to ensure no whitespace or diff issues (clean).
- Ran `pnpm exec tsc --noEmit`; this failed due to unrelated, preexisting TypeScript errors elsewhere in the codebase (errors in ActivityMedia and some tests), so full type-checking could not be completed in this branch.
- No runtime/unit tests were added for this change in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffb18cc6608328996dea54a48be3fb)