### PR TITLE
Actualizar /accounting/social-fee: tarjeta "Caja" y reordenar métricas

### DIFF
--- a/src/app/accounting/social-fee/page.tsx
+++ b/src/app/accounting/social-fee/page.tsx
@@ -1,4 +1,4 @@
-import { BillableConceptCode } from '@prisma/client';
+import { BillableConceptCode, MovementType } from '@prisma/client';
 import Link from 'next/link';
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
@@ -100,7 +100,16 @@ export default async function SocialFeePage({
     1
   );
 
-  const [concept, members, payments] = await Promise.all([
+  const periodStart = new Date(Date.UTC(year, month - 1, 1, 0, 0, 0, 0));
+  const periodEnd = new Date(Date.UTC(year, month, 0, 23, 59, 59, 999));
+
+  const [
+    concept,
+    members,
+    payments,
+    socialFeeExpenseMovements,
+    previousMonthCloses,
+  ] = await Promise.all([
     prisma.billableConcept.findUnique({
       where: { code: BillableConceptCode.SOCIAL_FEE },
       select: { defaultAmount: true, name: true, active: true },
@@ -127,6 +136,50 @@ export default async function SocialFeePage({
         },
       },
       orderBy: [{ lastName: 'asc' }, { name: 'asc' }],
+    }),
+
+    prisma.accountingMovement.findMany({
+      where: {
+        type: MovementType.EXPENSE,
+        date: {
+          gte: periodStart,
+          lte: periodEnd,
+        },
+        OR: [
+          {
+            category: {
+              contains: 'cuota social',
+              mode: 'insensitive',
+            },
+          },
+          {
+            description: {
+              contains: 'cuota social',
+              mode: 'insensitive',
+            },
+          },
+        ],
+      },
+      select: {
+        amount: true,
+      },
+    }),
+    prisma.accountingMonthClose.findMany({
+      where: {
+        OR: [
+          { periodYear: { lt: year } },
+          {
+            periodYear: year,
+            periodMonth: { lt: month },
+          },
+        ],
+      },
+      orderBy: [{ periodYear: 'asc' }, { periodMonth: 'asc' }],
+      select: {
+        periodMonth: true,
+        periodYear: true,
+        positiveBalance: true,
+      },
     }),
     prisma.socialFeePayment.findMany({
       where: {
@@ -263,6 +316,16 @@ export default async function SocialFeePage({
     (sum, person) => sum + person.amount,
     0
   );
+  const socialFeeExpenseAmount = socialFeeExpenseMovements.reduce(
+    (sum, movement) => sum + movement.amount,
+    0
+  );
+  const previousSocialFeeCash = previousMonthCloses.reduce(
+    (sum, close) => sum + Math.max(close.positiveBalance, 0),
+    0
+  );
+  const socialFeeCashAmount =
+    collectedAmount - socialFeeExpenseAmount + previousSocialFeeCash;
   const expectedAmount = people.length * socialFeeAmount;
   const visiblePaidRangeLabel =
     paidPeople.length === 0
@@ -290,8 +353,20 @@ export default async function SocialFeePage({
 
   return (
     <div className="space-y-6">
-      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-5">
         {[
+          {
+            label: 'Caja',
+            value: formatAmount(socialFeeCashAmount),
+            helper: `${formatAmount(collectedAmount)} - ${formatAmount(
+              socialFeeExpenseAmount
+            )} + ${formatAmount(previousSocialFeeCash)}`,
+          },
+          {
+            label: 'Pagos registrados',
+            value: paidPeople.length.toString(),
+            helper: formatAmount(collectedAmount),
+          },
           {
             label: 'Cuota configurada',
             value: formatAmount(socialFeeAmount),
@@ -301,11 +376,6 @@ export default async function SocialFeePage({
             label: 'Obligados del período',
             value: people.length.toString(),
             helper: `${formatPeriodLabel(month, year)}`,
-          },
-          {
-            label: 'Pagos registrados',
-            value: paidPeople.length.toString(),
-            helper: formatAmount(collectedAmount),
           },
           {
             label: 'Pendientes',


### PR DESCRIPTION
### Motivation
- Mostrar en la vista de ` /accounting/social-fee` un indicador de `Caja` que refleje el flujo neto de la cuota social del período y los saldos acumulados anteriores. 
- Reordenar las tarjetas de resumen para que `Pagos registrados` aparezca antes que `Cuota configurada`, y mantener la UI consistente con un nuevo rectángulo para `Caja`.

### Description
- Agregué la tarjeta `Caja` y reordené las tarjetas resumen en `src/app/accounting/social-fee/page.tsx` para que `Pagos registrados` esté antes de `Cuota configurada` y `Caja` aparezca en el mismo estilo visual. 
- Nuevas consultas Prisma añadidas en `page.tsx`: se consultan `accountingMovement` (filtrando `MovementType.EXPENSE` cuyo `category` o `description` contienen "cuota social") y `accountingMonthClose` para sumar `positiveBalance` de meses anteriores. 
- Cálculo implementado para `Caja`: `suma de pagos del período` − `egresos de cuota social del período` + `caja acumulada de cierres anteriores` y formateo mostrado en la nueva tarjeta. 
- Ajustado layout de la grilla para admitir 5 tarjetas en XL cambiando la clase a `xl:grid-cols-5`. 

### Testing
- Ejecutado `pnpm lint`: completó correctamente (no fail); se reportaron warnings de `prettier` en otros archivos no modificados. 
- Ejecutado `pnpm prettier --write src/app/accounting/social-fee/page.tsx` para formatear el archivo modificado. 
- Estado: cambios compilables según linter y archivo formateado; no se ejecutaron tests unitarios adicionales.
- Riesgos no resueltos: el filtro de egresos depende de que `category` o `description` contengan exactamente la cadena "cuota social`, por lo que movimientos con nomenclatura distinta no se incluirán; la acumulación usa `positiveBalance` de `AccountingMonthClose` previos y estará incompleta si faltan cierres históricos; la consulta extra puede impactar ligeramente el tiempo de respuesta en períodos con muchos movimientos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2cdad3508328acb4a8ec5331df5d)