### PR TITLE
Ajusta la caja por actividad para descontar egresos

### DIFF
--- a/src/app/accounting/movements/activities/page.tsx
+++ b/src/app/accounting/movements/activities/page.tsx
@@ -33,6 +33,8 @@ type ActivitySummaryRow = {
   monthlyPaymentCount: number;
   sessionPaymentCount: number;
   totalCollected: number;
+  totalExpenses: number;
+  availableBalance: number;
   lastPaidAt: Date | null;
 };
 
@@ -110,6 +112,8 @@ async function getActivitySummary(activityId: string) {
       COALESCE(payments."monthlyPaymentCount", 0)::int AS "monthlyPaymentCount",
       COALESCE(payments."sessionPaymentCount", 0)::int AS "sessionPaymentCount",
       COALESCE(payments."totalCollected", 0)::double precision AS "totalCollected",
+      COALESCE(expenses."totalExpenses", 0)::double precision AS "totalExpenses",
+      (COALESCE(payments."totalCollected", 0) - COALESCE(expenses."totalExpenses", 0))::double precision AS "availableBalance",
       payments."lastPaidAt" AS "lastPaidAt"
     FROM "Activity" a
     LEFT JOIN (
@@ -131,6 +135,15 @@ async function getActivitySummary(activityId: string) {
       FROM "ActivityParticipantPayment" app
       GROUP BY app."activityId"
     ) payments ON payments."activityId" = a."id"
+    LEFT JOIN (
+      SELECT
+        am."activityId",
+        SUM(am."amount") AS "totalExpenses"
+      FROM "AccountingMovement" am
+      WHERE am."type" = 'EXPENSE'
+        AND am."activityId" IS NOT NULL
+      GROUP BY am."activityId"
+    ) expenses ON expenses."activityId" = a."id"
     WHERE a."id" = ${activityId}
     LIMIT 1
   `;
@@ -369,12 +382,13 @@ export default async function ActivityMovementsPage({
               </p>
             </div>
             <div className="rounded-2xl border bg-card p-4 shadow-sm">
-              <p className="text-sm text-muted-foreground">Recaudado</p>
+              <p className="text-sm text-muted-foreground">Caja disponible</p>
               <p className="mt-2 text-2xl font-bold">
-                {formatAmount(selectedActivity.totalCollected)}
+                {formatAmount(selectedActivity.availableBalance)}
               </p>
               <p className="mt-1 text-xs text-muted-foreground">
-                Precio base: {formatAmount(selectedActivity.price)}
+                Recaudado: {formatAmount(selectedActivity.totalCollected)} ·
+                Egresos: {formatAmount(selectedActivity.totalExpenses)}
               </p>
             </div>
           </section>


### PR DESCRIPTION
### Motivation
- Cada actividad debe mostrar su "caja" real: todo lo recaudado menos los egresos asociados para controlar cuánto dinero dispone cada actividad.

### Description
- Se añadió una agregación de `AccountingMovement` (filtro `type = 'EXPENSE'`) en `getActivitySummary` y se calculó `availableBalance = totalCollected - totalExpenses` en la consulta SQL. 
- Se amplió el tipo `ActivitySummaryRow` para incluir `totalExpenses` y `availableBalance` y se expone esa información a la UI. 
- La tarjeta de métricas en la vista `/accounting/movements/activities` ahora muestra `Caja disponible` con el desglose `Recaudado` y `Egresos`. 
- Archivo modificado: `src/app/accounting/movements/activities/page.tsx`.
- Riesgos no resueltos: es recomendable agregar tests de integración para validar escenarios con/ sin egresos y casos donde los egresos superen los ingresos (saldo negativo).

### Testing
- Ejecutado `pnpm -s lint`, que finalizó correctamente (se registraron warnings de formato en archivos no relacionados). 
- Ejecutado `pnpm -s prettier --write src/app/accounting/movements/activities/page.tsx`, que aplicó formato al archivo modificado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e2fd007088328af821fa41d603ec7)