### PR TITLE
Remove session times from compact agenda day headers

### DIFF
--- a/src/app/my-activities/activity-calendar.tsx
+++ b/src/app/my-activities/activity-calendar.tsx
@@ -85,10 +85,6 @@ function formatDayTitle(date: Date, todayKey: string): string {
   return weekday;
 }
 
-function formatDistinctSchedules(days: CalendarActivityDay[]): string {
-  return Array.from(new Set(days.map((day) => day.schedule))).join(' / ');
-}
-
 function getGoogleMapsHref(day: CalendarActivityDay): string {
   const query =
     day.latitude != null && day.longitude != null
@@ -585,9 +581,6 @@ export default function ActivityCalendar({
                 const isMainDay = key === activeCompactKey;
                 const title = formatDayTitle(date, todayKey);
                 const hasActivities = activities.length > 0;
-                const scheduleLabel = hasActivities
-                  ? formatDistinctSchedules(activities)
-                  : '';
                 const isExpanded = expandedCompactKeys.has(key);
                 const compactActivityLimit = isMainDay ? 3 : 2;
                 const visibleActivities = isExpanded
@@ -632,11 +625,6 @@ export default function ActivityCalendar({
                           className={`${isMainDay ? (compactCalendarSize === 'large' ? 'text-lg' : 'text-base') : 'text-sm'} font-bold text-foreground`}
                         >
                           <span>{title}</span>
-                          {scheduleLabel && (
-                            <span className="ml-1 whitespace-nowrap">
-                              · {scheduleLabel}
-                            </span>
-                          )}
                         </p>
                         <p
                           className={`${compactCalendarSize === 'large' ? 'text-sm' : 'text-xs'} font-medium text-muted-foreground`}


### PR DESCRIPTION
### Motivation
- Quitar la hora/s de los encabezados diarios en la vista compacta de "Agenda de actividades" para que las sesiones no muestren el horario al lado del día y así dejar esa información solo dentro de cada actividad.

### Description
- Eliminé la agregación y el render del resumen de horarios junto al título del día en la vista compacta de la agenda dentro de `src/app/my-activities/activity-calendar.tsx`.
- Removí la función auxiliar `formatDistinctSchedules` y la variable `scheduleLabel` usada para insertar `· {schedule}` en el encabezado del día.
- Mantengo el horario de cada sesión mostrado en el componente `ActivitySummary` para que los horarios sigan siendo visibles bajo el nombre de la actividad.

### Testing
- Ejecuté `pnpm lint` (Next.js lint) que terminó correctamente; el repo todavía muestra advertencias de Prettier en archivos no relacionados que no fueron tocados por este cambio.
- No se modificaron ni ejecutaron tests unitarios para este ajuste puntual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffddce716083288c18a326c87c03ef)