### PR TITLE
Hide agenda schedule from daily title

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -85,10 +85,6 @@ function formatDayTitle(date: Date, todayKey: string): string {
   return weekday;
 }
 
-function formatDistinctSchedules(days: CalendarActivityDay[]): string {
-  return Array.from(new Set(days.map((day) => day.schedule))).join(' / ');
-}
-
 function getGoogleMapsHref(day: CalendarActivityDay): string {
   const query =
     day.latitude != null && day.longitude != null
@@ -585,9 +581,6 @@ export default function ActivityCalendar({
                 const isMainDay = key === activeCompactKey;
                 const title = formatDayTitle(date, todayKey);
                 const hasActivities = activities.length > 0;
-                const scheduleLabel = hasActivities
-                  ? formatDistinctSchedules(activities)
-                  : '';
                 const isExpanded = expandedCompactKeys.has(key);
                 const compactActivityLimit = isMainDay ? 3 : 2;
                 const visibleActivities = isExpanded
@@ -631,12 +624,7 @@ export default function ActivityCalendar({
                         <p
                           className={`${isMainDay ? (compactCalendarSize === 'large' ? 'text-lg' : 'text-base') : 'text-sm'} font-bold text-foreground`}
                         >
-                          <span>{title}</span>
-                          {scheduleLabel && (
-                            <span className="ml-1 whitespace-nowrap">
-                              · {scheduleLabel}
-                            </span>
-                          )}
+                          {title}
                         </p>
                         <p
                           className={`${compactCalendarSize === 'large' ? 'text-sm' : 'text-xs'} font-medium text-muted-foreground`}


### PR DESCRIPTION
### Motivation

- The compact daily calendar was displaying a concatenated schedule next to the bold day title, which should not be shown there to avoid visual clutter and duplication. 
- Each activity already shows its own `schedule` in the activity summary and that information should remain there instead of in the header.

### Description

- Removed the helper `formatDistinctSchedules` and the `scheduleLabel` calculation used to append schedules to the day title. 
- Updated the compact day card rendering in `ActivityCalendar` so the bold header shows only the day title (e.g. `Hoy · domingo`) and no longer appends the aggregated schedule. 
- File touched: `src/app/my-activities/activity-calendar.tsx`.

### Testing

- Ran `pnpm lint`, which completed successfully while reporting existing Prettier warnings in unrelated files. 
- Ran `git diff --check`, which reported no errors.
- Browser/visual tests were not executed in CI because `playwright` is not available in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffd532c9fc8328a2b8aa9af6f05ab6)