### PR TITLE
Add 'Pequeños habitantes de la tierra' documentary section and detail page

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -13,6 +13,9 @@ Agents should check this before searching the codebase.
 - `/` → Home page
   - File: `src/app/page.tsx`
 
+- `/documental-pequenos-habitantes` → Documentary detail page for Pequeños habitantes de la tierra
+  - File: `src/app/documental-pequenos-habitantes/page.tsx`
+
 - `/contact` → Contact page
   - File: `src/app/contact/page.tsx`
   - Related component: `src/app/contact/contact-form.tsx`

--- a/src/app/documental-pequenos-habitantes/page.tsx
+++ b/src/app/documental-pequenos-habitantes/page.tsx
@@ -1,0 +1,127 @@
+import Link from 'next/link';
+import { ArrowLeft, ExternalLink } from 'lucide-react';
+
+const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
+const documentaryDriveUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/view?usp=sharing`;
+const documentaryDriveEmbedUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/preview`;
+const documentaryThumbnailUrl = `https://drive.google.com/thumbnail?id=${documentaryDriveFileId}`;
+
+function documentaryPhotoStyle(size: number, gradient: string) {
+  return {
+    backgroundImage: `${gradient}, url('${documentaryThumbnailUrl}&sz=w${size}')`,
+  };
+}
+
+export default function DocumentaryPage() {
+  return (
+    <main className="px-4 py-12">
+      <div className="mx-auto max-w-5xl space-y-10">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-primary transition hover:text-primary/80"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+          Volver al inicio
+        </Link>
+
+        <section className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div className="space-y-5">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+              Documental del Club Hualas
+            </p>
+            <h1 className="font-heading text-4xl font-semibold leading-tight sm:text-5xl">
+              Pequeños habitantes de la tierra
+            </h1>
+            <p className="text-lg leading-8 text-muted-foreground">
+              Un proyecto audiovisual para acercarnos a las pequeñas formas de
+              vida que habitan el territorio y para celebrar la curiosidad de
+              las infancias en contacto con la naturaleza.
+            </p>
+            <a
+              href={documentaryDriveUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+            >
+              Ver trailer en Drive
+              <ExternalLink className="h-4 w-4" aria-hidden="true" />
+            </a>
+          </div>
+
+          <div className="overflow-hidden rounded-xl border bg-black shadow-sm">
+            <iframe
+              title="Trailer de Pequeños habitantes de la tierra"
+              src={documentaryDriveEmbedUrl}
+              className="aspect-video w-full"
+              allow="autoplay; fullscreen"
+              allowFullScreen
+              loading="lazy"
+            />
+          </div>
+        </section>
+
+        <section className="grid gap-6 md:grid-cols-3">
+          <article className="rounded-lg border bg-card p-5 shadow-sm">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+              Naturaleza
+            </p>
+            <h2 className="mt-2 text-xl font-semibold">Mirar de cerca</h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              El documental propone observar el ambiente desde los detalles: los
+              seres pequeños, sus refugios y sus vínculos con el paisaje.
+            </p>
+          </article>
+          <article className="rounded-lg border bg-card p-5 shadow-sm">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+              Infancias
+            </p>
+            <h2 className="mt-2 text-xl font-semibold">Aprender explorando</h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              La experiencia recupera la curiosidad, las preguntas y el asombro
+              como motores para aprender en comunidad.
+            </p>
+          </article>
+          <article className="rounded-lg border bg-card p-5 shadow-sm">
+            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+              Territorio
+            </p>
+            <h2 className="mt-2 text-xl font-semibold">Cuidar lo propio</h2>
+            <p className="mt-3 text-sm leading-6 text-muted-foreground">
+              Una invitación a valorar la Patagonia que habitamos y a construir
+              hábitos de cuidado desde el club.
+            </p>
+          </article>
+        </section>
+
+        <section className="rounded-xl border bg-muted/30 p-5 shadow-sm">
+          <div
+            className="grid gap-3 sm:grid-cols-3"
+            aria-label="Fotos del documental"
+          >
+            <div
+              className="h-40 rounded-lg border bg-cover bg-center"
+              style={documentaryPhotoStyle(
+                700,
+                'linear-gradient(135deg, rgba(34,197,94,0.35), rgba(14,116,144,0.2))'
+              )}
+            />
+            <div
+              className="h-40 rounded-lg border bg-cover bg-center"
+              style={documentaryPhotoStyle(
+                900,
+                'linear-gradient(135deg, rgba(245,158,11,0.28), rgba(22,101,52,0.2))'
+              )}
+            />
+            <div
+              className="h-40 rounded-lg border bg-cover bg-center"
+              style={documentaryPhotoStyle(
+                1100,
+                'linear-gradient(135deg, rgba(59,130,246,0.25), rgba(132,204,22,0.22))'
+              )}
+            />
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,6 +51,17 @@ const activityTypeLabels: Record<'TEMPORARY' | 'ANNUAL', string> = {
 const mapEmbedUrl =
   'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d47685.15!2d-71.3586!3d-40.1569!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9610be21a87b3b29%3A0x3f3d5fc3f3da0c0!2sSan%20Mart%C3%ADn%20de%20los%20Andes%2C%20Neuqu%C3%A9n!5e0!3m2!1ses!2sar!4v1';
 
+const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
+const documentaryDriveUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/view?usp=sharing`;
+const documentaryDriveEmbedUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/preview`;
+const documentaryThumbnailUrl = `https://drive.google.com/thumbnail?id=${documentaryDriveFileId}`;
+
+function documentaryPhotoStyle(size: number, gradient: string) {
+  return {
+    backgroundImage: `${gradient}, url('${documentaryThumbnailUrl}&sz=w${size}')`,
+  };
+}
+
 export default async function Home() {
   let activities: Awaited<
     ReturnType<typeof listActivitiesWithParticipantCount>
@@ -224,6 +235,87 @@ export default async function Home() {
                 </div>
               )}
             </aside>
+          </div>
+        </div>
+      </section>
+
+      {/* Documental */}
+      <section className="border-t bg-gradient-to-br from-primary/10 via-background to-muted/40 px-4 py-14">
+        <div className="mx-auto grid max-w-5xl gap-8 lg:grid-cols-[1.05fr_0.95fr] lg:items-center">
+          <div className="space-y-5">
+            <div>
+              <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+                Proyecto audiovisual
+              </p>
+              <h2 className="mt-2 font-heading text-3xl font-semibold sm:text-4xl">
+                Pequeños habitantes de la tierra
+              </h2>
+            </div>
+            <p className="text-base leading-7 text-muted-foreground">
+              Un documental del Club Hualas que invita a mirar la naturaleza con
+              ojos curiosos: las infancias, el territorio y la vida pequeña que
+              sostiene los paisajes de nuestra Patagonia.
+            </p>
+            <p className="text-base leading-7 text-muted-foreground">
+              La propuesta acompaña el trabajo educativo del club y comparte una
+              experiencia sensible para descubrir, cuidar y valorar el ambiente
+              que habitamos.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/documental-pequenos-habitantes"
+                className="inline-flex rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
+              >
+                Conocer más
+              </Link>
+              <a
+                href={documentaryDriveUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex rounded-md border bg-card px-4 py-2.5 text-sm font-semibold text-foreground transition hover:border-primary hover:text-primary"
+              >
+                Abrir trailer
+              </a>
+            </div>
+          </div>
+
+          <div className="space-y-4">
+            <div className="overflow-hidden rounded-xl border bg-black shadow-sm">
+              <iframe
+                title="Trailer de Pequeños habitantes de la tierra"
+                src={documentaryDriveEmbedUrl}
+                className="aspect-video w-full"
+                allow="autoplay; fullscreen"
+                allowFullScreen
+                loading="lazy"
+              />
+            </div>
+            <div
+              className="grid grid-cols-3 gap-3"
+              aria-label="Fotos del documental"
+            >
+              <div
+                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
+                style={documentaryPhotoStyle(
+                  600,
+                  'linear-gradient(135deg, rgba(34,197,94,0.35), rgba(14,116,144,0.2))'
+                )}
+              />
+              <div
+                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
+                style={documentaryPhotoStyle(
+                  800,
+                  'linear-gradient(135deg, rgba(245,158,11,0.28), rgba(22,101,52,0.2))'
+                )}
+              />
+              <div
+                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
+                style={documentaryPhotoStyle(
+                  1000,
+                  'linear-gradient(135deg, rgba(59,130,246,0.25), rgba(132,204,22,0.22))'
+                )}
+              />
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Mostrar en la página de inicio la información, fotos y el trailer del proyecto audiovisual “Pequeños habitantes de la tierra” y ofrecer un botón “Conocer más” que lleve a una página de detalle.

### Description
- Añadida sección en el home (`src/app/page.tsx`) que centraliza el `documentaryDriveFileId`, muestra un `iframe` con el preview de Drive, texto introductorio, CTA `Conocer más` y una grilla de miniaturas usando la helper `documentaryPhotoStyle`.
- Nueva página pública de detalle `src/app/documental-pequenos-habitantes/page.tsx` con título, descripción, trailer embebido, tarjetas temáticas y galería de fotos, más un enlace para volver al inicio.
- Registrada la nueva ruta en `ROUTE_MAP.md` como `/documental-pequenos-habitantes`.
- No se añadieron dependencias externas; cambios visuales y de markup/estilos siguiendo las clases existentes de Tailwind.

### Testing
- Ejecutado `pnpm lint`; pasó (hubo warnings de Prettier en archivos no relacionados ya presentes en el repo).
- Ejecutado `pnpm exec tsc --noEmit`; falló por errores de tipado preexistentes en `tests/api/pickup-notices.test.ts` no relacionados con estos cambios.
- Levantado el servidor de desarrollo con `pnpm dev` y verificado que la sección aparece en `/` y la página de detalle responde en `/documental-pequenos-habitantes` mediante `curl` comprobaciones locales.
- Capturadas capturas de pantalla de ambas rutas usando Playwright (`npx playwright screenshot ...`) y guardadas en `/tmp/hualas-screenshots/` para revisión visual.
- Nota: la reproducción y las miniaturas dependen de la configuración de acceso del archivo en Google Drive; en este entorno Drive puede requerir permisos públicos para que el `iframe` y las miniaturas funcionen correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ce5547bc83289bb8014d16b50ea6)