### PR TITLE
Show activity schedule beside day in my activities

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -76,6 +76,10 @@ function formatDayTitle(date: Date, todayKey: string): string {
   return weekday;
 }
 
+function formatDistinctSchedules(days: CalendarActivityDay[]): string {
+  return Array.from(new Set(days.map((day) => day.schedule))).join(' / ');
+}
+
 function getGoogleMapsHref(day: CalendarActivityDay): string {
   const query =
     day.latitude != null && day.longitude != null
@@ -531,6 +535,9 @@ export default function ActivityCalendar({
                 const isMainDay = key === activeCompactKey;
                 const title = formatDayTitle(date, todayKey);
                 const hasActivities = activities.length > 0;
+                const scheduleLabel = hasActivities
+                  ? formatDistinctSchedules(activities)
+                  : '';
                 const isExpanded = expandedCompactKeys.has(key);
                 const compactActivityLimit = isMainDay ? 3 : 2;
                 const visibleActivities = isExpanded
@@ -568,7 +575,12 @@ export default function ActivityCalendar({
                         <p
                           className={`${isMainDay ? 'text-base' : 'text-sm'} font-bold text-foreground`}
                         >
-                          {title}
+                          <span>{title}</span>
+                          {scheduleLabel && (
+                            <span className="ml-1 whitespace-nowrap">
+                              · {scheduleLabel}
+                            </span>
+                          )}
                         </p>
                         <p className="text-xs font-medium text-muted-foreground">
                           {date.toLocaleDateString('es-AR', {


### PR DESCRIPTION
### Motivation
- Improve the compact weekly view on `/my-activities` by showing the activity schedule next to the day title in bold so users can see the time at a glance.

### Description
- Added `formatDistinctSchedules(days: CalendarActivityDay[])` to compute a unique schedule label for the day's activities.
- Rendered a `scheduleLabel` next to the day title in the compact agenda header using the same bold styling as the day name.
- File changed: `src/app/my-activities/activity-calendar.tsx`.

### Testing
- Ran `pnpm lint` which completed successfully (it reported pre-existing Prettier warnings in unrelated files but no errors).
- Ran `pnpm exec prettier --check src/app/my-activities/activity-calendar.tsx` which passed for the modified file.
- Ran `git diff --check` which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffbb6b2490832882908bcf37720820)