### PR TITLE
Android: mostrar menú desplegable superior junto a la campana de notificaciones

### DIFF
--- a/android/app/src/main/java/com/hualas/mobile/features/home/HomeScreen.kt
+++ b/android/app/src/main/java/com/hualas/mobile/features/home/HomeScreen.kt
@@ -20,7 +20,11 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -29,6 +33,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -129,6 +136,7 @@ fun HomeScreen(
                     onRefresh = onRefresh,
                     onLogout = onLogout,
                     onSwitchRole = onSwitchRole,
+                    destinations = destinations,
                     onLoadActivities = onLoadActivities,
                     onSelectActivityDay = onSelectActivityDay,
                     onLoadActivityDayDetail = onLoadActivityDayDetail,
@@ -155,6 +163,7 @@ private fun HomeContent(
     onRefresh: () -> Unit,
     onLogout: () -> Unit,
     onSwitchRole: (MobileRole) -> Unit,
+    destinations: List<PrimaryDestination>,
     onLoadActivities: () -> Unit,
     onSelectActivityDay: (String) -> Unit,
     onLoadActivityDayDetail: (String) -> Unit,
@@ -177,6 +186,10 @@ private fun HomeContent(
                 profile = home.profile,
                 isRefreshing = isRefreshing,
                 onRefresh = onRefresh,
+                destinations = destinations,
+                selectedDestinationId = selectedDestinationId,
+                onSelectDestination = { selectedDestinationId = it },
+                onOpenNotifications = { selectedDestinationId = "more" },
                 onSwitchRole = onSwitchRole
             )
         }
@@ -492,8 +505,14 @@ private fun Header(
     profile: HomeProfile,
     isRefreshing: Boolean,
     onRefresh: () -> Unit,
+    destinations: List<PrimaryDestination>,
+    selectedDestinationId: String,
+    onSelectDestination: (String) -> Unit,
+    onOpenNotifications: () -> Unit,
     onSwitchRole: (MobileRole) -> Unit
 ) {
+    var menuExpanded by remember { mutableStateOf(false) }
+
     Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -514,8 +533,52 @@ private fun Header(
                     overflow = TextOverflow.Ellipsis
                 )
             }
-            TextButton(onClick = onRefresh, enabled = !isRefreshing) {
-                Text(if (isRefreshing) "Actualizando" else "Actualizar")
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                IconButton(onClick = onOpenNotifications) {
+                    Icon(
+                        imageVector = Icons.Default.Notifications,
+                        contentDescription = "Notificaciones"
+                    )
+                }
+                Box {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = "Menú"
+                        )
+                    }
+                    DropdownMenu(
+                        expanded = menuExpanded,
+                        onDismissRequest = { menuExpanded = false }
+                    ) {
+                        destinations
+                            .filterNot { it.id == "home" }
+                            .forEach { destination ->
+                                DropdownMenuItem(
+                                    text = {
+                                        Text(
+                                            if (destination.id == selectedDestinationId) {
+                                                "✓ ${destination.label}"
+                                            } else {
+                                                destination.label
+                                            }
+                                        )
+                                    },
+                                    onClick = {
+                                        menuExpanded = false
+                                        onSelectDestination(destination.id)
+                                    }
+                                )
+                            }
+                        DropdownMenuItem(
+                            text = { Text(if (isRefreshing) "Actualizando..." else "Actualizar") },
+                            onClick = {
+                                menuExpanded = false
+                                if (!isRefreshing) onRefresh()
+                            }
+                        )
+                    }
+                }
             }
         }
         if (session.allowedRoles.size > 1) {


### PR DESCRIPTION
### Motivation
- La versión Android necesitaba un acceso al menú en la barra superior con un menú desplegable junto a la campana de notificaciones, igual que en la versión móvil/desktop solicitada.  
- Queríamos ofrecer navegación rápida a destinos principales desde el header y conservar la acción de `Actualizar` en el nuevo menú.

### Description
- Añadí un menú de cabecera en `HomeScreen` que muestra un botón de notificaciones y un botón de tres puntos que abre un `DropdownMenu` con accesos rápidos a destinos (excluye `home`).
- Pasé la lista `destinations` y la selección (`selectedDestinationId`) desde `HomeScreen` hacia `HomeContent` y `Header` para permitir que la selección del dropdown actualice la vista.
- Implementé un ítem `Actualizar` dentro del dropdown que dispara `onRefresh` cuando no está en curso la actualización.  
- Archivo modificado: `android/app/src/main/java/com/hualas/mobile/features/home/HomeScreen.kt` (nuevos imports, IconButton para campana y menú, uso de `DropdownMenu` y lógica de estado `menuExpanded`).

### Testing
- Intenté compilar con `./gradlew :app:compileDebugKotlin` en el contenedor de CI, pero la compilación falló por la configuración del entorno Android SDK (`25.0.2`) y no por errores de sintaxis introducidos por el cambio.  
- No se ejecutaron tests unitarios adicionales en este entorno por la limitación de SDK; se recomienda validar la compilación y probar visualmente en Android Studio o en un emulador real después de sincronizar el SDK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d28ec2bf8832895bb6bc9bfcca4a9)