### PR TITLE
Embebir video documental en home y mostrar PDF en la página del documental

### DIFF
--- a/src/app/documental-pequenos-habitantes/page.tsx
+++ b/src/app/documental-pequenos-habitantes/page.tsx
@@ -1,16 +1,9 @@
 import Link from 'next/link';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
 
-const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
-const documentaryDriveUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/view?usp=sharing`;
-const documentaryDriveEmbedUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/preview`;
-const documentaryThumbnailUrl = `https://drive.google.com/thumbnail?id=${documentaryDriveFileId}`;
-
-function documentaryPhotoStyle(size: number, gradient: string) {
-  return {
-    backgroundImage: `${gradient}, url('${documentaryThumbnailUrl}&sz=w${size}')`,
-  };
-}
+const documentaryPdfDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
+const documentaryPdfDriveUrl = `https://drive.google.com/file/d/${documentaryPdfDriveFileId}/view?usp=sharing`;
+const documentaryPdfEmbedUrl = `https://drive.google.com/file/d/${documentaryPdfDriveFileId}/preview`;
 
 export default function DocumentaryPage() {
   return (
@@ -24,8 +17,8 @@ export default function DocumentaryPage() {
           Volver al inicio
         </Link>
 
-        <section className="grid gap-8 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
-          <div className="space-y-5">
+        <section className="space-y-6">
+          <div className="max-w-3xl space-y-5">
             <p className="text-sm font-semibold uppercase tracking-wide text-primary">
               Documental del Club Hualas
             </p>
@@ -33,91 +26,28 @@ export default function DocumentaryPage() {
               Pequeños habitantes de la tierra
             </h1>
             <p className="text-lg leading-8 text-muted-foreground">
-              Un proyecto audiovisual para acercarnos a las pequeñas formas de
-              vida que habitan el territorio y para celebrar la curiosidad de
-              las infancias en contacto con la naturaleza.
+              En esta página podés consultar el PDF con más información sobre el
+              proyecto audiovisual, su mirada educativa y la propuesta para
+              acercarnos a las pequeñas formas de vida que habitan el
+              territorio.
             </p>
             <a
-              href={documentaryDriveUrl}
+              href={documentaryPdfDriveUrl}
               target="_blank"
               rel="noreferrer"
               className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
             >
-              Ver trailer en Drive
+              Abrir PDF en otra pestaña
               <ExternalLink className="h-4 w-4" aria-hidden="true" />
             </a>
           </div>
 
-          <div className="overflow-hidden rounded-xl border bg-black shadow-sm">
+          <div className="overflow-hidden rounded-xl border bg-card shadow-sm">
             <iframe
-              title="Trailer de Pequeños habitantes de la tierra"
-              src={documentaryDriveEmbedUrl}
-              className="aspect-video w-full"
-              allow="autoplay; fullscreen"
-              allowFullScreen
+              title="PDF de Pequeños habitantes de la tierra"
+              src={documentaryPdfEmbedUrl}
+              className="h-[75vh] min-h-[520px] w-full"
               loading="lazy"
-            />
-          </div>
-        </section>
-
-        <section className="grid gap-6 md:grid-cols-3">
-          <article className="rounded-lg border bg-card p-5 shadow-sm">
-            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
-              Naturaleza
-            </p>
-            <h2 className="mt-2 text-xl font-semibold">Mirar de cerca</h2>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              El documental propone observar el ambiente desde los detalles: los
-              seres pequeños, sus refugios y sus vínculos con el paisaje.
-            </p>
-          </article>
-          <article className="rounded-lg border bg-card p-5 shadow-sm">
-            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
-              Infancias
-            </p>
-            <h2 className="mt-2 text-xl font-semibold">Aprender explorando</h2>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              La experiencia recupera la curiosidad, las preguntas y el asombro
-              como motores para aprender en comunidad.
-            </p>
-          </article>
-          <article className="rounded-lg border bg-card p-5 shadow-sm">
-            <p className="text-sm font-semibold uppercase tracking-wide text-primary">
-              Territorio
-            </p>
-            <h2 className="mt-2 text-xl font-semibold">Cuidar lo propio</h2>
-            <p className="mt-3 text-sm leading-6 text-muted-foreground">
-              Una invitación a valorar la Patagonia que habitamos y a construir
-              hábitos de cuidado desde el club.
-            </p>
-          </article>
-        </section>
-
-        <section className="rounded-xl border bg-muted/30 p-5 shadow-sm">
-          <div
-            className="grid gap-3 sm:grid-cols-3"
-            aria-label="Fotos del documental"
-          >
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                700,
-                'linear-gradient(135deg, rgba(34,197,94,0.35), rgba(14,116,144,0.2))'
-              )}
-            />
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                900,
-                'linear-gradient(135deg, rgba(245,158,11,0.28), rgba(22,101,52,0.2))'
-              )}
-            />
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                1100,
-                'linear-gradient(135deg, rgba(59,130,246,0.25), rgba(132,204,22,0.22))'
-              )}
             />
           </div>
         </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,16 +51,8 @@ const activityTypeLabels: Record<'TEMPORARY' | 'ANNUAL', string> = {
 const mapEmbedUrl =
   'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d47685.15!2d-71.3586!3d-40.1569!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x9610be21a87b3b29%3A0x3f3d5fc3f3da0c0!2sSan%20Mart%C3%ADn%20de%20los%20Andes%2C%20Neuqu%C3%A9n!5e0!3m2!1ses!2sar!4v1';
 
-const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
-const documentaryDriveUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/view?usp=sharing`;
-const documentaryDriveEmbedUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/preview`;
-const documentaryThumbnailUrl = `https://drive.google.com/thumbnail?id=${documentaryDriveFileId}`;
-
-function documentaryPhotoStyle(size: number, gradient: string) {
-  return {
-    backgroundImage: `${gradient}, url('${documentaryThumbnailUrl}&sz=w${size}')`,
-  };
-}
+const documentaryYoutubeEmbedUrl =
+  'https://www.youtube.com/embed/r2-qBpH6FHg?si=V1S3P8eb24fC6sBV';
 
 export default async function Home() {
   let activities: Awaited<
@@ -266,56 +258,20 @@ export default async function Home() {
                 href="/documental-pequenos-habitantes"
                 className="inline-flex rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
               >
-                Conocer más
+                Ver más
               </Link>
-              <a
-                href={documentaryDriveUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex rounded-md border bg-card px-4 py-2.5 text-sm font-semibold text-foreground transition hover:border-primary hover:text-primary"
-              >
-                Abrir trailer
-              </a>
             </div>
           </div>
 
-          <div className="space-y-4">
-            <div className="overflow-hidden rounded-xl border bg-black shadow-sm">
-              <iframe
-                title="Trailer de Pequeños habitantes de la tierra"
-                src={documentaryDriveEmbedUrl}
-                className="aspect-video w-full"
-                allow="autoplay; fullscreen"
-                allowFullScreen
-                loading="lazy"
-              />
-            </div>
-            <div
-              className="grid grid-cols-3 gap-3"
-              aria-label="Fotos del documental"
-            >
-              <div
-                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
-                style={documentaryPhotoStyle(
-                  600,
-                  'linear-gradient(135deg, rgba(34,197,94,0.35), rgba(14,116,144,0.2))'
-                )}
-              />
-              <div
-                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
-                style={documentaryPhotoStyle(
-                  800,
-                  'linear-gradient(135deg, rgba(245,158,11,0.28), rgba(22,101,52,0.2))'
-                )}
-              />
-              <div
-                className="h-24 rounded-lg border bg-cover bg-center shadow-sm sm:h-28"
-                style={documentaryPhotoStyle(
-                  1000,
-                  'linear-gradient(135deg, rgba(59,130,246,0.25), rgba(132,204,22,0.22))'
-                )}
-              />
-            </div>
+          <div className="overflow-hidden rounded-xl border bg-black shadow-sm">
+            <iframe
+              title="Video de Pequeños habitantes de la tierra"
+              src={documentaryYoutubeEmbedUrl}
+              className="aspect-video w-full"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowFullScreen
+              loading="lazy"
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Mostrar en la portada el video de YouTube solicitado y desde el botón “Ver más” llevar a la página dedicada donde el PDF con información del documental se abre embebido.
- Evitar reproducir el preview en Drive en el home y centralizar la lectura del PDF en la página del documental para una experiencia más clara.

### Description
- Replaced the Drive preview on the home with a YouTube iframe using `https://www.youtube.com/embed/r2-qBpH6FHg?si=V1S3P8eb24fC6sBV` and updated the home CTA label to `Ver más` in `src/app/page.tsx`.
- Updated `src/app/documental-pequenos-habitantes/page.tsx` to embed the Drive PDF via its `/preview` URL and added an external-open button that points to the Drive `view` link.
- Removed unused Drive thumbnail/photo helper usage from the documentary detail page and adjusted layout classes for the embedded PDF viewer.
- Files touched: `src/app/page.tsx`, `src/app/documental-pequenos-habitantes/page.tsx`.

### Testing
- Ran `pnpm lint` which completed (repository still shows unrelated Prettier warnings in other files but no new lint errors from the changes).
- Ran `git diff --check` and standard diff checks which passed for these edits.
- Launched the dev server with `pnpm dev` and verified the rendered pages via `curl` requests that confirmed the home contains the YouTube embed and the documentary page contains the Drive PDF `preview` and the external-open button.
- Attempted an automated screenshot with Playwright (`npx playwright screenshot ...`) but browser install failed (`npx playwright install chromium`) due to network/socket errors in the environment, so the headful screenshot step failed.
- Unresolved risk: the PDF/Drive file used is the ID already present in the repo; if a different PDF should be used please provide the new Drive file ID or URL to update the embed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d37caf088328b628b36c39e3694c)