### PR TITLE
Android chat UX: recent conversations + contacts tab with search

### DIFF
--- a/android/app/src/main/java/com/hualas/mobile/features/chat/ChatListScreen.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/chat/ChatListScreen.kt
@@ -1,0 +1,82 @@
+package com.hualas.mobile.features.chat
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ChatListScreen(
+    state: ChatListUiState,
+    onRetry: () -> Unit,
+    onSearchChange: (String) -> Unit = {}
+) {
+    var selectedTab by remember { mutableStateOf(ChatTab.RECENT) }
+
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        Text("Chat", style = MaterialTheme.typography.headlineSmall)
+
+        OutlinedTextField(
+            value = state.searchQuery,
+            onValueChange = onSearchChange,
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Buscar chats y contactos") }
+        )
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            FilterChip(
+                selected = selectedTab == ChatTab.RECENT,
+                onClick = { selectedTab = ChatTab.RECENT },
+                label = { Text("Recientes") }
+            )
+            FilterChip(
+                selected = selectedTab == ChatTab.CONTACTS,
+                onClick = { selectedTab = ChatTab.CONTACTS },
+                label = { Text("Contactos") }
+            )
+        }
+
+        val query = state.searchQuery.trim().lowercase()
+        LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+            when (selectedTab) {
+                ChatTab.RECENT -> {
+                    val rows = state.conversations.filter {
+                        query.isBlank() || it.title.lowercase().contains(query) || it.lastMessage.lowercase().contains(query)
+                    }
+                    items(rows) { row ->
+                        Text("${row.title} · ${row.lastMessage}", style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+
+                ChatTab.CONTACTS -> {
+                    val rows = state.contacts.filter {
+                        query.isBlank() || it.name.lowercase().contains(query)
+                    }
+                    items(rows) { row ->
+                        Text("${row.name} · ${row.subtitle}", style = MaterialTheme.typography.bodyLarge)
+                    }
+                }
+            }
+        }
+
+        if (state.error != null) {
+            Text(state.error, color = MaterialTheme.colorScheme.error)
+        }
+    }
+}
+
+private enum class ChatTab { RECENT, CONTACTS }

--- a/android/app/src/main/java/com/hualas/mobile/features/chat/ChatListViewModel.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/chat/ChatListViewModel.kt
@@ -1,0 +1,95 @@
+package com.hualas.mobile.features.chat
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.hualas.mobile.core.network.ApiResult
+import com.hualas.mobile.features.chat.data.MobileChatPeerDto
+import com.hualas.mobile.features.chat.data.MobileChatRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ChatListUiState(
+    val loading: Boolean = false,
+    val error: String? = null,
+    val searchQuery: String = "",
+    val conversations: List<ChatConversationUiModel> = emptyList(),
+    val contacts: List<ChatContactUiModel> = emptyList()
+)
+
+data class ChatConversationUiModel(
+    val id: String,
+    val peerId: String,
+    val title: String,
+    val subtitle: String,
+    val lastMessage: String,
+    val unreadCount: Int
+)
+
+data class ChatContactUiModel(
+    val id: String,
+    val name: String,
+    val subtitle: String
+)
+
+class ChatListViewModel(
+    private val repository: MobileChatRepository
+) : ViewModel() {
+    private val _uiState = MutableStateFlow(ChatListUiState())
+    val uiState: StateFlow<ChatListUiState> = _uiState.asStateFlow()
+
+    fun updateSearch(query: String) {
+        _uiState.update { it.copy(searchQuery = query) }
+    }
+
+    fun load() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(loading = true, error = null) }
+
+            val conversationsResult = repository.getConversations()
+            val contactsResult = repository.getContacts()
+
+            if (conversationsResult is ApiResult.Success && contactsResult is ApiResult.Success) {
+                val contacts = buildList {
+                    addAll(contactsResult.value.familyContacts.map { it.toContact("Familia") })
+                    addAll(contactsResult.value.professorContacts.map { it.toContact("Profesor") })
+                    addAll(contactsResult.value.staffContacts.map { it.toContact("Staff") })
+                }.distinctBy { it.id }
+
+                _uiState.update {
+                    it.copy(
+                        loading = false,
+                        conversations = conversationsResult.value.conversations.map { dto ->
+                            ChatConversationUiModel(
+                                id = dto.id,
+                                peerId = dto.peer?.id.orEmpty(),
+                                title = dto.title ?: dto.peer?.label ?: "Chat",
+                                subtitle = dto.subtitle ?: "",
+                                lastMessage = dto.lastMessage?.content ?: "Sin mensajes todavía",
+                                unreadCount = dto.unreadCount
+                            )
+                        },
+                        contacts = contacts
+                    )
+                }
+            } else {
+                _uiState.update {
+                    it.copy(
+                        loading = false,
+                        error = "No pudimos cargar el chat. Probá nuevamente."
+                    )
+                }
+            }
+        }
+    }
+
+    private fun MobileChatPeerDto.toContact(type: String): ChatContactUiModel {
+        val displayName = label
+            ?: listOfNotNull(name?.trim(), lastName?.trim()).joinToString(" ").ifBlank { null }
+            ?: email
+            ?: "Contacto"
+        return ChatContactUiModel(id = id, name = displayName, subtitle = type)
+    }
+}

--- a/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatDtos.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatDtos.kt
@@ -1,0 +1,64 @@
+package com.hualas.mobile.features.chat.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MobileConversationsResponseDto(
+    val conversations: List<MobileConversationDto> = emptyList()
+)
+
+@Serializable
+data class MobileConversationDto(
+    val id: String,
+    val title: String? = null,
+    val subtitle: String? = null,
+    val unreadCount: Int = 0,
+    val peer: MobileChatPeerDto? = null,
+    val lastMessage: MobileChatMessageDto? = null
+)
+
+@Serializable
+data class MobileChatPeerDto(
+    val id: String,
+    val name: String? = null,
+    val lastName: String? = null,
+    val email: String? = null,
+    val phone: String? = null,
+    val role: String? = null,
+    val profilePhoto: String? = null,
+    val label: String? = null
+)
+
+@Serializable
+data class MobileChatMessageDto(
+    val id: String,
+    @SerialName("from") val senderId: String,
+    val content: String,
+    val createdAt: String,
+    val readAt: String? = null
+)
+
+@Serializable
+data class MobileChatContactsResponseDto(
+    val familyContacts: List<MobileChatPeerDto> = emptyList(),
+    val professorContacts: List<MobileChatPeerDto> = emptyList(),
+    val staffContacts: List<MobileChatPeerDto> = emptyList()
+)
+
+@Serializable
+data class MobileThreadResponseDto(
+    val conversationId: String? = null,
+    val peer: MobileChatPeerDto? = null,
+    val messages: List<MobileChatMessageDto> = emptyList()
+)
+
+@Serializable
+data class MobileSendMessageDto(
+    val content: String
+)
+
+@Serializable
+data class MobileSendMessageResponseDto(
+    val message: MobileChatMessageDto? = null
+)

--- a/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatRepository.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatRepository.kt
@@ -1,0 +1,21 @@
+package com.hualas.mobile.features.chat.data
+
+import com.hualas.mobile.core.network.ApiResult
+
+class MobileChatRepository(
+    private val service: MobileChatService
+) {
+    suspend fun getConversations(): ApiResult<MobileConversationsResponseDto> = runCatching {
+        service.getConversations()
+    }.fold(
+        onSuccess = { ApiResult.Success(it) },
+        onFailure = { ApiResult.fromThrowable(it) }
+    )
+
+    suspend fun getContacts(): ApiResult<MobileChatContactsResponseDto> = runCatching {
+        service.getContacts()
+    }.fold(
+        onSuccess = { ApiResult.Success(it) },
+        onFailure = { ApiResult.fromThrowable(it) }
+    )
+}

--- a/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatService.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/chat/data/MobileChatService.kt
@@ -1,0 +1,23 @@
+package com.hualas.mobile.features.chat.data
+
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.POST
+import retrofit2.http.Path
+
+interface MobileChatService {
+    @GET("api/mobile/messages")
+    suspend fun getConversations(): MobileConversationsResponseDto
+
+    @GET("api/mobile/chat/contacts")
+    suspend fun getContacts(): MobileChatContactsResponseDto
+
+    @GET("api/mobile/messages/{userId}")
+    suspend fun getThread(@Path("userId") userId: String): MobileThreadResponseDto
+
+    @POST("api/mobile/messages/{userId}")
+    suspend fun sendMessage(
+        @Path("userId") userId: String,
+        @Body payload: MobileSendMessageDto
+    ): MobileSendMessageResponseDto
+}


### PR DESCRIPTION
### Motivation
- Provide a WhatsApp-style chat experience on Android with a top search and tabs for recent conversations and contacts as requested.
- Surface the existing mobile chat API (`/api/mobile/messages`, `/api/mobile/chat/contacts`) to the Android UI so the app can show recent threads and allowed contacts.

### Description
- Added a Retrofit API definition and serializable DTOs in `features/chat/data` to consume `/api/mobile/messages`, `/api/mobile/messages/{userId}`, `/api/mobile/chat/contacts`, and send messages via `/api/mobile/messages/{userId}`.
- Implemented `MobileChatRepository` to fetch conversations and contacts and wrap results in the existing `ApiResult` pattern.
- Implemented `ChatListViewModel` to load conversations and contacts, maintain search query state, normalize contact types (`Familia`, `Profesor`, `Staff`) and expose UI models.
- Implemented `ChatListScreen` (Jetpack Compose) that renders a search field, two tabs (`Recientes`, `Contactos`), and filtered lists based on the query.
- Files added: `android/app/src/main/java/com/hualas/mobile/features/chat/ChatListScreen.kt`, `ChatListViewModel.kt`, `data/MobileChatService.kt`, `data/MobileChatRepository.kt`, and `data/MobileChatDtos.kt`.

### Testing
- Ran Android compile attempt with `cd android && ./gradlew :app:compileLocalDebugKotlin`, which failed due to the local Android SDK/toolchain environment (`25.0.2`) and not due to Kotlin compile errors from these new files.
- No unit or instrumentation tests were executed in this environment; code compiles should be validated locally or in CI with a proper Android SDK installed.
- Unresolved risks: navigation from the list into a thread and message send UI/flows are not yet wired from this screen, and the build must be verified on a machine with the Android SDK to confirm imports and serialization integration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0cbb68ac83288a718ef4c3c82a53)