### PR TITLE
Move activity join media gallery to the end of the page

### DIFF
--- a/src/app/activities/join/[id]/page.tsx
+++ b/src/app/activities/join/[id]/page.tsx
@@ -184,48 +184,6 @@ export default async function ActivityJoinPage({
             </div>
           </div>
 
-          {activityData.media.length > 0 && (
-            <section className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
-              <div>
-                <h2 className="font-heading text-xl font-semibold">
-                  Fotos y videos
-                </h2>
-                <p className="text-sm text-muted-foreground font-body">
-                  Conocé la actividad con más fotos y videos antes de anotarte.
-                </p>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {activityData.media.map((item) => {
-                  const mediaUrl = `/api/activities/${activityData.id}/media/${item.id}`;
-                  return (
-                    <div
-                      key={item.id}
-                      className="overflow-hidden rounded-lg border bg-muted/30"
-                    >
-                      <div className="relative aspect-video">
-                        {item.type === 'IMAGE' ? (
-                          <Image
-                            src={mediaUrl}
-                            alt={item.fileName ?? activityData.name}
-                            fill
-                            unoptimized
-                            className="object-cover"
-                          />
-                        ) : (
-                          <video
-                            src={mediaUrl}
-                            controls
-                            className="h-full w-full object-cover"
-                          />
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-              </div>
-            </section>
-          )}
-
           <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_minmax(0,2fr)]">
             <div className="rounded-lg border bg-card p-4">
               <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground font-body">
@@ -307,6 +265,48 @@ export default async function ActivityJoinPage({
           }
           activityStartDate={activityData.date.toISOString()}
         />
+
+        {activityData.media.length > 0 && (
+          <section className="space-y-4 rounded-xl border bg-card p-4 shadow-sm">
+            <div>
+              <h2 className="font-heading text-xl font-semibold">
+                Fotos y videos
+              </h2>
+              <p className="text-sm text-muted-foreground font-body">
+                Conocé la actividad con más fotos y videos antes de anotarte.
+              </p>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {activityData.media.map((item) => {
+                const mediaUrl = `/api/activities/${activityData.id}/media/${item.id}`;
+                return (
+                  <div
+                    key={item.id}
+                    className="overflow-hidden rounded-lg border bg-muted/30"
+                  >
+                    <div className="relative aspect-video">
+                      {item.type === 'IMAGE' ? (
+                        <Image
+                          src={mediaUrl}
+                          alt={item.fileName ?? activityData.name}
+                          fill
+                          unoptimized
+                          className="object-cover"
+                        />
+                      ) : (
+                        <video
+                          src={mediaUrl}
+                          controls
+                          className="h-full w-full object-cover"
+                        />
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+        )}
       </div>
     </main>
   );


### PR DESCRIPTION
### Motivation
- Users expect the “Fotos y videos” gallery to appear after the enrollment panel on the public activity join page, so the media should be shown at the end of the page for better signup focus.

### Description
- Moved the media gallery JSX block so it renders after the `JoinEnrollmentPanel` on the `/activities/join/[id]` page by updating `src/app/activities/join/[id]/page.tsx` without changing media ordering or rendering logic.

### Testing
- Ran `pnpm exec eslint src/app/activities/join/[id]/page.tsx` and applied `--fix` to resolve Prettier warnings, and re-ran ESLint successfully; no automated unit or e2e tests were added, and visual verification in a browser is recommended as an unresolved risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d233994788328b9fe9da1785f4e95)