### PR TITLE
Filter notifications by active profile role

### DIFF
--- a/src/app/api/mobile/notifications/[id]/route.ts
+++ b/src/app/api/mobile/notifications/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getMobileSessionFromRequest } from '@/lib/mobile-auth';
 import { prisma } from '@/lib/prisma';
+import { isNotificationVisibleForActiveRole } from '@/lib/notifications/visibility';
 
 type RouteContext = {
   params: {
@@ -17,10 +18,14 @@ export async function PATCH(req: Request, context: RouteContext) {
   const { id } = context.params;
   const notification = await prisma.notification.findUnique({
     where: { id },
-    select: { id: true, userId: true, readAt: true },
+    select: { id: true, userId: true, type: true, url: true, readAt: true },
   });
 
-  if (!notification || notification.userId !== session.userId) {
+  if (
+    !notification ||
+    notification.userId !== session.userId ||
+    !isNotificationVisibleForActiveRole(notification, session.appRole)
+  ) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
 

--- a/src/app/api/mobile/notifications/route.ts
+++ b/src/app/api/mobile/notifications/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 import { getMobileSessionFromRequest } from '@/lib/mobile-auth';
 import { prisma } from '@/lib/prisma';
+import { filterNotificationsForActiveRole } from '@/lib/notifications/visibility';
 
 export async function GET(req: Request) {
   const session = await getMobileSessionFromRequest(req);
@@ -16,14 +17,13 @@ export async function GET(req: Request) {
     50
   );
 
-  const [notifications, unreadCount, chatUnreadCount] = await Promise.all([
+  const [notificationRows, unreadRows] = await Promise.all([
     prisma.notification.findMany({
       where: {
         userId: session.userId,
         ...(unreadOnly ? { readAt: null } : {}),
       },
       orderBy: { createdAt: 'desc' },
-      take: limit,
       select: {
         id: true,
         type: true,
@@ -34,17 +34,24 @@ export async function GET(req: Request) {
         createdAt: true,
       },
     }),
-    prisma.notification.count({
+    prisma.notification.findMany({
       where: { userId: session.userId, readAt: null },
-    }),
-    prisma.notification.count({
-      where: {
-        userId: session.userId,
-        readAt: null,
-        type: 'CHAT_MESSAGE_NEW',
-      },
+      select: { type: true, url: true },
     }),
   ]);
+
+  const notifications = filterNotificationsForActiveRole(
+    notificationRows,
+    session.appRole
+  ).slice(0, limit);
+  const visibleUnreadRows = filterNotificationsForActiveRole(
+    unreadRows,
+    session.appRole
+  );
+  const unreadCount = visibleUnreadRows.length;
+  const chatUnreadCount = visibleUnreadRows.filter(
+    (notification) => notification.type === 'CHAT_MESSAGE_NEW'
+  ).length;
 
   return NextResponse.json({
     notifications: notifications.map((notification) => ({
@@ -67,8 +74,21 @@ export async function PATCH(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const result = await prisma.notification.updateMany({
+  const unreadRows = await prisma.notification.findMany({
     where: { userId: session.userId, readAt: null },
+    select: { id: true, type: true, url: true },
+  });
+  const visibleIds = filterNotificationsForActiveRole(
+    unreadRows,
+    session.appRole
+  ).map((notification) => notification.id);
+
+  if (visibleIds.length === 0) {
+    return NextResponse.json({ updated: 0 });
+  }
+
+  const result = await prisma.notification.updateMany({
+    where: { userId: session.userId, id: { in: visibleIds }, readAt: null },
     data: { readAt: new Date() },
   });
 

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,21 +1,26 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getNotificationUserIdFromRequest } from '@/lib/notifications/notification-access';
+import { getNotificationContextFromRequest } from '@/lib/notifications/notification-access';
+import { isNotificationVisibleForActiveRole } from '@/lib/notifications/visibility';
 
 export async function PATCH(
   req: Request,
   { params }: { params: { id: string } }
 ) {
-  const userId = await getNotificationUserIdFromRequest(req);
-  if (!userId) {
+  const context = await getNotificationContextFromRequest(req);
+  if (!context) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
   const notification = await prisma.notification.findUnique({
     where: { id: params.id },
-    select: { userId: true, readAt: true },
+    select: { userId: true, type: true, url: true, readAt: true },
   });
-  if (!notification || notification.userId !== userId) {
+  if (
+    !notification ||
+    notification.userId !== context.userId ||
+    !isNotificationVisibleForActiveRole(notification, context.activeRole)
+  ) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
   if (notification.readAt) {

--- a/src/app/api/notifications/route.ts
+++ b/src/app/api/notifications/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
-import { getNotificationUserIdFromRequest } from '@/lib/notifications/notification-access';
+import { getNotificationContextFromRequest } from '@/lib/notifications/notification-access';
+import { filterNotificationsForActiveRole } from '@/lib/notifications/visibility';
 
 export async function GET(req: Request) {
-  const userId = await getNotificationUserIdFromRequest(req);
-  if (!userId) {
+  const context = await getNotificationContextFromRequest(req);
+  if (!context) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
   const url = new URL(req.url);
@@ -15,14 +16,13 @@ export async function GET(req: Request) {
     50
   );
 
-  const [notifications, unreadCount, chatUnreadCount] = await Promise.all([
+  const [notificationRows, unreadRows] = await Promise.all([
     prisma.notification.findMany({
       where: {
-        userId,
+        userId: context.userId,
         ...(unreadOnly ? { readAt: null } : {}),
       },
       orderBy: { createdAt: 'desc' },
-      take: limit,
       select: {
         id: true,
         type: true,
@@ -34,22 +34,49 @@ export async function GET(req: Request) {
         createdAt: true,
       },
     }),
-    prisma.notification.count({ where: { userId, readAt: null } }),
-    prisma.notification.count({
-      where: { userId, readAt: null, type: 'CHAT_MESSAGE_NEW' },
+    prisma.notification.findMany({
+      where: { userId: context.userId, readAt: null },
+      select: { type: true, url: true },
     }),
   ]);
+
+  const notifications = filterNotificationsForActiveRole(
+    notificationRows,
+    context.activeRole
+  ).slice(0, limit);
+  const visibleUnreadRows = filterNotificationsForActiveRole(
+    unreadRows,
+    context.activeRole
+  );
+  const unreadCount = visibleUnreadRows.length;
+  const chatUnreadCount = visibleUnreadRows.filter(
+    (notification) => notification.type === 'CHAT_MESSAGE_NEW'
+  ).length;
 
   return NextResponse.json({ notifications, unreadCount, chatUnreadCount });
 }
 
 export async function PATCH(req: Request) {
-  const userId = await getNotificationUserIdFromRequest(req);
-  if (!userId) {
+  const context = await getNotificationContextFromRequest(req);
+  if (!context) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
+
+  const unreadRows = await prisma.notification.findMany({
+    where: { userId: context.userId, readAt: null },
+    select: { id: true, type: true, url: true },
+  });
+  const visibleIds = filterNotificationsForActiveRole(
+    unreadRows,
+    context.activeRole
+  ).map((notification) => notification.id);
+
+  if (visibleIds.length === 0) {
+    return NextResponse.json({ updated: 0 });
+  }
+
   const result = await prisma.notification.updateMany({
-    where: { userId, readAt: null },
+    where: { userId: context.userId, id: { in: visibleIds }, readAt: null },
     data: { readAt: new Date() },
   });
   return NextResponse.json({ updated: result.count });

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -3,6 +3,8 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import NotificationsInbox from './notifications-inbox';
+import { filterNotificationsForActiveRole } from '@/lib/notifications/visibility';
+import type { Role } from '@prisma/client';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,9 +14,11 @@ export default async function NotificationsPage() {
     redirect('/login?callbackUrl=/notifications');
   }
 
-  const userId = (session.user as { id: string }).id;
+  const sessionUser = session.user as { id: string; activeRole?: Role | null };
+  const userId = sessionUser.id;
+  const activeRole = sessionUser.activeRole ?? null;
 
-  const [notifications, unreadCount] = await Promise.all([
+  const [notificationRows, unreadRows] = await Promise.all([
     prisma.notification.findMany({
       where: { userId },
       orderBy: { createdAt: 'desc' },
@@ -28,8 +32,20 @@ export default async function NotificationsPage() {
         createdAt: true,
       },
     }),
-    prisma.notification.count({ where: { userId, readAt: null } }),
+    prisma.notification.findMany({
+      where: { userId, readAt: null },
+      select: { type: true, url: true },
+    }),
   ]);
+
+  const notifications = filterNotificationsForActiveRole(
+    notificationRows,
+    activeRole
+  );
+  const unreadCount = filterNotificationsForActiveRole(
+    unreadRows,
+    activeRole
+  ).length;
 
   return (
     <main className="max-w-6xl mx-auto px-4 py-8">

--- a/src/lib/__tests__/notification-visibility.test.ts
+++ b/src/lib/__tests__/notification-visibility.test.ts
@@ -1,0 +1,66 @@
+import {
+  filterNotificationsForActiveRole,
+  getNotificationRequiredActiveRoles,
+  isNotificationVisibleForActiveRole,
+} from '../notifications/visibility';
+
+describe('notification visibility', () => {
+  it('hides professor group notifications from the member profile', () => {
+    const notification = {
+      type: 'PROFESSOR_GROUP_ASSIGNED' as const,
+      url: '/activities/activity-1/groups/group-1',
+    };
+
+    expect(isNotificationVisibleForActiveRole(notification, 'MEMBER')).toBe(
+      false
+    );
+    expect(isNotificationVisibleForActiveRole(notification, 'PROFESSOR')).toBe(
+      true
+    );
+  });
+
+  it('requires an admin or professor profile for activity group links', () => {
+    const notification = {
+      type: 'ACTIVITY_DAY_UPDATED' as const,
+      url: '/activities/activity-1/groups/group-1',
+    };
+
+    expect(getNotificationRequiredActiveRoles(notification)).toEqual([
+      'ADMIN',
+      'PROFESSOR',
+      'SUPER_ADMIN',
+    ]);
+    expect(isNotificationVisibleForActiveRole(notification, 'MEMBER')).toBe(
+      false
+    );
+    expect(isNotificationVisibleForActiveRole(notification, 'ADMIN')).toBe(
+      true
+    );
+  });
+
+  it('filters accounting notifications out of non-accounting profiles', () => {
+    const notifications = [
+      {
+        id: 'member-news',
+        type: 'NEWS_CREATED' as const,
+        url: '/news#post-1',
+      },
+      {
+        id: 'accounting-movement',
+        type: 'PAYMENT_MANUAL_CREATED' as const,
+        url: '/accounting/movements',
+      },
+    ];
+
+    expect(
+      filterNotificationsForActiveRole(notifications, 'MEMBER').map(
+        (notification) => notification.id
+      )
+    ).toEqual(['member-news']);
+    expect(
+      filterNotificationsForActiveRole(notifications, 'COUNTER').map(
+        (notification) => notification.id
+      )
+    ).toEqual(['member-news', 'accounting-movement']);
+  });
+});

--- a/src/lib/notifications/dispatcher.ts
+++ b/src/lib/notifications/dispatcher.ts
@@ -1,11 +1,12 @@
 import { prisma } from '@/lib/prisma';
-import { Prisma, type NotificationType } from '@prisma/client';
+import { Prisma, type NotificationType, type Role } from '@prisma/client';
 import { resolvePreferences } from './preferences';
 import { sendPushAlert, PushAlertError } from '@/lib/pushalert';
 import {
   sendMobilePushNotifications,
   type MobilePushDevice,
 } from '@/lib/mobile-push';
+import { isNotificationVisibleForActiveRole } from './visibility';
 
 export type DispatchInput = {
   type: NotificationType;
@@ -27,6 +28,13 @@ export async function dispatch(input: DispatchInput): Promise<void> {
     const p = prefs.get(id) ?? { inApp: true, push: true };
     return p.inApp || p.push;
   });
+  if (candidates.length === 0) return;
+
+  candidates = await filterCandidatesForActiveRole(
+    candidates,
+    type,
+    url ?? null
+  );
   if (candidates.length === 0) return;
 
   if (type === 'CHAT_MESSAGE_NEW' && data) {
@@ -77,7 +85,7 @@ export async function dispatch(input: DispatchInput): Promise<void> {
   const pushUsers = candidates.filter((id) => prefs.get(id)?.push ?? true);
   if (pushUsers.length === 0) return;
 
-  const mobileDevices = await prisma.mobileDeviceToken.findMany({
+  let mobileDevices = await prisma.mobileDeviceToken.findMany({
     where: {
       userId: { in: pushUsers },
       revokedAt: null,
@@ -88,8 +96,14 @@ export async function dispatch(input: DispatchInput): Promise<void> {
       environment: true,
       bundleId: true,
       userId: true,
+      sessionId: true,
     },
   });
+  mobileDevices = await filterMobileDevicesForActiveRole(
+    mobileDevices,
+    type,
+    url ?? null
+  );
 
   if (mobileDevices.length > 0) {
     const mobileResults = await sendMobilePushNotifications(
@@ -137,6 +151,71 @@ export async function dispatch(input: DispatchInput): Promise<void> {
       status: err instanceof PushAlertError ? err.statusCode : undefined,
     });
   }
+}
+
+async function filterCandidatesForActiveRole(
+  userIds: string[],
+  type: NotificationType,
+  url: string | null
+): Promise<string[]> {
+  const requiredNotification = { type, url };
+  const hasRoleRequirement = !isNotificationVisibleForActiveRole(
+    requiredNotification,
+    null
+  );
+  if (!hasRoleRequirement) return userIds;
+
+  const users = await prisma.user.findMany({
+    where: { id: { in: userIds }, isActive: true },
+    select: { id: true, activeRole: true },
+  });
+  const activeRoles = new Map<string, Role>(
+    users.map((user) => [user.id, user.activeRole])
+  );
+
+  return userIds.filter((userId) =>
+    isNotificationVisibleForActiveRole(
+      requiredNotification,
+      activeRoles.get(userId) ?? null
+    )
+  );
+}
+
+async function filterMobileDevicesForActiveRole<
+  T extends { sessionId: string | null },
+>(devices: T[], type: NotificationType, url: string | null): Promise<T[]> {
+  const requiredNotification = { type, url };
+  const hasRoleRequirement = !isNotificationVisibleForActiveRole(
+    requiredNotification,
+    null
+  );
+  if (!hasRoleRequirement) return devices;
+
+  const sessionIds = devices
+    .map((device) => device.sessionId)
+    .filter((sessionId): sessionId is string => Boolean(sessionId));
+  if (sessionIds.length === 0) return [];
+
+  const sessions = await prisma.mobileSession.findMany({
+    where: {
+      id: { in: sessionIds },
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+    select: { id: true, appRole: true },
+  });
+  const activeRoles = new Map<string, Role>(
+    sessions.map((session) => [session.id, session.appRole])
+  );
+
+  return devices.filter(
+    (device) =>
+      device.sessionId &&
+      isNotificationVisibleForActiveRole(
+        requiredNotification,
+        activeRoles.get(device.sessionId) ?? null
+      )
+  );
 }
 
 function normalizeMobileDevice(device: {

--- a/src/lib/notifications/notification-access.ts
+++ b/src/lib/notifications/notification-access.ts
@@ -1,11 +1,22 @@
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { getMobileSessionFromRequest } from '@/lib/mobile-auth';
+import type { Role } from '@prisma/client';
 
-export async function getNotificationUserIdFromRequest(req: Request) {
+export type NotificationRequestContext = {
+  userId: string;
+  activeRole: Role | null;
+};
+
+export async function getNotificationContextFromRequest(
+  req: Request
+): Promise<NotificationRequestContext | null> {
   const mobileSession = await getMobileSessionFromRequest(req);
   if (mobileSession) {
-    return mobileSession.userId;
+    return {
+      userId: mobileSession.userId,
+      activeRole: mobileSession.appRole,
+    };
   }
 
   const session = await getServerSession(authOptions);
@@ -13,5 +24,14 @@ export async function getNotificationUserIdFromRequest(req: Request) {
     return null;
   }
 
-  return (session.user as { id: string }).id;
+  const user = session.user as { id: string; activeRole?: Role | null };
+  return {
+    userId: user.id,
+    activeRole: user.activeRole ?? null,
+  };
+}
+
+export async function getNotificationUserIdFromRequest(req: Request) {
+  const context = await getNotificationContextFromRequest(req);
+  return context?.userId ?? null;
 }

--- a/src/lib/notifications/visibility.ts
+++ b/src/lib/notifications/visibility.ts
@@ -1,0 +1,61 @@
+import type { Notification, NotificationType, Role } from '@prisma/client';
+
+export type NotificationVisibilityInput = Pick<Notification, 'type' | 'url'>;
+
+const ADMIN_ROLES: Role[] = ['ADMIN', 'SUPER_ADMIN'];
+const ACCOUNTING_ROLES: Role[] = ['COUNTER', 'ADMIN', 'SUPER_ADMIN'];
+const PROFESSOR_ROLES: Role[] = ['PROFESSOR'];
+const GROUP_MANAGER_ROLES: Role[] = ['ADMIN', 'PROFESSOR', 'SUPER_ADMIN'];
+
+const ADMIN_ONLY_TYPES = new Set<NotificationType>(['ACTIVITY_CAPACITY_FULL']);
+
+const ACCOUNTING_TYPES = new Set<NotificationType>([
+  'PAYMENT_MANUAL_CREATED',
+  'PROFESSOR_INVOICE_CREATED',
+]);
+
+const PROFESSOR_ONLY_TYPES = new Set<NotificationType>([
+  'PROFESSOR_ACTIVITY_ASSIGNED',
+  'PROFESSOR_GROUP_ASSIGNED',
+]);
+
+function startsWithPath(url: string | null | undefined, path: string): boolean {
+  return url === path || url?.startsWith(`${path}/`) === true;
+}
+
+export function getNotificationRequiredActiveRoles(
+  notification: NotificationVisibilityInput
+): Role[] | null {
+  if (PROFESSOR_ONLY_TYPES.has(notification.type)) return PROFESSOR_ROLES;
+  if (ACCOUNTING_TYPES.has(notification.type)) return ACCOUNTING_ROLES;
+  if (ADMIN_ONLY_TYPES.has(notification.type)) return ADMIN_ROLES;
+
+  const url = notification.url;
+  if (startsWithPath(url, '/accounting')) return ACCOUNTING_ROLES;
+  if (startsWithPath(url, '/admin')) return ADMIN_ROLES;
+  if (startsWithPath(url, '/my-payments')) return PROFESSOR_ROLES;
+
+  if (url && /^\/activities\/[^/]+\/groups\/[^/]+(?:$|[/?#])/.test(url)) {
+    return GROUP_MANAGER_ROLES;
+  }
+
+  return null;
+}
+
+export function isNotificationVisibleForActiveRole(
+  notification: NotificationVisibilityInput,
+  activeRole: Role | null | undefined
+): boolean {
+  const requiredRoles = getNotificationRequiredActiveRoles(notification);
+  if (!requiredRoles) return true;
+  if (!activeRole) return false;
+  return requiredRoles.includes(activeRole);
+}
+
+export function filterNotificationsForActiveRole<
+  T extends NotificationVisibilityInput,
+>(notifications: T[], activeRole: Role | null | undefined): T[] {
+  return notifications.filter((notification) =>
+    isNotificationVisibleForActiveRole(notification, activeRole)
+  );
+}


### PR DESCRIPTION
### Motivation
- Prevent users from receiving notifications that link to pages they cannot access with their current active profile (e.g. a parent/member receiving a group/admin notification that requires `ADMIN`/`PROFESSOR`).
- Ensure unread counters, inbox lists and push delivery respect the session's active role so the UI doesn't direct users to unreachable pages.

### Description
- Add a shared visibility module `src/lib/notifications/visibility.ts` that maps notification `type` and `url` to required active roles and exposes `filterNotificationsForActiveRole` and `isNotificationVisibleForActiveRole`.
- Extend notification request context to include `activeRole` via `getNotificationContextFromRequest` in `src/lib/notifications/notification-access.ts` and keep a compatibility wrapper `getNotificationUserIdFromRequest`.
- Filter notification listing, unread counters and mark-as-read operations in web and mobile APIs (`src/app/api/notifications/*`, `src/app/api/mobile/notifications/*`) and in the `/notifications` page so only notifications visible to the current active role are returned or marked read.
- Prevent dispatch from creating/sending role-restricted notifications to users/sessions whose active role cannot open them by filtering recipients and mobile devices in `src/lib/notifications/dispatcher.ts`.
- Add unit tests for visibility rules in `src/lib/__tests__/notification-visibility.test.ts` covering group and accounting notification cases.

### Testing
- Ran the new unit tests with `pnpm test -- notification-visibility.test.ts` and they passed (3 tests).
- Ran `pnpm lint` / `next lint` which completed successfully (there are existing Prettier warnings in unrelated files but no fatal lint failure for these changes).
- Ran `pnpm exec tsc --noEmit` which surfaced unrelated TypeScript errors in existing test files (`tests/api/pickup-notices.test.ts`); these failures are pre-existing and not caused by the notification changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffc3c073148328bf02335ca439bafa)