### PR TITLE
Agregar opción de asignar sesiones múltiples a todos los grupos

### DIFF
--- a/src/app/activities/[id]/bulk-session-creator.tsx
+++ b/src/app/activities/[id]/bulk-session-creator.tsx
@@ -98,6 +98,7 @@ export default function BulkSessionCreator({
   const [coordinates, setCoordinates] = useState<Coordinates | null>(null);
   const [professorIds, setProfessorIds] =
     useState<string[]>(defaultProfessorIds);
+  const ALL_GROUPS_VALUE = '__all_groups__';
   const [activityGroupId, setActivityGroupId] = useState<string | null>(null);
   const [sportIcon, setSportIcon] = useState<string | null>(null);
   const [description, setDescription] = useState('');
@@ -172,26 +173,33 @@ export default function BulkSessionCreator({
     const dates = Array.from(selectedDates).sort();
     let failCount = 0;
 
+    const targetGroupIds =
+      activityGroupId === ALL_GROUPS_VALUE
+        ? groups.map((group) => group.id)
+        : [activityGroupId];
+
     for (const dateStr of dates) {
-      try {
-        const res = await fetch(`/api/activities/${activityId}/days`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            date: dateStr,
-            schedule: schedule.trim(),
-            description: description.trim() || undefined,
-            geoLocation: geoLocation.trim(),
-            latitude: coordinates.latitude,
-            longitude: coordinates.longitude,
-            professorIds,
-            activityGroupId,
-            sportIcon: sportIcon || null,
-          }),
-        });
-        if (!res.ok) failCount++;
-      } catch {
-        failCount++;
+      for (const targetGroupId of targetGroupIds) {
+        try {
+          const res = await fetch(`/api/activities/${activityId}/days`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              date: dateStr,
+              schedule: schedule.trim(),
+              description: description.trim() || undefined,
+              geoLocation: geoLocation.trim(),
+              latitude: coordinates.latitude,
+              longitude: coordinates.longitude,
+              professorIds,
+              activityGroupId: targetGroupId,
+              sportIcon: sportIcon || null,
+            }),
+          });
+          if (!res.ok) failCount++;
+        } catch {
+          failCount++;
+        }
       }
     }
 
@@ -398,6 +406,7 @@ export default function BulkSessionCreator({
                   className={inputClass}
                 >
                   <option value="">Sin restricción de grupo</option>
+                  <option value={ALL_GROUPS_VALUE}>Todos los grupos</option>
                   {groups.map((group) => (
                     <option key={group.id} value={group.id}>
                       {group.name}


### PR DESCRIPTION
### Motivation
- Facilitar la creación de sesiones temporales cuando se desean generar las mismas sesiones para todos los grupos de una actividad en lugar de asignarlas manualmente una por una.

### Description
- Añadí la constante interna `ALL_GROUPS_VALUE` y una nueva opción en el selector `Grupo de la sesión` con el label `Todos los grupos` en `src/app/activities/[id]/bulk-session-creator.tsx`.
- Modifiqué `handleSubmit` para calcular `targetGroupIds` y hacer un POST al endpoint `/api/activities/[id]/days` para cada combinación `fecha x grupo` cuando se selecciona `Todos los grupos`.
- Mantengo el comportamiento previo para `Sin restricción de grupo` y la asignación a un único grupo puntual, y el archivo modificado es `src/app/activities/[id]/bulk-session-creator.tsx`.
- Riesgo conocido: si ya existen sesiones para alguna combinación fecha/grupo el endpoint puede rechazar algunas solicitudes y solo se reporta un contador total de fallos sin desglose por fecha/grupo.

### Testing
- Ejecutado `pnpm -s eslint src/app/activities/[id]/bulk-session-creator.tsx` y pasó correctamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc23164608328a7d6e1c45f2ce144)