### PR TITLE
Agregar buscador en el selector de profesores de actividades

### DIFF
--- a/src/app/activities/professor-picker.tsx
+++ b/src/app/activities/professor-picker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown } from 'lucide-react';
-import { useId, useState } from 'react';
+import { useId, useMemo, useState } from 'react';
 
 type ProfessorOption = {
   id: string;
@@ -25,6 +25,22 @@ export default function ProfessorPicker({
 }: ProfessorPickerProps) {
   const listId = useId();
   const [collapsed, setCollapsed] = useState(defaultCollapsed);
+  const [search, setSearch] = useState('');
+
+  const normalizedSearch = search.trim().toLocaleLowerCase();
+  const filteredProfessors = useMemo(() => {
+    if (!normalizedSearch) return professors;
+
+    return professors.filter((professor) => {
+      const fullName = `${professor.name ?? ''} ${professor.lastName ?? ''}`
+        .trim()
+        .toLocaleLowerCase();
+      const email = professor.email.toLocaleLowerCase();
+      return (
+        fullName.includes(normalizedSearch) || email.includes(normalizedSearch)
+      );
+    });
+  }, [normalizedSearch, professors]);
 
   const selectedCountLabel =
     value.length === 1 ? '1 seleccionado' : `${value.length} seleccionados`;
@@ -45,37 +61,55 @@ export default function ProfessorPicker({
           No hay usuarios con rol profesor disponibles.
         </p>
       ) : (
-        <div className="grid gap-2 sm:grid-cols-2">
-          {professors.map((professor) => {
-            const checked = value.includes(professor.id);
-            return (
-              <label
-                key={professor.id}
-                className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
-              >
-                <input
-                  type="checkbox"
-                  checked={checked}
-                  onChange={(e) => {
-                    if (e.target.checked) {
-                      onChange([...value, professor.id]);
-                      return;
-                    }
-                    onChange(value.filter((id) => id !== professor.id));
-                  }}
-                  className="mt-1 accent-primary"
-                />
-                <span>
-                  <span className="block font-medium">
-                    {professor.name ?? 'Sin nombre'} {professor.lastName ?? ''}
-                  </span>
-                  <span className="block text-xs text-muted-foreground">
-                    {professor.email}
-                  </span>
-                </span>
-              </label>
-            );
-          })}
+        <div className="space-y-3">
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Buscar profesor por nombre o email"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            aria-label="Buscar profesor"
+          />
+
+          {filteredProfessors.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No se encontraron profesores para &quot;{search.trim()}&quot;.
+            </p>
+          ) : (
+            <div className="grid gap-2 sm:grid-cols-2">
+              {filteredProfessors.map((professor) => {
+                const checked = value.includes(professor.id);
+                return (
+                  <label
+                    key={professor.id}
+                    className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          onChange([...value, professor.id]);
+                          return;
+                        }
+                        onChange(value.filter((id) => id !== professor.id));
+                      }}
+                      className="mt-1 accent-primary"
+                    />
+                    <span>
+                      <span className="block font-medium">
+                        {professor.name ?? 'Sin nombre'}{' '}
+                        {professor.lastName ?? ''}
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {professor.email}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
### Motivation
- Facilitar la asignación de profesores al editar/crear actividades filtrando por nombre/apellido o email. 
- Mejorar la UX cuando hay muchos profesores disponibles sin cambiar el flujo de selección por checkboxes.

### Description
- Añadí un campo de búsqueda y lógica de filtrado en `ProfessorPicker` usando `useState` y `useMemo`, manteniendo el comportamiento colapsable y los checkboxes. 
- Mostrar mensaje claro cuando la búsqueda no arroja resultados y preservar la selección existente al filtrar. 
- Archivo modificado: `src/app/activities/professor-picker.tsx` (se actualizaron ~66 inserciones y 32 borrados según diff).

### Testing
- Ejecuté el linter: `pnpm -s exec eslint src/app/activities/professor-picker.tsx` y la verificación quedó sin errores tras corregir advertencias de caracteres no escapados. 
- No se añadieron pruebas unitarias ni E2E automáticas en este cambio. 
- Riesgo no resuelto: conviene una prueba manual en la pantalla de edición de actividad con una lista grande de profesores para validar comportamiento visual y accesibilidad en contexto real.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d22fe8d48832886f7bf19bb087b5e)