### PR TITLE
Add month‑end accounting close (model, API, UI, snapshot)

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -364,6 +364,12 @@ Agents should check this before searching the codebase.
 - `GET /api/accounting/reports` → aggregated report data
   - File: `src/app/api/accounting/reports/route.ts`
 
+- `GET /api/accounting/month-close` → fetch latest saved month-end accounting close
+  - File: `src/app/api/accounting/month-close/route.ts`
+
+- `POST /api/accounting/month-close` → save/update month-end balances and activity payment snapshot
+  - File: `src/app/api/accounting/month-close/route.ts`
+
 ### Professor Payments
 
 - `GET /api/professors/[id]/profile` → get professor banking/salary profile

--- a/prisma/migrations/20260510120000_add_accounting_month_close/migration.sql
+++ b/prisma/migrations/20260510120000_add_accounting_month_close/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "AccountingMonthClose" (
+    "id" TEXT NOT NULL,
+    "periodMonth" INTEGER NOT NULL,
+    "periodYear" INTEGER NOT NULL,
+    "periodStart" TIMESTAMP(3) NOT NULL,
+    "periodEnd" TIMESTAMP(3) NOT NULL,
+    "totalIncome" INTEGER NOT NULL,
+    "totalExpense" INTEGER NOT NULL,
+    "netBalance" INTEGER NOT NULL,
+    "positiveBalance" INTEGER NOT NULL,
+    "activitySnapshot" JSONB NOT NULL,
+    "createdById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "AccountingMonthClose_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "AccountingMonthClose_periodYear_periodMonth_key" ON "AccountingMonthClose"("periodYear", "periodMonth");
+
+-- CreateIndex
+CREATE INDEX "AccountingMonthClose_periodStart_periodEnd_idx" ON "AccountingMonthClose"("periodStart", "periodEnd");
+
+-- CreateIndex
+CREATE INDEX "AccountingMonthClose_createdById_idx" ON "AccountingMonthClose"("createdById");
+
+-- AddForeignKey
+ALTER TABLE "AccountingMonthClose" ADD CONSTRAINT "AccountingMonthClose_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,7 @@ model User {
   activityDayProfessors       ActivityDayProfessor[]
   children                    Child[]
   accountingMovements         AccountingMovement[]
+  accountingMonthClosings     AccountingMonthClose[]
   responsibleFamilyGroups     FamilyGroup[]                @relation("FamilyGroupResponsible")
   familyMemberships           FamilyGroupMember[]          @relation("FamilyGroupMemberUser")
   ordersAsResponsible         Order[]                      @relation("OrderResponsible")
@@ -460,6 +461,27 @@ model AccountingMovement {
   updatedAt     DateTime     @updatedAt
 
   @@index([date])
+  @@index([createdById])
+}
+
+model AccountingMonthClose {
+  id               String   @id @default(cuid())
+  periodMonth      Int
+  periodYear       Int
+  periodStart      DateTime
+  periodEnd        DateTime
+  totalIncome      Int
+  totalExpense     Int
+  netBalance       Int
+  positiveBalance  Int
+  activitySnapshot Json
+  createdById      String
+  createdBy        User     @relation(fields: [createdById], references: [id])
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+
+  @@unique([periodYear, periodMonth])
+  @@index([periodStart, periodEnd])
   @@index([createdById])
 }
 

--- a/src/app/accounting/month-close-button.tsx
+++ b/src/app/accounting/month-close-button.tsx
@@ -1,0 +1,209 @@
+'use client';
+
+import { useState } from 'react';
+import { CheckCircle2, Loader2, LockKeyhole } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { formatAccountingDate, formatAmount } from '@/lib/accounting';
+
+type MonthCloseSummary = {
+  id: string;
+  periodMonth: number;
+  periodYear: number;
+  totalIncome: number;
+  totalExpense: number;
+  netBalance: number;
+  positiveBalance: number;
+  updatedAt: string | Date;
+  activitySnapshot?: {
+    activityReports?: Array<{
+      activityId: string;
+      activityName: string;
+      totalParticipants: number;
+      paidParticipants: number;
+      pendingParticipants: number;
+      paidAmount: number;
+    }>;
+  };
+};
+
+const MONTH_LABELS = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+] as const;
+
+function periodLabel(month: number, year: number) {
+  return `${MONTH_LABELS[month - 1] ?? 'mes'} ${year}`;
+}
+
+export default function MonthCloseButton({
+  month,
+  year,
+  initialClose,
+}: {
+  month: number;
+  year: number;
+  initialClose: MonthCloseSummary | null;
+}) {
+  const [close, setClose] = useState<MonthCloseSummary | null>(initialClose);
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const handleCloseMonth = async () => {
+    setLoading(true);
+    setMessage('');
+    setError('');
+
+    try {
+      const response = await fetch('/api/accounting/month-close', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ month, year }),
+      });
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? 'No se pudo cerrar el mes');
+      }
+
+      setClose(payload.close);
+      setMessage('Fin de mes guardado correctamente.');
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : 'No se pudo guardar el cierre'
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const activityReports = close?.activitySnapshot?.activityReports ?? [];
+  const paidActivities = activityReports.filter(
+    (activity) => activity.paidParticipants > 0
+  ).length;
+  const totalParticipants = activityReports.reduce(
+    (sum, activity) => sum + activity.totalParticipants,
+    0
+  );
+  const totalPaidParticipants = activityReports.reduce(
+    (sum, activity) => sum + activity.paidParticipants,
+    0
+  );
+
+  return (
+    <section className="rounded-2xl border bg-card p-5 shadow-sm">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+        <div className="space-y-2">
+          <div className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+            <LockKeyhole className="h-3.5 w-3.5" />
+            Fin de mes
+          </div>
+          <div>
+            <h2 className="text-xl font-semibold tracking-tight">
+              Cierre de {periodLabel(month, year)}
+            </h2>
+            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+              Guarda una foto contable del mes con balances, saldo positivo,
+              cantidad de socios por actividad y socios pagos por actividad. Si
+              volvés a cerrar el mismo período, se actualiza el reporte
+              guardado.
+            </p>
+          </div>
+        </div>
+
+        <Button type="button" onClick={handleCloseMonth} disabled={loading}>
+          {loading ? (
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+          ) : (
+            <CheckCircle2 className="mr-2 h-4 w-4" />
+          )}
+          Hacer fin de mes
+        </Button>
+      </div>
+
+      {close && (
+        <div className="mt-5 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+          {[
+            {
+              label: 'Ingresos guardados',
+              value: formatAmount(close.totalIncome),
+            },
+            {
+              label: 'Egresos guardados',
+              value: formatAmount(close.totalExpense),
+            },
+            { label: 'Balance neto', value: formatAmount(close.netBalance) },
+            {
+              label: 'Saldo positivo',
+              value: formatAmount(close.positiveBalance),
+            },
+            {
+              label: 'Socios pagos',
+              value: `${totalPaidParticipants}/${totalParticipants}`,
+            },
+          ].map((item) => (
+            <article
+              key={item.label}
+              className="rounded-xl border bg-muted/20 p-4"
+            >
+              <p className="text-xs text-muted-foreground">{item.label}</p>
+              <p className="mt-1 text-xl font-semibold">{item.value}</p>
+            </article>
+          ))}
+        </div>
+      )}
+
+      {close && activityReports.length > 0 && (
+        <div className="mt-5 overflow-x-auto rounded-xl border">
+          <table className="min-w-full text-sm">
+            <thead className="border-b bg-muted/30 text-left text-muted-foreground">
+              <tr>
+                <th className="px-4 py-2 font-medium">Actividad</th>
+                <th className="px-4 py-2 font-medium">Socios</th>
+                <th className="px-4 py-2 font-medium">Socios pagos</th>
+                <th className="px-4 py-2 font-medium">Pendientes</th>
+                <th className="px-4 py-2 font-medium">Cobrado</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {activityReports.slice(0, 6).map((activity) => (
+                <tr key={activity.activityId}>
+                  <td className="px-4 py-3 font-medium">
+                    {activity.activityName}
+                  </td>
+                  <td className="px-4 py-3">{activity.totalParticipants}</td>
+                  <td className="px-4 py-3">{activity.paidParticipants}</td>
+                  <td className="px-4 py-3">{activity.pendingParticipants}</td>
+                  <td className="px-4 py-3">
+                    {formatAmount(activity.paidAmount)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {close && (
+        <p className="mt-3 text-xs text-muted-foreground">
+          Último cierre guardado: {formatAccountingDate(close.updatedAt)} ·{' '}
+          {activityReports.length} actividades relevadas · {paidActivities}{' '}
+          actividades con socios pagos.
+        </p>
+      )}
+
+      {message && <p className="mt-3 text-sm text-emerald-700">{message}</p>}
+      {error && <p className="mt-3 text-sm text-red-700">{error}</p>}
+    </section>
+  );
+}

--- a/src/app/accounting/page.tsx
+++ b/src/app/accounting/page.tsx
@@ -22,6 +22,7 @@ import {
   buildManualPaymentReceiptUrl,
 } from '@/lib/blob-urls';
 import { matchesAccountingSearch } from '@/lib/accounting-search';
+import MonthCloseButton from './month-close-button';
 
 function startOfMonth(date: Date) {
   return new Date(date.getFullYear(), date.getMonth(), 1);
@@ -66,6 +67,7 @@ export default async function AccountingDashboardPage({
     verifiedManualPaymentsCount,
     pendingManualPaymentsCount,
     monthProfessorPayments,
+    currentMonthClose,
   ] = await Promise.all([
     prisma.accountingMovement.findMany({
       where: {
@@ -141,6 +143,14 @@ export default async function AccountingDashboardPage({
         paidAt: {
           gte: monthStart,
           lte: monthEnd,
+        },
+      },
+    }),
+    prisma.accountingMonthClose.findUnique({
+      where: {
+        periodYear_periodMonth: {
+          periodYear: now.getFullYear(),
+          periodMonth: now.getMonth() + 1,
         },
       },
     }),
@@ -302,6 +312,26 @@ export default async function AccountingDashboardPage({
           </article>
         ))}
       </section>
+
+      <MonthCloseButton
+        month={now.getMonth() + 1}
+        year={now.getFullYear()}
+        initialClose={
+          currentMonthClose
+            ? {
+                id: currentMonthClose.id,
+                periodMonth: currentMonthClose.periodMonth,
+                periodYear: currentMonthClose.periodYear,
+                totalIncome: currentMonthClose.totalIncome,
+                totalExpense: currentMonthClose.totalExpense,
+                netBalance: currentMonthClose.netBalance,
+                positiveBalance: currentMonthClose.positiveBalance,
+                updatedAt: currentMonthClose.updatedAt,
+                activitySnapshot: currentMonthClose.activitySnapshot as any,
+              }
+            : null
+        }
+      />
 
       <section className="grid gap-6 xl:grid-cols-[1.5fr_1fr]">
         <form className="xl:col-span-2 rounded-2xl border bg-card p-4 shadow-sm">

--- a/src/app/api/accounting/month-close/route.ts
+++ b/src/app/api/accounting/month-close/route.ts
@@ -1,0 +1,116 @@
+import { NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { isAccountingRole } from '@/lib/accounting';
+import { prisma } from '@/lib/prisma';
+import {
+  buildAccountingMonthCloseSnapshot,
+  getAccountingPeriodBounds,
+} from '@/lib/accounting-month-close';
+
+function currentPeriod() {
+  const now = new Date();
+  return {
+    month: now.getMonth() + 1,
+    year: now.getFullYear(),
+  };
+}
+
+function parsePeriod(value: unknown) {
+  if (!value || typeof value !== 'object') return currentPeriod();
+
+  const input = value as { month?: unknown; year?: unknown };
+  const month = Number(input.month);
+  const year = Number(input.year);
+
+  if (
+    !Number.isInteger(month) ||
+    month < 1 ||
+    month > 12 ||
+    !Number.isInteger(year) ||
+    year < 2000 ||
+    year > 2100
+  ) {
+    return null;
+  }
+
+  return { month, year };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!isAccountingRole((session?.user as any)?.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const latest = await prisma.accountingMonthClose.findFirst({
+    orderBy: [{ periodYear: 'desc' }, { periodMonth: 'desc' }],
+    include: {
+      createdBy: { select: { name: true, lastName: true, email: true } },
+    },
+  });
+
+  return NextResponse.json({ latest });
+}
+
+export async function POST(request: Request) {
+  const session = await getServerSession(authOptions);
+  const role = (session?.user as any)?.role;
+  const userId = (session?.user as any)?.id;
+
+  if (!userId || !isAccountingRole(role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const period = parsePeriod(body);
+
+  if (!period) {
+    return NextResponse.json(
+      { error: 'El período indicado no es válido' },
+      { status: 400 }
+    );
+  }
+
+  const { periodStart, periodEnd } = getAccountingPeriodBounds(
+    period.month,
+    period.year
+  );
+  const snapshot = await buildAccountingMonthCloseSnapshot(period);
+
+  const close = await prisma.accountingMonthClose.upsert({
+    where: {
+      periodYear_periodMonth: {
+        periodYear: period.year,
+        periodMonth: period.month,
+      },
+    },
+    create: {
+      periodMonth: period.month,
+      periodYear: period.year,
+      periodStart,
+      periodEnd,
+      totalIncome: snapshot.balances.totalIncome,
+      totalExpense: snapshot.balances.totalExpense,
+      netBalance: snapshot.balances.netBalance,
+      positiveBalance: snapshot.balances.positiveBalance,
+      activitySnapshot: snapshot,
+      createdById: userId,
+    },
+    update: {
+      periodStart,
+      periodEnd,
+      totalIncome: snapshot.balances.totalIncome,
+      totalExpense: snapshot.balances.totalExpense,
+      netBalance: snapshot.balances.netBalance,
+      positiveBalance: snapshot.balances.positiveBalance,
+      activitySnapshot: snapshot,
+      createdById: userId,
+    },
+    include: {
+      createdBy: { select: { name: true, lastName: true, email: true } },
+    },
+  });
+
+  return NextResponse.json({ close });
+}

--- a/src/lib/accounting-month-close.ts
+++ b/src/lib/accounting-month-close.ts
@@ -1,0 +1,282 @@
+import type { Prisma } from '@prisma/client';
+import { prisma } from '@/lib/prisma';
+import {
+  getAccountingManualPaymentAmount,
+  getAccountingPaymentDate,
+} from '@/lib/accounting';
+import {
+  buildAccountingReportEntries,
+  buildAccountingCategoryTotals,
+  summarizeAccounting,
+  type ProfessorPaymentLike,
+} from '@/lib/accounting-summary';
+
+export type AccountingMonthCloseActivity = {
+  activityId: string;
+  activityName: string;
+  totalParticipants: number;
+  paidParticipants: number;
+  pendingParticipants: number;
+  paidAmount: number;
+};
+
+export type AccountingMonthCloseSnapshot = {
+  period: {
+    month: number;
+    year: number;
+    from: string;
+    to: string;
+  };
+  balances: {
+    totalIncome: number;
+    totalExpense: number;
+    netBalance: number;
+    positiveBalance: number;
+    movementIncome: number;
+    movementExpense: number;
+    manualIncome: number;
+    mercadoPagoIncome: number;
+    professorExpense: number;
+  };
+  activityReports: AccountingMonthCloseActivity[];
+  categoryTotals: Record<string, { income: number; expense: number }>;
+  entriesCount: number;
+};
+
+export function getAccountingPeriodBounds(month: number, year: number) {
+  return {
+    periodStart: new Date(year, month - 1, 1, 0, 0, 0, 0),
+    periodEnd: new Date(year, month, 0, 23, 59, 59, 999),
+  };
+}
+
+function parsePersonName(person: {
+  name?: string | null;
+  lastName?: string | null;
+}) {
+  return `${person.name ?? ''} ${person.lastName ?? ''}`.trim() || 'Sin nombre';
+}
+
+function isDateInRange(
+  value: Date | string | null | undefined,
+  from: Date,
+  to: Date
+) {
+  if (!value) return false;
+  const date = value instanceof Date ? value : new Date(value);
+  return !Number.isNaN(date.getTime()) && date >= from && date <= to;
+}
+
+export async function buildAccountingMonthCloseSnapshot({
+  month,
+  year,
+}: {
+  month: number;
+  year: number;
+}): Promise<AccountingMonthCloseSnapshot> {
+  const { periodStart, periodEnd } = getAccountingPeriodBounds(month, year);
+  const dateFilter: Prisma.DateTimeFilter = {
+    gte: periodStart,
+    lte: periodEnd,
+  };
+
+  const [
+    movements,
+    manualPayments,
+    mpParticipants,
+    paidProfessorPayments,
+    activities,
+  ] = await Promise.all([
+    prisma.accountingMovement.findMany({
+      where: { date: dateFilter },
+      orderBy: { date: 'desc' },
+    }),
+    prisma.payment.findMany({
+      where: {
+        provider: 'MANUAL_TRANSFER',
+        status: 'APPROVED',
+      },
+      orderBy: { paidAt: 'desc' },
+      select: {
+        id: true,
+        paidAt: true,
+        updatedAt: true,
+        createdAt: true,
+        amount: true,
+        receiptUrl: true,
+        payerName: true,
+        order: {
+          select: {
+            responsibleName: true,
+            total: true,
+            items: {
+              select: {
+                description: true,
+                billableConcept: { select: { code: true } },
+                activity: { select: { name: true } },
+              },
+            },
+          },
+        },
+      },
+    }),
+    prisma.activityParticipant.findMany({
+      where: {
+        receipt: { not: null },
+        receiptDate: dateFilter,
+      },
+      include: {
+        activity: { select: { name: true, price: true } },
+        user: { select: { name: true, lastName: true } },
+        child: { select: { name: true, lastName: true } },
+      },
+    }),
+    prisma.professorPayment.findMany({
+      where: {
+        status: 'PAID',
+        paidAt: dateFilter,
+      },
+      orderBy: { paidAt: 'desc' },
+      include: {
+        professorProfile: {
+          include: { user: { select: { name: true, lastName: true } } },
+        },
+      },
+    }),
+    prisma.activity.findMany({
+      orderBy: { name: 'asc' },
+      select: {
+        id: true,
+        name: true,
+        price: true,
+        participants: {
+          select: {
+            id: true,
+            receipt: true,
+            receiptDate: true,
+            payments: {
+              where: { paidAt: dateFilter },
+              select: { id: true, amount: true },
+            },
+          },
+        },
+      },
+    }),
+  ]);
+
+  const manualIncomePayments = manualPayments
+    .filter((payment) => {
+      const paymentDate = getAccountingPaymentDate(payment);
+      return isDateInRange(paymentDate, periodStart, periodEnd);
+    })
+    .map((payment) => ({
+      id: payment.id,
+      paidAt: payment.paidAt ?? payment.updatedAt ?? payment.createdAt,
+      amount: getAccountingManualPaymentAmount(payment),
+      customerName: payment.payerName ?? payment.order.responsibleName,
+      activities: payment.order.items
+        .filter((item) => item.billableConcept.code === 'ACTIVITY_FEE')
+        .map((item) => item.activity?.name ?? item.description)
+        .filter((name): name is string => Boolean(name)),
+      receiptUrl: payment.receiptUrl,
+    }));
+
+  const reportMpPayments = mpParticipants.map((payment) => ({
+    id: payment.id,
+    receiptDate: payment.receiptDate,
+    amount: payment.activity.price,
+    participantName: payment.child
+      ? parsePersonName(payment.child)
+      : parsePersonName(payment.user),
+    activityName: payment.activity.name,
+    receipt: payment.receipt,
+  }));
+
+  const reportProfessorPayments: ProfessorPaymentLike[] =
+    paidProfessorPayments.map((payment) => ({
+      id: payment.id,
+      paidAt: payment.paidAt,
+      amount: payment.amount,
+      professorName: parsePersonName(payment.professorProfile.user),
+    }));
+
+  const summary = summarizeAccounting({
+    movements,
+    manualPayments: manualIncomePayments,
+    mpPayments: reportMpPayments,
+    professorPayments: reportProfessorPayments,
+  });
+  const entries = buildAccountingReportEntries({
+    movements,
+    manualPayments: manualIncomePayments,
+    mpPayments: reportMpPayments,
+    professorPayments: reportProfessorPayments,
+  });
+
+  const movementIncome = movements
+    .filter((movement) => movement.type === 'INCOME')
+    .reduce((sum, movement) => sum + movement.amount, 0);
+  const movementExpense = movements
+    .filter((movement) => movement.type === 'EXPENSE')
+    .reduce((sum, movement) => sum + movement.amount, 0);
+
+  const activityReports = activities.map((activity) => {
+    const paidParticipants = activity.participants.filter(
+      (participant) =>
+        participant.payments.length > 0 ||
+        (Boolean(participant.receipt) &&
+          isDateInRange(participant.receiptDate, periodStart, periodEnd))
+    );
+    const paidAmount = activity.participants.reduce((sum, participant) => {
+      const registeredPaymentsAmount = participant.payments.reduce(
+        (paymentSum, payment) => paymentSum + payment.amount,
+        0
+      );
+
+      if (registeredPaymentsAmount > 0) return sum + registeredPaymentsAmount;
+      if (
+        participant.receipt &&
+        isDateInRange(participant.receiptDate, periodStart, periodEnd)
+      ) {
+        return sum + activity.price;
+      }
+
+      return sum;
+    }, 0);
+
+    return {
+      activityId: activity.id,
+      activityName: activity.name,
+      totalParticipants: activity.participants.length,
+      paidParticipants: paidParticipants.length,
+      pendingParticipants: Math.max(
+        activity.participants.length - paidParticipants.length,
+        0
+      ),
+      paidAmount,
+    };
+  });
+
+  return {
+    period: {
+      month,
+      year,
+      from: periodStart.toISOString(),
+      to: periodEnd.toISOString(),
+    },
+    balances: {
+      totalIncome: summary.totalIncome,
+      totalExpense: summary.totalExpense,
+      netBalance: summary.netBalance,
+      positiveBalance: Math.max(summary.netBalance, 0),
+      movementIncome,
+      movementExpense,
+      manualIncome: summary.manualIncome,
+      mercadoPagoIncome: summary.mpIncome,
+      professorExpense: summary.professorExpense,
+    },
+    activityReports,
+    categoryTotals: buildAccountingCategoryTotals(entries),
+    entriesCount: entries.length,
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide an auditable "fin de mes" workflow that saves a snapshot of the month (balances, category totals, activities with counts and paid amounts) so accounting can store and review monthly reports.
- Keep the snapshot immutable-per-period (upsert updates if re-run) and available from the accounting dashboard.

### Description
- Add Prisma model `AccountingMonthClose` and SQL migration to persist monthly closes, indexed by year/month and linked to `User` as creator (`prisma/schema.prisma`, migration file).
- Implement snapshot builder `src/lib/accounting-month-close.ts` that aggregates movements, manual and Mercado Pago payments, professor payments, and per-activity participation/payment metrics for a given month.
- Add protected API `GET /api/accounting/month-close` and `POST /api/accounting/month-close` (`src/app/api/accounting/month-close/route.ts`) that returns the latest close and upserts a period close using the snapshot builder.
- Add a client UI `MonthCloseButton` and integrate it in the accounting dashboard (`src/app/accounting/month-close-button.tsx`, updated `src/app/accounting/page.tsx`) to trigger and display the saved snapshot; document routes in `ROUTE_MAP.md`.

### Testing
- Ran `pnpm prisma:generate` successfully to regen the Prisma client.
- Ran `pnpm lint`; linter completed (there are existing Prettier warnings in unrelated files, no new lint failures in the added code).
- Ran `pnpm exec tsc --noEmit`; TypeScript check fails due to pre-existing test type errors in unrelated tests (these errors are not caused by the accounting changes).
- Verified there are no TypeScript errors introduced in the new/modified accounting files by scanning tsc output for those paths (no errors reported for `src/app/accounting`, `src/app/api/accounting/month-close`, `src/lib/accounting-month-close`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd1a8da6483289c08879112a30f3d)