### PR TITLE
Agregar sección de planificación semanal para actividades temporales

### DIFF
--- a/src/app/activities/[id]/activity-days-panel.tsx
+++ b/src/app/activities/[id]/activity-days-panel.tsx
@@ -58,6 +58,7 @@ type ActivityDay = {
 
 interface ActivityDaysPanelProps {
   activityId: string;
+  isTemporaryActivity: boolean;
   canManageDays: boolean;
   hideSessionDetails?: boolean;
   hideSessionList?: boolean;
@@ -71,6 +72,7 @@ interface ActivityDaysPanelProps {
 
 export default function ActivityDaysPanel({
   activityId,
+  isTemporaryActivity,
   canManageDays,
   hideSessionDetails = false,
   canOpenSessionDetails = false,
@@ -112,6 +114,30 @@ export default function ActivityDaysPanel({
   }));
 
   const existingDayDates = days.map((day) => day.date.slice(0, 10));
+  const weekdayLabels = [
+    'Domingo',
+    'Lunes',
+    'Martes',
+    'Miércoles',
+    'Jueves',
+    'Viernes',
+    'Sábado',
+  ];
+
+  const weeklyGrid = weekdayLabels.map((weekdayLabel, weekdayIndex) => {
+    const perGroup = groups.map((group) => {
+      const match = days.find((day) => {
+        if (day.activityGroupId !== group.id) return false;
+        return new Date(day.date).getDay() === weekdayIndex;
+      });
+      return { group, day: match ?? null };
+    });
+
+    return {
+      weekdayLabel,
+      perGroup,
+    };
+  });
 
   return (
     <>
@@ -188,6 +214,80 @@ export default function ActivityDaysPanel({
           <p className="mt-6 text-sm text-muted-foreground font-body">
             Aún no hay días cargados para esta actividad.
           </p>
+        )}
+
+        {canManageDays && isTemporaryActivity && groups.length > 0 && (
+          <div className="mt-8 rounded-lg border bg-muted/20 p-4">
+            <h3 className="font-heading text-lg font-semibold">
+              Planificar semana (actividades temporales)
+            </h3>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Definí por grupo y día el lugar, deporte y materiales desde cada
+              sesión.
+            </p>
+            <div className="mt-4 overflow-x-auto">
+              <table className="w-full min-w-[800px] border-collapse text-sm">
+                <thead>
+                  <tr>
+                    <th className="border bg-background p-2 text-left">Día</th>
+                    {groups.map((group) => (
+                      <th
+                        key={group.id}
+                        className="border bg-background p-2 text-left"
+                      >
+                        {group.name}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {weeklyGrid.map((row) => (
+                    <tr key={row.weekdayLabel}>
+                      <td className="border p-2 font-medium">
+                        {row.weekdayLabel}
+                      </td>
+                      {row.perGroup.map(({ group, day }) => (
+                        <td key={group.id} className="border p-2 align-top">
+                          {day ? (
+                            <div className="space-y-1">
+                              <p>
+                                <span className="font-medium">Lugar:</span>{' '}
+                                {day.geoLocation}
+                              </p>
+                              <p>
+                                <span className="font-medium">Deporte:</span>{' '}
+                                {day.sportIcon || 'Sin definir'}
+                              </p>
+                              <p>
+                                <span className="font-medium">Materiales:</span>{' '}
+                                {day.description || 'Sin definir'}
+                              </p>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() =>
+                                  router.push(
+                                    `/activities/${activityId}/days/${day.id}/edit`
+                                  )
+                                }
+                              >
+                                Editar
+                              </Button>
+                            </div>
+                          ) : (
+                            <p className="text-muted-foreground">
+                              Sin sesión para este cruce.
+                            </p>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
         )}
       </section>
     </>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -628,6 +628,7 @@ export default async function ActivityPage({ params }: ActivityPageProps) {
         {canSeeSessions && (
           <ActivityDaysPanel
             activityId={activity.id}
+            isTemporaryActivity={activity.activityType === 'TEMPORARY'}
             canManageDays={canManageDays}
             canOpenSessionDetails={isAdmin || isProfessor}
             hideSessionDetails={hideSessionDetails}


### PR DESCRIPTION
### Motivation
- Facilitar a los administradores la planificación semanal de las `activities` de tipo temporal mostrando una vista por día y por grupo donde se defina rápidamente lugar, deporte y materiales. 

### Description
- Se añadió un nuevo prop `isTemporaryActivity` a `ActivityDaysPanel` y se lo pasa desde `src/app/activities/[id]/page.tsx` evaluando `activity.activityType === 'TEMPORARY'`. 
- Se construye una matriz semanal (`weeklyGrid`) basada en los días Domingo–Sábado y en las `groups` para cruzar cada día de semana con cada grupo y buscar la sesión correspondiente. 
- Se renderiza una tabla con filas por día y columnas por grupo mostrando en cada intersección `Lugar` (`geoLocation`), `Deporte` (`sportIcon`), `Materiales` (`description`) y un botón `Editar` que redirige a `/activities/{activityId}/days/{dayId}/edit`. 
- La sección `Planificar semana (actividades temporales)` solo se muestra cuando `canManageDays && isTemporaryActivity && groups.length > 0` para mantener la visibilidad restringida a administración y actividades temporales.

### Testing
- Ejecuté `pnpm lint` y finalizó correctamente sin errores (se observaron warnings de formato preexistentes en otros archivos no relacionados con este cambio). 
- Se ejecutó `pnpm prettier --write` sobre los archivos modificados para corregir formato localmente.


what changed
- Agregada la sección visual de planificación semanal en el panel de días de actividad para actividades temporales.

files touched
- `src/app/activities/[id]/activity-days-panel.tsx` (nuevo cálculo `weeklyGrid` y render de la tabla semanal).
- `src/app/activities/[id]/page.tsx` (se pasa `isTemporaryActivity={activity.activityType === 'TEMPORARY'}`).

tests or verification run
- `pnpm lint` (éxito, con warnings no relacionados); `pnpm prettier --write` sobre archivos modificados.

unresolved risks
- Si no existe una sesión para la combinación día/grupo la celda muestra `Sin sesión para este cruce` y no hay creación inline de sesiones en esta PR. 
- "Materiales" se toma desde el campo `description`; no se creó un campo estructurado nuevo en la base de datos para materiales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dd69aa1e88328ac3063c718ad59da)