### PR TITLE
Restrict Android app navbar entry to admins only

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -60,6 +60,7 @@ export default function Navbar() {
   const isCounter = isCounterRole(role);
   const isAccounting = role === 'COUNTER' || isAdmin;
   const isProfessor = role === 'PROFESSOR';
+  const canSeeAndroidLink = isAdmin;
   const isMember = !!session && !isAdmin && !isCounter;
   const isMemberRole = role === 'MEMBER';
   const canSeeChildrenSection = isMemberRole;
@@ -246,7 +247,7 @@ export default function Navbar() {
         </div>
 
         <div className="hidden md:flex md:items-center md:gap-6">
-          {renderAndroidLink()}
+          {canSeeAndroidLink && renderAndroidLink()}
           {session && !isCounter && (
             <Link
               href={activitiesHref}
@@ -500,7 +501,7 @@ export default function Navbar() {
                   {session.user.name || 'Usuario'}
                 </span>
               </Link>
-              {renderAndroidLink(() => setMenuOpen(false))}
+              {canSeeAndroidLink && renderAndroidLink(() => setMenuOpen(false))}
               {session && !isCounter && (
                 <Link
                   href={activitiesHref}
@@ -689,7 +690,7 @@ export default function Navbar() {
               >
                 {t.register}
               </Link>
-              {renderAndroidLink(() => setMenuOpen(false))}
+              {canSeeAndroidLink && renderAndroidLink(() => setMenuOpen(false))}
               <select
                 value={lang}
                 onChange={(e) => setLang(e.target.value as Lang)}


### PR DESCRIPTION
### Motivation
- Temporarily hide the top-menu "App Android" shortcut from non-admin users so the Android APK link is only offered to administrators.

### Description
- Add `canSeeAndroidLink = isAdmin` and guard every `renderAndroidLink` call in both desktop and mobile menu branches inside `src/components/navbar.tsx` so the `/android` link is only rendered for admins.
- Files touched: `src/components/navbar.tsx`; note that the `/android` route itself remains reachable by direct URL (UI-only visibility change).

### Testing
- Ran `pnpm -s eslint src/components/navbar.tsx` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc6615fac83289d188564338a42ff)