### PR TITLE
Add documentary PDF book viewer with server proxy and dependencies (pdfjs-dist, undici)

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -28,6 +28,9 @@ Agents should check this before searching the codebase.
   - File: `src/app/android/page.tsx`
   - Static APK: `public/downloads/hualas-mobile.apk`
 
+- `GET /api/documental-pequenos-habitantes/pdf` → proxy cached del PDF del documental para el visor tipo libro
+  - File: `src/app/api/documental-pequenos-habitantes/pdf/route.ts`
+
 ### Auth
 
 - `/login` → Login page

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "mercadopago": "^2.0.0",
     "next": "14.2.5",
     "next-auth": "^4.24.7",
+    "pdfjs-dist": "4.10.38",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
@@ -40,6 +41,7 @@
     "socket.io-client": "^4.7.5",
     "tailwind-merge": "^2.2.0",
     "tailwindcss-animate": "^1.0.7",
+    "undici": "7.16.0",
     "web-push": "^3.6.7",
     "xlsx": "^0.18.5",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ dependencies:
   next-auth:
     specifier: ^4.24.7
     version: 4.24.14(next@14.2.5)(react-dom@18.3.1)(react@18.3.1)
+  pdfjs-dist:
+    specifier: 4.10.38
+    version: 4.10.38
   react:
     specifier: ^18.2.0
     version: 18.3.1
@@ -62,6 +65,9 @@ dependencies:
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.19)
+  undici:
+    specifier: 7.16.0
+    version: 7.16.0
   web-push:
     specifier: ^3.6.7
     version: 3.6.7
@@ -922,6 +928,124 @@ packages:
       - encoding
       - supports-color
     dev: false
+
+  /@napi-rs/canvas-android-arm64@0.1.100:
+    resolution: {integrity: sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-darwin-arm64@0.1.100:
+    resolution: {integrity: sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-darwin-x64@0.1.100:
+    resolution: {integrity: sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm-gnueabihf@0.1.100:
+    resolution: {integrity: sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm64-gnu@0.1.100:
+    resolution: {integrity: sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-arm64-musl@0.1.100:
+    resolution: {integrity: sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-riscv64-gnu@0.1.100:
+    resolution: {integrity: sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-x64-gnu@0.1.100:
+    resolution: {integrity: sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-linux-x64-musl@0.1.100:
+    resolution: {integrity: sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-win32-arm64-msvc@0.1.100:
+    resolution: {integrity: sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas-win32-x64-msvc@0.1.100:
+    resolution: {integrity: sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@napi-rs/canvas@0.1.100:
+    resolution: {integrity: sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==}
+    engines: {node: '>= 10'}
+    requiresBuild: true
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-arm64': 0.1.100
+      '@napi-rs/canvas-darwin-x64': 0.1.100
+      '@napi-rs/canvas-linux-arm-gnueabihf': 0.1.100
+      '@napi-rs/canvas-linux-arm64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-arm64-musl': 0.1.100
+      '@napi-rs/canvas-linux-riscv64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-gnu': 0.1.100
+      '@napi-rs/canvas-linux-x64-musl': 0.1.100
+      '@napi-rs/canvas-win32-arm64-msvc': 0.1.100
+      '@napi-rs/canvas-win32-x64-msvc': 0.1.100
+    dev: false
+    optional: true
 
   /@napi-rs/wasm-runtime@0.2.12:
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -5033,6 +5157,13 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pdfjs-dist@4.10.38:
+    resolution: {integrity: sha512-/Y3fcFrXEAsMjJXeL9J8+ZG9U01LbuWaYypvDW2ycW1jL269L3js3DVBjDJ0Up9Np1uqDXsDrRihHANhZOlwdQ==}
+    engines: {node: '>=20'}
+    optionalDependencies:
+      '@napi-rs/canvas': 0.1.100
+    dev: false
+
   /performance-now@2.1.0:
     resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
     requiresBuild: true
@@ -6172,6 +6303,11 @@ packages:
   /undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+    dev: false
+
+  /undici@7.16.0:
+    resolution: {integrity: sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==}
+    engines: {node: '>=20.18.1'}
     dev: false
 
   /unrs-resolver@1.11.1:

--- a/src/app/api/documental-pequenos-habitantes/pdf/route.ts
+++ b/src/app/api/documental-pequenos-habitantes/pdf/route.ts
@@ -1,0 +1,42 @@
+import { ProxyAgent, type Dispatcher } from 'undici';
+
+export const runtime = 'nodejs';
+
+const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
+const documentaryDriveDownloadUrl = `https://drive.google.com/uc?export=download&id=${documentaryDriveFileId}`;
+
+const proxyUrl = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
+const proxyDispatcher = proxyUrl ? new ProxyAgent(proxyUrl) : undefined;
+
+type ProxiedRequestInit = RequestInit & {
+  dispatcher?: Dispatcher;
+};
+
+export async function GET() {
+  try {
+    const requestInit: ProxiedRequestInit = {
+      cache: 'no-store',
+      dispatcher: proxyDispatcher,
+    };
+    const driveResponse = await fetch(documentaryDriveDownloadUrl, requestInit);
+
+    if (!driveResponse.ok || !driveResponse.body) {
+      return Response.json(
+        { error: 'No se pudo cargar el PDF del documental.' },
+        { status: 502 }
+      );
+    }
+
+    return new Response(driveResponse.body, {
+      headers: {
+        'Content-Type': 'application/pdf',
+        'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      },
+    });
+  } catch {
+    return Response.json(
+      { error: 'No se pudo cargar el PDF del documental.' },
+      { status: 502 }
+    );
+  }
+}

--- a/src/app/documental-pequenos-habitantes/documentary-book-viewer.tsx
+++ b/src/app/documental-pequenos-habitantes/documentary-book-viewer.tsx
@@ -1,0 +1,317 @@
+'use client';
+
+import {
+  GlobalWorkerOptions,
+  getDocument,
+  type PDFDocumentProxy,
+} from 'pdfjs-dist';
+import {
+  UIEvent,
+  WheelEvent,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+GlobalWorkerOptions.workerSrc = new URL(
+  'pdfjs-dist/build/pdf.worker.min.mjs',
+  import.meta.url
+).toString();
+
+const pageGap = 28;
+const pageWidth = 360;
+
+type DocumentaryBookViewerProps = {
+  pdfUrl: string;
+};
+
+type PdfPageCanvasProps = {
+  pdf: PDFDocumentProxy;
+  pageNumber: number;
+};
+
+type PdfLoadState =
+  | { status: 'loading'; pdf: null; pageNumbers: number[]; error: null }
+  | {
+      status: 'ready';
+      pdf: PDFDocumentProxy;
+      pageNumbers: number[];
+      error: null;
+    }
+  | { status: 'error'; pdf: null; pageNumbers: number[]; error: string };
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function PdfPageCanvas({ pdf, pageNumber }: PdfPageCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [isRendering, setIsRendering] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    let renderTask: ReturnType<
+      Awaited<ReturnType<typeof pdf.getPage>>['render']
+    > | null = null;
+
+    setIsRendering(true);
+
+    pdf.getPage(pageNumber).then((page) => {
+      if (cancelled) {
+        return;
+      }
+
+      const canvas = canvasRef.current;
+      const context = canvas?.getContext('2d');
+
+      if (!canvas || !context) {
+        return;
+      }
+
+      const viewport = page.getViewport({ scale: 1.9 });
+      const outputScale = window.devicePixelRatio || 1;
+
+      canvas.width = Math.floor(viewport.width * outputScale);
+      canvas.height = Math.floor(viewport.height * outputScale);
+
+      renderTask = page.render({
+        canvasContext: context,
+        transform:
+          outputScale !== 1
+            ? [outputScale, 0, 0, outputScale, 0, 0]
+            : undefined,
+        viewport,
+      });
+
+      renderTask.promise.finally(() => {
+        if (!cancelled) {
+          setIsRendering(false);
+        }
+      });
+    });
+
+    return () => {
+      cancelled = true;
+      renderTask?.cancel();
+    };
+  }, [pageNumber, pdf]);
+
+  return (
+    <div className="relative aspect-[595/842] w-full overflow-hidden rounded-r-xl rounded-l-sm border bg-white">
+      {isRendering ? (
+        <div className="absolute inset-0 grid place-items-center text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          Cargando página
+        </div>
+      ) : null}
+      <canvas
+        ref={canvasRef}
+        className="relative h-full w-full object-contain"
+        aria-label={`Página ${pageNumber} del documental Pequeños habitantes de la tierra`}
+      />
+    </div>
+  );
+}
+
+export function DocumentaryBookViewer({ pdfUrl }: DocumentaryBookViewerProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [loadState, setLoadState] = useState<PdfLoadState>({
+    status: 'loading',
+    pdf: null,
+    pageNumbers: [],
+    error: null,
+  });
+  const [scrollState, setScrollState] = useState({
+    left: 0,
+    viewportWidth: 1,
+    scrollWidth: 1,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadingTask = getDocument({
+      url: pdfUrl,
+      disableAutoFetch: true,
+      disableRange: true,
+      disableStream: true,
+      withCredentials: false,
+    });
+
+    setLoadState({
+      status: 'loading',
+      pdf: null,
+      pageNumbers: [],
+      error: null,
+    });
+
+    loadingTask.promise
+      .then((pdf) => {
+        if (cancelled) {
+          pdf.destroy();
+          return;
+        }
+
+        setLoadState({
+          status: 'ready',
+          pdf,
+          pageNumbers: Array.from(
+            { length: pdf.numPages },
+            (_, index) => index + 1
+          ),
+          error: null,
+        });
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setLoadState({
+            status: 'error',
+            pdf: null,
+            pageNumbers: [],
+            error:
+              'No pudimos cargar el PDF desde Drive. Probá abrirlo desde el botón superior.',
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+      loadingTask.destroy();
+    };
+  }, [pdfUrl]);
+
+  const pageNumbers = loadState.pageNumbers;
+  const progressLabel = useMemo(() => {
+    if (loadState.status === 'loading') {
+      return 'Cargando páginas';
+    }
+
+    if (pageNumbers.length === 0) {
+      return 'Sin páginas disponibles';
+    }
+
+    const maxScroll = Math.max(
+      scrollState.scrollWidth - scrollState.viewportWidth,
+      1
+    );
+    const estimatedPage = clamp(
+      Math.round((scrollState.left / maxScroll) * (pageNumbers.length - 1)) + 1,
+      1,
+      pageNumbers.length
+    );
+
+    return `Página ${estimatedPage} de ${pageNumbers.length}`;
+  }, [
+    loadState.status,
+    pageNumbers.length,
+    scrollState.left,
+    scrollState.scrollWidth,
+    scrollState.viewportWidth,
+  ]);
+
+  function updateScrollState(target: HTMLDivElement) {
+    setScrollState({
+      left: target.scrollLeft,
+      viewportWidth: Math.max(target.clientWidth, 1),
+      scrollWidth: Math.max(target.scrollWidth, 1),
+    });
+  }
+
+  function handleScroll(event: UIEvent<HTMLDivElement>) {
+    updateScrollState(event.currentTarget);
+  }
+
+  function handleWheel(event: WheelEvent<HTMLDivElement>) {
+    const target = scrollRef.current;
+
+    if (!target || Math.abs(event.deltaX) > Math.abs(event.deltaY)) {
+      return;
+    }
+
+    event.preventDefault();
+    target.scrollBy({ left: event.deltaY, behavior: 'smooth' });
+  }
+
+  return (
+    <section className="rounded-[2rem] border bg-gradient-to-br from-amber-50 via-stone-50 to-emerald-50 p-4 shadow-sm sm:p-6">
+      <div className="mb-5 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="text-sm font-semibold uppercase tracking-wide text-primary">
+            Libro visual
+          </p>
+          <h2 className="mt-2 font-heading text-3xl font-semibold">
+            Recorré las páginas del documental
+          </h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-muted-foreground">
+            Deslizá hacia el costado —o usá la rueda del mouse— para pasar las
+            hojas con un efecto de libro.
+          </p>
+        </div>
+        <p className="text-sm font-semibold text-primary" aria-live="polite">
+          {progressLabel}
+        </p>
+      </div>
+
+      {loadState.status === 'error' ? (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+          {loadState.error}
+        </div>
+      ) : null}
+
+      <div
+        ref={scrollRef}
+        className="book-scroll -mx-4 flex min-h-[32rem] snap-x snap-mandatory gap-7 overflow-x-auto px-4 pb-8 pt-3 [perspective:1200px] sm:-mx-6 sm:px-6"
+        onScroll={handleScroll}
+        onWheel={handleWheel}
+        aria-label="Páginas del documental Pequeños habitantes de la tierra"
+      >
+        {loadState.status === 'loading'
+          ? Array.from({ length: 3 }, (_, index) => (
+              <article
+                key={index}
+                className="relative w-[78vw] max-w-[360px] shrink-0 snap-center rounded-r-2xl rounded-l-md bg-white p-2 shadow-xl sm:w-[360px]"
+              >
+                <div className="aspect-[595/842] animate-pulse rounded-r-xl rounded-l-sm border bg-muted" />
+                <p className="mt-3 text-center text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                  Cargando
+                </p>
+              </article>
+            ))
+          : null}
+
+        {loadState.status === 'ready'
+          ? pageNumbers.map((pageNumber, index) => {
+              const pageCenter = index * (pageWidth + pageGap) + pageWidth / 2;
+              const viewportCenter =
+                scrollState.left + scrollState.viewportWidth / 2;
+              const distance =
+                (pageCenter - viewportCenter) / scrollState.viewportWidth;
+              const rotation = clamp(distance * -54, -42, 42);
+              const lift = 1 - Math.min(Math.abs(distance) * 0.13, 0.18);
+              const shadowStrength = 18 + Math.min(Math.abs(distance) * 34, 28);
+
+              return (
+                <article
+                  key={pageNumber}
+                  className="book-page relative w-[78vw] max-w-[360px] shrink-0 snap-center rounded-r-2xl rounded-l-md bg-white p-2 shadow-xl transition-transform duration-300 ease-out [transform-style:preserve-3d] sm:w-[360px]"
+                  style={{
+                    transform: `rotateY(${rotation}deg) scale(${lift})`,
+                    transformOrigin:
+                      rotation > 0 ? 'left center' : 'right center',
+                    boxShadow: `0 ${shadowStrength}px ${shadowStrength + 18}px rgba(41, 37, 36, 0.22)`,
+                  }}
+                  aria-label={`Página ${pageNumber} de ${pageNumbers.length}`}
+                >
+                  <span className="pointer-events-none absolute inset-y-3 left-3 z-10 w-5 rounded-full bg-gradient-to-r from-stone-900/20 to-transparent" />
+                  <span className="pointer-events-none absolute inset-y-2 right-2 z-10 w-8 rounded-r-2xl bg-gradient-to-l from-amber-200/35 to-transparent" />
+                  <PdfPageCanvas pdf={loadState.pdf} pageNumber={pageNumber} />
+                  <p className="mt-3 text-center text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                    Página {pageNumber}
+                  </p>
+                </article>
+              );
+            })
+          : null}
+      </div>
+    </section>
+  );
+}

--- a/src/app/documental-pequenos-habitantes/page.tsx
+++ b/src/app/documental-pequenos-habitantes/page.tsx
@@ -1,16 +1,11 @@
 import Link from 'next/link';
 import { ArrowLeft, ExternalLink } from 'lucide-react';
+import { DocumentaryBookViewer } from './documentary-book-viewer';
 
 const documentaryDriveFileId = '1xEVM3yeRTx1fCKqcqwGGn_pEFXWIBHIp';
 const documentaryDriveUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/view?usp=sharing`;
 const documentaryDriveEmbedUrl = `https://drive.google.com/file/d/${documentaryDriveFileId}/preview`;
-const documentaryThumbnailUrl = `https://drive.google.com/thumbnail?id=${documentaryDriveFileId}`;
-
-function documentaryPhotoStyle(size: number, gradient: string) {
-  return {
-    backgroundImage: `${gradient}, url('${documentaryThumbnailUrl}&sz=w${size}')`,
-  };
-}
+const documentaryPdfProxyUrl = '/api/documental-pequenos-habitantes/pdf';
 
 export default function DocumentaryPage() {
   return (
@@ -43,7 +38,7 @@ export default function DocumentaryPage() {
               rel="noreferrer"
               className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2.5 text-sm font-semibold text-primary-foreground transition hover:bg-primary/90"
             >
-              Ver trailer en Drive
+              Abrir PDF en Drive
               <ExternalLink className="h-4 w-4" aria-hidden="true" />
             </a>
           </div>
@@ -93,34 +88,7 @@ export default function DocumentaryPage() {
           </article>
         </section>
 
-        <section className="rounded-xl border bg-muted/30 p-5 shadow-sm">
-          <div
-            className="grid gap-3 sm:grid-cols-3"
-            aria-label="Fotos del documental"
-          >
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                700,
-                'linear-gradient(135deg, rgba(34,197,94,0.35), rgba(14,116,144,0.2))'
-              )}
-            />
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                900,
-                'linear-gradient(135deg, rgba(245,158,11,0.28), rgba(22,101,52,0.2))'
-              )}
-            />
-            <div
-              className="h-40 rounded-lg border bg-cover bg-center"
-              style={documentaryPhotoStyle(
-                1100,
-                'linear-gradient(135deg, rgba(59,130,246,0.25), rgba(132,204,22,0.22))'
-              )}
-            />
-          </div>
-        </section>
+        <DocumentaryBookViewer pdfUrl={documentaryPdfProxyUrl} />
       </div>
     </main>
   );


### PR DESCRIPTION
### Motivation

- Provide an interactive, book-like PDF viewer for the documentary so users can flip through pages in-browser.  
- Serve the documentary PDF through a server-side proxy to avoid CORS/Drive embed limitations and enable caching.  
- Add required libraries to render PDFs on the client and to perform proxied server requests.

### Description

- Added a server API route `src/app/api/documental-pequenos-habitantes/pdf/route.ts` that proxies and streams the Drive PDF using `undici`'s `ProxyAgent`, sets `runtime = 'nodejs'`, and returns `Content-Type: application/pdf` with caching headers.  
- Implemented a client component `src/app/documental-pequenos-habitantes/documentary-book-viewer.tsx` that uses `pdfjs-dist` to load and render PDF pages into canvases and provides horizontal scroll / wheel support with a 3D book-like visual effect and progress label.  
- Updated the documentary page `src/app/documental-pequenos-habitantes/page.tsx` to mount the new `DocumentaryBookViewer` and point it at the proxy URL `'/api/documental-pequenos-habitantes/pdf'`, removed the old thumbnail helper, and adjusted the CTA text.  
- Updated `package.json` and the lockfile to add `pdfjs-dist` and `undici`, and documented the new API route in `ROUTE_MAP.md`.

### Testing

- Ran the project's test suite with `npm test` (Jest) and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04e99f02d48328a2f9912574847794)