### PR TITLE
Allow professors to update banking data

### DIFF
--- a/ROUTE_MAP.md
+++ b/ROUTE_MAP.md
@@ -150,8 +150,9 @@ Agents should check this before searching the codebase.
   - File: `src/app/accounting/reports/page.tsx`
   - Related client: `src/app/accounting/reports/reports-client.tsx`
 
-- `/my-payments` → Professor self-view of banking data and payment history (read-only)
+- `/my-payments` → Professor self-view of banking data, editable own banking tab, invoices, and payment history
   - File: `src/app/my-payments/page.tsx`
+  - Related client: `src/app/my-payments/my-payments-client.tsx`
 
 ### Admin
 
@@ -385,7 +386,7 @@ Agents should check this before searching the codebase.
 - `GET /api/professors/[id]/profile` → get professor banking/salary profile
   - File: `src/app/api/professors/[id]/profile/route.ts`
 
-- `PUT /api/professors/[id]/profile` → upsert professor profile (COUNTER/ADMIN only)
+- `PUT /api/professors/[id]/profile` → upsert professor profile (COUNTER/ADMIN can edit salary/banking/notes; professor self can edit own banking data)
   - File: `src/app/api/professors/[id]/profile/route.ts`
 
 - `GET /api/professors/[id]/payments` → list professor payments

--- a/src/app/api/professors/[id]/profile/route.ts
+++ b/src/app/api/professors/[id]/profile/route.ts
@@ -5,14 +5,26 @@ import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { isAccountingRole } from '@/lib/accounting';
 
-const updateSchema = z.object({
-  monthlySalary: z.number().int().min(0),
+const bankingDataSchema = z.object({
   bankName: z.string().max(100).optional().nullable(),
   cbu: z.string().max(22).optional().nullable(),
   alias: z.string().max(50).optional().nullable(),
   cuit: z.string().max(13).optional().nullable(),
+});
+
+const accountingUpdateSchema = bankingDataSchema.extend({
+  monthlySalary: z.number().int().min(0),
   notes: z.string().max(500).optional().nullable(),
 });
+
+function cleanBankingData(data: z.infer<typeof bankingDataSchema>) {
+  return {
+    bankName: data.bankName?.trim() || null,
+    cbu: data.cbu?.trim() || null,
+    alias: data.alias?.trim() || null,
+    cuit: data.cuit?.trim() || null,
+  };
+}
 
 export async function GET(
   _req: Request,
@@ -20,7 +32,8 @@ export async function GET(
 ) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as any)?.id;
-  const role = (session?.user as any)?.role;
+  const role =
+    (session?.user as any)?.activeRole ?? (session?.user as any)?.role;
   if (!userId)
     return NextResponse.json({ error: 'No autorizado' }, { status: 401 });
 
@@ -52,19 +65,16 @@ export async function PUT(
 ) {
   const session = await getServerSession(authOptions);
   const userId = (session?.user as any)?.id;
-  const role = (session?.user as any)?.role;
-  if (!userId || !isAccountingRole(role)) {
+  const role =
+    (session?.user as any)?.activeRole ?? (session?.user as any)?.role;
+  const isProfessorSelf = role === 'PROFESSOR' && userId === params.id;
+  const isAccounting = isAccountingRole(role);
+
+  if (!userId || (!isAccounting && !isProfessorSelf)) {
     return NextResponse.json({ error: 'Sin permiso' }, { status: 403 });
   }
 
   const body = await req.json().catch(() => null);
-  const parsed = updateSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: parsed.error.flatten() },
-      { status: 400 }
-    );
-  }
 
   const professor = await prisma.user.findFirst({
     where: {
@@ -80,10 +90,49 @@ export async function PUT(
     );
   }
 
+  if (isAccounting) {
+    const parsed = accountingUpdateSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.flatten() },
+        { status: 400 }
+      );
+    }
+
+    const bankingData = cleanBankingData(parsed.data);
+    const profile = await prisma.professorProfile.upsert({
+      where: { userId: params.id },
+      create: {
+        userId: params.id,
+        ...bankingData,
+        monthlySalary: parsed.data.monthlySalary,
+        notes: parsed.data.notes?.trim() || null,
+      },
+      update: {
+        ...bankingData,
+        monthlySalary: parsed.data.monthlySalary,
+        notes: parsed.data.notes?.trim() || null,
+      },
+    });
+
+    return NextResponse.json({ profile });
+  }
+
+  const parsed = bankingDataSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.flatten() },
+      { status: 400 }
+    );
+  }
+
   const profile = await prisma.professorProfile.upsert({
     where: { userId: params.id },
-    create: { userId: params.id, ...parsed.data },
-    update: parsed.data,
+    create: {
+      userId: params.id,
+      ...cleanBankingData(parsed.data),
+    },
+    update: cleanBankingData(parsed.data),
   });
 
   return NextResponse.json({ profile });

--- a/src/app/my-payments/my-payments-client.tsx
+++ b/src/app/my-payments/my-payments-client.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { useState, type FormEvent, type ReactNode } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { formatAmount } from '@/lib/accounting';
+
+const MONTHS = [
+  'Enero',
+  'Febrero',
+  'Marzo',
+  'Abril',
+  'Mayo',
+  'Junio',
+  'Julio',
+  'Agosto',
+  'Septiembre',
+  'Octubre',
+  'Noviembre',
+  'Diciembre',
+];
+
+type Payment = {
+  id: string;
+  periodMonth: number;
+  periodYear: number;
+  amount: number;
+  status: string;
+  paidAt: string | null;
+  notes: string | null;
+};
+
+type ProfessorProfile = {
+  monthlySalary: number;
+  bankName: string | null;
+  cbu: string | null;
+  alias: string | null;
+  cuit: string | null;
+  notes: string | null;
+  payments: Payment[];
+};
+
+type Props = {
+  professorId: string;
+  initialProfile: ProfessorProfile | null;
+};
+
+type Tab = 'history' | 'banking';
+
+export default function MyPaymentsClient({
+  professorId,
+  initialProfile,
+}: Props) {
+  const router = useRouter();
+  const [activeTab, setActiveTab] = useState<Tab>('history');
+  const [profile, setProfile] = useState(initialProfile);
+  const [bankName, setBankName] = useState(initialProfile?.bankName ?? '');
+  const [cbu, setCbu] = useState(initialProfile?.cbu ?? '');
+  const [alias, setAlias] = useState(initialProfile?.alias ?? '');
+  const [cuit, setCuit] = useState(initialProfile?.cuit ?? '');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+
+  const payments = profile?.payments ?? [];
+
+  const saveBankingData = async (e: FormEvent) => {
+    e.preventDefault();
+    setSaving(true);
+    setError('');
+    setSuccess('');
+
+    try {
+      const res = await fetch(`/api/professors/${professorId}/profile`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          bankName: bankName.trim() || null,
+          cbu: cbu.trim() || null,
+          alias: alias.trim() || null,
+          cuit: cuit.trim() || null,
+        }),
+      });
+      const body = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(body?.error ?? 'No se pudo guardar');
+
+      setProfile((current) => ({
+        monthlySalary:
+          current?.monthlySalary ?? body.profile.monthlySalary ?? 0,
+        notes: current?.notes ?? body.profile.notes ?? null,
+        payments: current?.payments ?? [],
+        bankName: body.profile.bankName,
+        cbu: body.profile.cbu,
+        alias: body.profile.alias,
+        cuit: body.profile.cuit,
+      }));
+      setSuccess(
+        'Tus datos bancarios fueron guardados. Contaduría ya puede verlos en tu perfil.'
+      );
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Error al guardar');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section className="space-y-5">
+      <div
+        className="flex flex-wrap gap-2 rounded-full border bg-muted/20 p-1"
+        role="tablist"
+        aria-label="Secciones de mis pagos"
+      >
+        <TabButton
+          active={activeTab === 'history'}
+          onClick={() => setActiveTab('history')}
+        >
+          Historial de pagos
+        </TabButton>
+        <TabButton
+          active={activeTab === 'banking'}
+          onClick={() => setActiveTab('banking')}
+        >
+          Mis datos bancarios
+        </TabButton>
+      </div>
+
+      {activeTab === 'history' ? (
+        <div className="space-y-6" role="tabpanel">
+          {!profile ? (
+            <div className="rounded-xl border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
+              Todavía no tenés datos de pago cargados. Abrí la pestaña{' '}
+              <button
+                type="button"
+                onClick={() => setActiveTab('banking')}
+                className="font-medium text-primary hover:underline"
+              >
+                Mis datos bancarios
+              </button>{' '}
+              para completarlos y compartirlos automáticamente con contaduría.
+            </div>
+          ) : (
+            <BankingSummary profile={profile} />
+          )}
+
+          <PaymentHistory payments={payments} />
+        </div>
+      ) : (
+        <section className="rounded-xl border p-6 space-y-4" role="tabpanel">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold">Mis datos bancarios</h2>
+            <p className="text-sm text-muted-foreground">
+              Completá o actualizá tus datos de transferencia. Se guardan en el
+              mismo perfil que usa contaduría para pagarte.
+            </p>
+          </div>
+
+          <form onSubmit={saveBankingData} className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">Banco</span>
+                <Input
+                  value={bankName}
+                  onChange={(e) => setBankName(e.target.value)}
+                  placeholder="Ej: Banco Nación"
+                  maxLength={100}
+                />
+              </label>
+
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">CBU</span>
+                <Input
+                  value={cbu}
+                  onChange={(e) => setCbu(e.target.value)}
+                  className="font-mono"
+                  placeholder="22 dígitos"
+                  maxLength={22}
+                  inputMode="numeric"
+                />
+              </label>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">Alias</span>
+                <Input
+                  value={alias}
+                  onChange={(e) => setAlias(e.target.value)}
+                  className="font-mono"
+                  placeholder="mi.alias.mp"
+                  maxLength={50}
+                />
+              </label>
+
+              <label className="space-y-1 text-sm">
+                <span className="font-medium">CUIT/CUIL</span>
+                <Input
+                  value={cuit}
+                  onChange={(e) => setCuit(e.target.value)}
+                  className="font-mono"
+                  placeholder="20-12345678-9"
+                  maxLength={13}
+                />
+              </label>
+            </div>
+
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            {success && <p className="text-sm text-emerald-600">{success}</p>}
+
+            <Button type="submit" disabled={saving}>
+              {saving ? 'Guardando...' : 'Guardar mis datos bancarios'}
+            </Button>
+          </form>
+        </section>
+      )}
+    </section>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-full px-4 py-2 text-sm font-medium transition-colors ${
+        active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:bg-background/70 hover:text-foreground'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function BankingSummary({ profile }: { profile: ProfessorProfile }) {
+  return (
+    <section className="rounded-xl border p-6 space-y-4">
+      <h2 className="text-lg font-semibold">Datos bancarios</h2>
+      <dl className="grid gap-3 sm:grid-cols-2 text-sm">
+        <div>
+          <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+            Sueldo mensual
+          </dt>
+          <dd className="mt-0.5 font-mono font-semibold text-base">
+            {formatAmount(profile.monthlySalary)}
+          </dd>
+        </div>
+        <SummaryItem label="Banco" value={profile.bankName} />
+        <SummaryItem label="CBU" value={profile.cbu} mono />
+        <SummaryItem label="Alias" value={profile.alias} mono />
+        <SummaryItem label="CUIT/CUIL" value={profile.cuit} mono />
+      </dl>
+      {profile.notes && (
+        <p className="text-xs text-muted-foreground border-t pt-3">
+          {profile.notes}
+        </p>
+      )}
+    </section>
+  );
+}
+
+function SummaryItem({
+  label,
+  value,
+  mono = false,
+}: {
+  label: string;
+  value: string | null;
+  mono?: boolean;
+}) {
+  if (!value) return null;
+
+  return (
+    <div>
+      <dt className="text-xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </dt>
+      <dd className={`mt-0.5 ${mono ? 'font-mono text-xs' : ''}`}>{value}</dd>
+    </div>
+  );
+}
+
+function PaymentHistory({ payments }: { payments: Payment[] }) {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold">Historial de pagos</h2>
+      {payments.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Sin pagos registrados.</p>
+      ) : (
+        <div className="overflow-x-auto rounded-xl border">
+          <table className="w-full text-sm">
+            <thead className="border-b bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-4 py-3 text-left">Período</th>
+                <th className="px-4 py-3 text-right">Monto</th>
+                <th className="px-4 py-3 text-left">Estado</th>
+                <th className="px-4 py-3 text-left">Fecha pago</th>
+                <th className="px-4 py-3 text-left">Notas</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y">
+              {payments.map((payment) => (
+                <tr
+                  key={payment.id}
+                  className="hover:bg-muted/20 transition-colors"
+                >
+                  <td className="px-4 py-3 font-mono text-xs">
+                    {MONTHS[payment.periodMonth - 1]} {payment.periodYear}
+                  </td>
+                  <td className="px-4 py-3 text-right font-mono">
+                    {formatAmount(payment.amount)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <PaymentStatusBadge status={payment.status} />
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {payment.paidAt
+                      ? new Date(payment.paidAt).toLocaleDateString('es-AR')
+                      : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-muted-foreground">
+                    {payment.notes || '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PaymentStatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; className: string }> = {
+    PENDING: {
+      label: 'Pendiente',
+      className: 'bg-yellow-100 text-yellow-700 border-yellow-200',
+    },
+    PAID: {
+      label: 'Pagado',
+      className: 'bg-emerald-100 text-emerald-700 border-emerald-200',
+    },
+    CANCELLED: {
+      label: 'Cancelado',
+      className: 'bg-rose-100 text-rose-700 border-rose-200',
+    },
+  };
+  const config = map[status] ?? map.PENDING;
+  return (
+    <span
+      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${config.className}`}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/src/app/my-payments/page.tsx
+++ b/src/app/my-payments/page.tsx
@@ -2,25 +2,10 @@ import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
-import { formatAmount } from '@/lib/accounting';
 import { buildProfessorInvoiceFileUrl } from '@/lib/blob-urls';
 import type { ProfessorInvoice } from '@prisma/client';
 import ProfessorInvoicesPanel from '@/components/accounting/professor-invoices-panel';
-
-const MONTHS = [
-  'Enero',
-  'Febrero',
-  'Marzo',
-  'Abril',
-  'Mayo',
-  'Junio',
-  'Julio',
-  'Agosto',
-  'Septiembre',
-  'Octubre',
-  'Noviembre',
-  'Diciembre',
-];
+import MyPaymentsClient from './my-payments-client';
 
 export default async function MyPaymentsPage() {
   const session = await getServerSession(authOptions);
@@ -49,6 +34,26 @@ export default async function MyPaymentsPage() {
     console.error('[my-payments] failed to load professor invoices', err);
   }
 
+  const initialProfile = profile
+    ? {
+        monthlySalary: profile.monthlySalary,
+        bankName: profile.bankName,
+        cbu: profile.cbu,
+        alias: profile.alias,
+        cuit: profile.cuit,
+        notes: profile.notes,
+        payments: profile.payments.map((payment) => ({
+          id: payment.id,
+          periodMonth: payment.periodMonth,
+          periodYear: payment.periodYear,
+          amount: payment.amount,
+          status: payment.status,
+          paidAt: payment.paidAt?.toISOString() ?? null,
+          notes: payment.notes,
+        })),
+      }
+    : null;
+
   const invoiceRows = invoices.map((invoice) => ({
     id: invoice.id,
     originalName: invoice.originalName,
@@ -66,122 +71,12 @@ export default async function MyPaymentsPage() {
         </p>
         <h1 className="text-3xl font-bold tracking-tight">Mis pagos</h1>
         <p className="text-sm text-muted-foreground">
-          Información de sueldo y historial de pagos registrados por contaduría.
+          Información de sueldo, datos bancarios y pagos registrados por
+          contaduría.
         </p>
       </header>
 
-      {!profile ? (
-        <div className="rounded-xl border bg-muted/20 p-6 text-center text-sm text-muted-foreground">
-          Contaduría aún no configuró tus datos bancarios. Contactate con el
-          administrador.
-        </div>
-      ) : (
-        <>
-          {/* Banking info */}
-          <section className="rounded-xl border p-6 space-y-4">
-            <h2 className="text-lg font-semibold">Datos bancarios</h2>
-            <dl className="grid gap-3 sm:grid-cols-2 text-sm">
-              <div>
-                <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                  Sueldo mensual
-                </dt>
-                <dd className="mt-0.5 font-mono font-semibold text-base">
-                  {formatAmount(profile.monthlySalary)}
-                </dd>
-              </div>
-              {profile.bankName && (
-                <div>
-                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                    Banco
-                  </dt>
-                  <dd className="mt-0.5">{profile.bankName}</dd>
-                </div>
-              )}
-              {profile.cbu && (
-                <div>
-                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                    CBU
-                  </dt>
-                  <dd className="mt-0.5 font-mono text-xs">{profile.cbu}</dd>
-                </div>
-              )}
-              {profile.alias && (
-                <div>
-                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                    Alias
-                  </dt>
-                  <dd className="mt-0.5 font-mono">{profile.alias}</dd>
-                </div>
-              )}
-              {profile.cuit && (
-                <div>
-                  <dt className="text-xs uppercase tracking-wider text-muted-foreground">
-                    CUIT
-                  </dt>
-                  <dd className="mt-0.5 font-mono">{profile.cuit}</dd>
-                </div>
-              )}
-            </dl>
-            {profile.notes && (
-              <p className="text-xs text-muted-foreground border-t pt-3">
-                {profile.notes}
-              </p>
-            )}
-          </section>
-
-          {/* Payment history */}
-          <section className="space-y-4">
-            <h2 className="text-lg font-semibold">Historial de pagos</h2>
-            {profile.payments.length === 0 ? (
-              <p className="text-sm text-muted-foreground">
-                Sin pagos registrados.
-              </p>
-            ) : (
-              <div className="overflow-x-auto rounded-xl border">
-                <table className="w-full text-sm">
-                  <thead className="border-b bg-muted/40 text-xs uppercase tracking-wider text-muted-foreground">
-                    <tr>
-                      <th className="px-4 py-3 text-left">Período</th>
-                      <th className="px-4 py-3 text-right">Monto</th>
-                      <th className="px-4 py-3 text-left">Estado</th>
-                      <th className="px-4 py-3 text-left">Fecha pago</th>
-                      <th className="px-4 py-3 text-left">Notas</th>
-                    </tr>
-                  </thead>
-                  <tbody className="divide-y">
-                    {profile.payments.map((payment) => (
-                      <tr
-                        key={payment.id}
-                        className="hover:bg-muted/20 transition-colors"
-                      >
-                        <td className="px-4 py-3 font-mono text-xs">
-                          {MONTHS[payment.periodMonth - 1]} {payment.periodYear}
-                        </td>
-                        <td className="px-4 py-3 text-right font-mono">
-                          {formatAmount(payment.amount)}
-                        </td>
-                        <td className="px-4 py-3">
-                          <PaymentStatusBadge status={payment.status} />
-                        </td>
-                        <td className="px-4 py-3 text-xs text-muted-foreground">
-                          {payment.paidAt
-                            ? new Date(payment.paidAt).toLocaleDateString(
-                                'es-AR'
-                              )
-                            : '—'}
-                        </td>
-                        <td className="px-4 py-3 text-xs text-muted-foreground">
-                          {payment.notes || '—'}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            )}
-          </section>
-        </>
-      )}
+      <MyPaymentsClient professorId={userId} initialProfile={initialProfile} />
 
       <ProfessorInvoicesPanel
         professorId={userId}
@@ -193,30 +88,5 @@ export default async function MyPaymentsPage() {
         emptyMessage="Todavía no subiste facturas."
       />
     </div>
-  );
-}
-
-function PaymentStatusBadge({ status }: { status: string }) {
-  const map: Record<string, { label: string; className: string }> = {
-    PENDING: {
-      label: 'Pendiente',
-      className: 'bg-yellow-100 text-yellow-700 border-yellow-200',
-    },
-    PAID: {
-      label: 'Pagado',
-      className: 'bg-emerald-100 text-emerald-700 border-emerald-200',
-    },
-    CANCELLED: {
-      label: 'Cancelado',
-      className: 'bg-rose-100 text-rose-700 border-rose-200',
-    },
-  };
-  const config = map[status] ?? map.PENDING;
-  return (
-    <span
-      className={`inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium ${config.className}`}
-    >
-      {config.label}
-    </span>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide professors a self-service UI to enter/update their banking details so contaduría (accounting) receives those values automatically. 
- Keep accounting users able to manage salary and internal notes while allowing professors to edit only banking fields. 

### Description

- Add a client component with two tabs for `/my-payments`: payment history and an editable “Mis datos bancarios” form at `src/app/my-payments/my-payments-client.tsx`.
- Update the server page `src/app/my-payments/page.tsx` to serialize `professorProfile` and mount the new client component with `initialProfile` and invoice panel preserved.
- Extend `PUT /api/professors/[id]/profile` in `src/app/api/professors/[id]/profile/route.ts` to accept banking-only updates from professor self while keeping accounting users able to update salary and notes, plus add Zod schemas and a `cleanBankingData` helper.
- Update `ROUTE_MAP.md` to document the editable banking tab and the adjusted API permissions.

### Testing

- Ran `pnpm exec prettier --check ROUTE_MAP.md src/app/my-payments/page.tsx src/app/my-payments/my-payments-client.tsx src/app/api/professors/[id]/profile/route.ts` and it reported matched Prettier style for the changed files (success).
- Ran `pnpm lint` which completed successfully; unrelated Prettier warnings exist elsewhere in the repo but did not block this change (success for this PR files).
- Ran typecheck with `pnpm exec tsc --noEmit` which reported failures in unrelated test files (`tests/api/pickup-notices.test.ts`) and not from the modified files (typecheck failure originates outside these changes).
- Performed `git diff --check` and created the commit; no diff-check issues were found (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0685ead9888328841b62c9d52cdff0)