### PR TITLE
feat(activities): planificación semanal por celda (lugar, deporte, materiales)

### DIFF
--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -37,6 +37,9 @@ type AnnualScheduleDraft = {
   schedule: string;
   groupId: string;
   professorIds: string[];
+  description: string;
+  geoLocation: string;
+  sportIcon: string;
 };
 
 type AnnualSharedDraft = {
@@ -76,7 +79,13 @@ interface EditActivityFormProps {
     professorIds: string[];
   };
   annualDefaults?: AnnualSharedDraft;
-  initialAnnualSchedules?: Omit<AnnualScheduleDraft, 'tempId'>[];
+  initialAnnualSchedules?: Array<
+    Omit<AnnualScheduleDraft, 'tempId' | 'description' | 'geoLocation' | 'sportIcon'> & {
+      description?: string;
+      geoLocation?: string;
+      sportIcon?: string;
+    }
+  >;
   professors: ProfessorOption[];
   initialGroups: ExistingGroup[];
   existingDayCount: number;
@@ -89,6 +98,9 @@ function createEmptyScheduleDraft(): AnnualScheduleDraft {
     schedule: '',
     groupId: '',
     professorIds: [],
+    description: '',
+    geoLocation: '',
+    sportIcon: '',
   };
 }
 
@@ -115,6 +127,9 @@ export default function EditActivityForm({
   const [annualSchedules, setAnnualSchedules] = useState<AnnualScheduleDraft[]>(
     initialAnnualSchedules.map((draft) => ({
       ...draft,
+      description: draft.description ?? '',
+      geoLocation: draft.geoLocation ?? '',
+      sportIcon: draft.sportIcon ?? '',
       tempId: crypto.randomUUID(),
     }))
   );
@@ -342,6 +357,9 @@ export default function EditActivityForm({
               schedule: d.schedule.trim(),
               groupId: d.groupId || undefined,
               professorIds: d.professorIds,
+              description: d.description.trim() || undefined,
+              geoLocation: d.geoLocation.trim() || undefined,
+              sportIcon: d.sportIcon || undefined,
             }))
           : [];
 
@@ -781,6 +799,44 @@ export default function EditActivityForm({
                               }
                               className={inputClass}
                             />
+                            <input
+                              type="text"
+                              placeholder="Lugar"
+                              value={draft.geoLocation}
+                              onChange={(e) =>
+                                updateScheduleDraft(draft.tempId, {
+                                  geoLocation: e.target.value,
+                                })
+                              }
+                              className={inputClass}
+                            />
+                            <input
+                              type="text"
+                              placeholder="Materiales"
+                              value={draft.description}
+                              onChange={(e) =>
+                                updateScheduleDraft(draft.tempId, {
+                                  description: e.target.value,
+                                })
+                              }
+                              className={inputClass}
+                            />
+                            <select
+                              value={draft.sportIcon}
+                              onChange={(e) =>
+                                updateScheduleDraft(draft.tempId, {
+                                  sportIcon: e.target.value,
+                                })
+                              }
+                              className={inputClass}
+                            >
+                              <option value="">Deporte compartido</option>
+                              {SPORT_ICONS.map((icon) => (
+                                <option key={icon.file} value={icon.file}>
+                                  {icon.label}
+                                </option>
+                              ))}
+                            </select>
                             <select
                               value={draft.groupId}
                               onChange={(e) =>

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -35,6 +35,9 @@ type AnnualScheduleDraft = {
   schedule: string;
   groupTempId: string;
   professorIds: string[];
+  description: string;
+  geoLocation: string;
+  sportIcon: string;
 };
 
 type AnnualSharedDraft = {
@@ -74,6 +77,9 @@ function createEmptyAnnualScheduleDraft(): AnnualScheduleDraft {
     schedule: '',
     groupTempId: '',
     professorIds: [],
+    description: '',
+    geoLocation: '',
+    sportIcon: '',
   };
 }
 
@@ -243,6 +249,9 @@ export default function CreateActivityForm({
                 schedule: draft.schedule.trim(),
                 groupTempId: draft.groupTempId || undefined,
                 professorIds: draft.professorIds,
+                description: draft.description.trim() || undefined,
+                geoLocation: draft.geoLocation.trim() || undefined,
+                sportIcon: draft.sportIcon || undefined,
               };
             })
           : [];
@@ -655,6 +664,44 @@ export default function CreateActivityForm({
                             }
                             className={inputClass}
                           />
+                          <input
+                            type="text"
+                            placeholder="Lugar"
+                            value={draft.geoLocation}
+                            onChange={(e) =>
+                              updateAnnualScheduleDraft(draft.tempId, {
+                                geoLocation: e.target.value,
+                              })
+                            }
+                            className={inputClass}
+                          />
+                          <input
+                            type="text"
+                            placeholder="Materiales"
+                            value={draft.description}
+                            onChange={(e) =>
+                              updateAnnualScheduleDraft(draft.tempId, {
+                                description: e.target.value,
+                              })
+                            }
+                            className={inputClass}
+                          />
+                          <select
+                            value={draft.sportIcon}
+                            onChange={(e) =>
+                              updateAnnualScheduleDraft(draft.tempId, {
+                                sportIcon: e.target.value,
+                              })
+                            }
+                            className={inputClass}
+                          >
+                            <option value="">Deporte compartido</option>
+                            {SPORT_ICONS.map((icon) => (
+                              <option key={icon.file} value={icon.file}>
+                                {icon.label}
+                              </option>
+                            ))}
+                          </select>
                           <select
                             value={draft.groupTempId}
                             onChange={(e) =>

--- a/src/lib/activities/annual-schedule.ts
+++ b/src/lib/activities/annual-schedule.ts
@@ -5,6 +5,9 @@ type AnnualScheduleTemplate = {
   groupTempId?: string;
   groupId?: string;
   professorIds?: string[];
+  description?: string;
+  geoLocation?: string;
+  sportIcon?: string;
 };
 
 type AnnualSharedFields = {
@@ -49,11 +52,11 @@ export function buildAnnualActivityDays(
       days.push({
         ...template,
         date: new Date(cursor),
-        description: sharedFields.description,
-        geoLocation: sharedFields.geoLocation,
+        description: template.description ?? sharedFields.description,
+        geoLocation: template.geoLocation ?? sharedFields.geoLocation,
         latitude: sharedFields.latitude,
         longitude: sharedFields.longitude,
-        sportIcon: sharedFields.sportIcon,
+        sportIcon: template.sportIcon ?? sharedFields.sportIcon,
       });
     }
   }

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -27,6 +27,9 @@ const annualScheduleSchema = z.object({
   schedule: z.string().min(1),
   groupTempId: z.string().min(1).optional(),
   professorIds: z.array(z.string().min(1)).min(1),
+  description: z.string().optional(),
+  geoLocation: z.string().optional(),
+  sportIcon: z.string().optional().nullable(),
 });
 
 const annualScheduleEditSchema = z.object({
@@ -35,6 +38,9 @@ const annualScheduleEditSchema = z.object({
   schedule: z.string().min(1),
   groupId: z.string().min(1).optional(),
   professorIds: z.array(z.string().min(1)).min(1),
+  description: z.string().optional(),
+  geoLocation: z.string().optional(),
+  sportIcon: z.string().optional().nullable(),
 });
 
 const activityGroupBaseShape = {


### PR DESCRIPTION
### Motivation
- Permitir que en la planificación semanal (intersección día × grupo) cada sesión tenga su propia configuración de `lugar`, `deporte` y `materiales` en lugar de depender solo de valores compartidos.

### Description
- Se extendieron los borradores de sesiones anuales para incluir los campos por sesión `description` (materiales), `geoLocation` (lugar) y `sportIcon` (deporte). 
- Se actualizó la normalización/envío de `annualSchedules` en los formularios de crear y editar actividad para incluir esos campos por sesión. 
- Se cambió la generación de días anuales para que los valores por sesión sobrescriban los valores compartidos cuando existan (fallback a valores compartidos si no hay override). 
- Archivos modificados: `src/app/activities/new/form.tsx`, `src/app/activities/[id]/edit/form.tsx`, `src/lib/activities/annual-schedule.ts`, `src/lib/validations/activity.ts`.

### Testing
- Se ejecutó el linter con `pnpm -s lint` y finalizó correctamente; quedaron warnings de `prettier`/formato preexistentes en otros archivos que no bloquean este cambio. 
- No se agregaron tests automatizados; la verificación funcional se limita a la inspección del formulario y la serialización enviada a las rutas existentes de `POST /api/activities` y `PUT /api/activities/[id]`.
- Riesgos sin resolver: la UI sigue mostrando cards por día con sesiones internas en vez de una tabla rígida (columnas = grupos / filas = días), por lo que puede requerirse un ajuste visual adicional para que la vista sea exactamente una cuadrícula; además quedan warnings de formato en el repo que no fueron corregidos en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd08007948328b7390ffa978fccd4)