### PR TITLE
Default activity withdrawal rating to five stars

### DIFF
--- a/src/app/activities/[id]/activity-withdrawal-panel.tsx
+++ b/src/app/activities/[id]/activity-withdrawal-panel.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { Star } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
+const DEFAULT_WITHDRAWAL_RATING = 5;
+
 type Registration = {
   id: string;
   label: string;
@@ -33,7 +35,7 @@ export default function ActivityWithdrawalPanel({
 
   async function withdraw(participantId: string) {
     const note = notes[participantId]?.trim() ?? '';
-    const rating = ratings[participantId] ?? 0;
+    const rating = ratings[participantId] ?? DEFAULT_WITHDRAWAL_RATING;
 
     if (note.length < 50) {
       setError('La nota debe tener al menos 50 caracteres.');
@@ -85,7 +87,7 @@ export default function ActivityWithdrawalPanel({
           const isWritingFeedback = feedbackId === registration.id;
           const isSubmitting = submittingId === registration.id;
           const note = notes[registration.id] ?? '';
-          const rating = ratings[registration.id] ?? 0;
+          const rating = ratings[registration.id] ?? DEFAULT_WITHDRAWAL_RATING;
           const noteCharacters = note.trim().length;
 
           return (

--- a/src/app/activities/__tests__/activity-withdrawal-panel.test.tsx
+++ b/src/app/activities/__tests__/activity-withdrawal-panel.test.tsx
@@ -1,0 +1,102 @@
+import React, { act } from 'react';
+import { createRoot, Root } from 'react-dom/client';
+import ActivityWithdrawalPanel from '../[id]/activity-withdrawal-panel';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const refreshMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    refresh: refreshMock,
+  }),
+}));
+
+describe('ActivityWithdrawalPanel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    refreshMock.mockClear();
+    fetchMock = jest.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+    jest.restoreAllMocks();
+  });
+
+  it('sends five stars by default when the member does not change the rating', async () => {
+    act(() => {
+      root.render(
+        <ActivityWithdrawalPanel
+          activityId="activity_1"
+          registrations={[{ id: 'participant_1', label: 'Participante 1' }]}
+        />
+      );
+    });
+
+    const clickButton = async (label: string) => {
+      const button = Array.from(container.querySelectorAll('button')).find(
+        (candidate) => candidate.textContent === label
+      );
+
+      expect(button).toBeDefined();
+
+      await act(async () => {
+        button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+    };
+
+    await clickButton('Desinscribirme');
+    await clickButton('Confirmar baja');
+
+    const fiveStarButton = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Valorar con 5 estrellas"]'
+    );
+    expect(fiveStarButton?.className).toContain('border-primary');
+
+    const note = container.querySelector<HTMLTextAreaElement>(
+      '#withdrawal-note-participant_1'
+    );
+    expect(note).not.toBeNull();
+
+    await act(async () => {
+      const value =
+        'Me doy de baja porque cambiaron mis horarios laborales y ya no puedo asistir normalmente.';
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        'value'
+      )?.set;
+      setter?.call(note, value);
+      note!.dispatchEvent(new Event('input', { bubbles: true }));
+      note!.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await clickButton('Enviar baja');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/activities/activity_1/withdraw',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          participantId: 'participant_1',
+          note: 'Me doy de baja porque cambiaron mis horarios laborales y ya no puedo asistir normalmente.',
+          rating: 5,
+        }),
+      }
+    );
+    expect(refreshMock).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
### Motivation
- Make the activity withdrawal UX recommend a 5-star rating by default so users who don't change the control will submit a positive default rating.

### Description
- Introduce `DEFAULT_WITHDRAWAL_RATING = 5` and use it as the fallback rating in `src/app/activities/[id]/activity-withdrawal-panel.tsx` where the component previously defaulted to `0`.
- Keep full user control so the rating UI still accepts values `0`–`5` and the user can change the selection before submitting.
- Add a UI regression test `src/app/activities/__tests__/activity-withdrawal-panel.test.tsx` that asserts the 5-star option is preselected and that the form posts `rating: 5` when the user does not change the rating.

### Testing
- Ran the new and existing unit tests with `pnpm test -- src/app/activities/__tests__/activity-withdrawal-panel.test.tsx src/lib/__tests__/activity-withdrawal.test.ts --runInBand` and all tests passed.
- Ran linter with `pnpm lint`, which completed normally (Prettier warnings exist in unrelated files but did not fail the run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c9c32dc88328a9eddb81c7410041)