### PR TITLE
Asignar profesor a nivel de grupo en actividades temporales

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,6 +45,7 @@ model User {
   activityParticipants        ActivityParticipant[]
   activityParticipantPayments ActivityParticipantPayment[]
   activityProfessors          ActivityProfessor[]
+  activityGroupProfessors     ActivityGroupProfessor[]
   createdActivityDays         ActivityDay[]                @relation("ActivityDayCreatedBy")
   activityDayProfessors       ActivityDayProfessor[]
   children                    Child[]
@@ -270,8 +271,22 @@ model ActivityGroup {
   activity    Activity              @relation(fields: [activityId], references: [id], onDelete: Cascade)
   members     ActivityGroupMember[]
   days        ActivityDay[]
+  professors  ActivityGroupProfessor[]
 
   @@index([activityId])
+}
+
+model ActivityGroupProfessor {
+  id              String        @id @default(cuid())
+  activityGroupId String
+  userId          String
+  createdAt       DateTime      @default(now())
+  activityGroup   ActivityGroup @relation(fields: [activityGroupId], references: [id], onDelete: Cascade)
+  user            User          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([activityGroupId, userId])
+  @@index([activityGroupId])
+  @@index([userId])
 }
 
 model ActivityGroupMember {

--- a/src/app/activities/[id]/edit/form.tsx
+++ b/src/app/activities/[id]/edit/form.tsx
@@ -133,6 +133,7 @@ export default function EditActivityForm({
   const [newGroupCapacity, setNewGroupCapacity] = useState('');
   const [newGroupMinAge, setNewGroupMinAge] = useState('');
   const [newGroupMaxAge, setNewGroupMaxAge] = useState('');
+  const [newGroupProfessorId, setNewGroupProfessorId] = useState('');
   const [groupError, setGroupError] = useState('');
   const [creatingGroup, setCreatingGroup] = useState(false);
   const [deletingGroupId, setDeletingGroupId] = useState<string | null>(null);
@@ -202,9 +203,10 @@ export default function EditActivityForm({
       !newGroupName.trim() ||
       !newGroupCapacity ||
       !newGroupMinAge ||
-      !newGroupMaxAge
+      !newGroupMaxAge ||
+      !newGroupProfessorId
     ) {
-      setGroupError('Completá nombre, cupo y edades del grupo');
+      setGroupError('Completá nombre, cupo, edades y profesor del grupo');
       return;
     }
     if (Number(newGroupCapacity) < 1) {
@@ -229,6 +231,7 @@ export default function EditActivityForm({
           capacity: Number(newGroupCapacity),
           minAge: Number(newGroupMinAge),
           maxAge: Number(newGroupMaxAge),
+          professorIds: [newGroupProfessorId],
         }),
       });
       if (!res.ok) throw new Error('No se pudo crear el grupo');
@@ -239,6 +242,7 @@ export default function EditActivityForm({
       setNewGroupCapacity('');
       setNewGroupMinAge('');
       setNewGroupMaxAge('');
+      setNewGroupProfessorId('');
     } catch (err) {
       setGroupError(
         err instanceof Error ? err.message : 'Error al crear el grupo'
@@ -521,7 +525,7 @@ export default function EditActivityForm({
             <p className="text-xs text-muted-foreground">Sin grupos todavía.</p>
           )}
 
-          <div className="grid gap-2 items-end sm:grid-cols-2 lg:grid-cols-[1fr_1fr_110px_110px_110px_auto]">
+          <div className="grid gap-2 items-end sm:grid-cols-2 lg:grid-cols-[1fr_1fr_130px_110px_110px_110px_auto]">
             <input
               type="text"
               placeholder="Nombre del grupo"
@@ -572,6 +576,18 @@ export default function EditActivityForm({
               onChange={(e) => setNewGroupMaxAge(e.target.value)}
               className={inputClass}
             />
+            <select
+              value={newGroupProfessorId}
+              onChange={(e) => setNewGroupProfessorId(e.target.value)}
+              className={inputClass}
+            >
+              <option value="">Profesor del grupo</option>
+              {selectedProfessors.map((professor) => (
+                <option key={professor.id} value={professor.id}>
+                  {professor.name ?? 'Sin nombre'} {professor.lastName ?? ''}
+                </option>
+              ))}
+            </select>
             <Button
               type="button"
               variant="outline"

--- a/src/app/activities/new/form.tsx
+++ b/src/app/activities/new/form.tsx
@@ -22,6 +22,7 @@ type GroupDraft = {
   capacity: string;
   minAge: string;
   maxAge: string;
+  professorIds: string[];
 };
 
 type Coordinates = {
@@ -96,6 +97,7 @@ export default function CreateActivityForm({
   const [newGroupCapacity, setNewGroupCapacity] = useState('');
   const [newGroupMinAge, setNewGroupMinAge] = useState('');
   const [newGroupMaxAge, setNewGroupMaxAge] = useState('');
+  const [newGroupProfessorId, setNewGroupProfessorId] = useState('');
   const [annualSchedules, setAnnualSchedules] = useState<AnnualScheduleDraft[]>(
     []
   );
@@ -121,9 +123,10 @@ export default function CreateActivityForm({
       !newGroupName.trim() ||
       !newGroupCapacity ||
       !newGroupMinAge ||
-      !newGroupMaxAge
+      !newGroupMaxAge ||
+      !newGroupProfessorId
     ) {
-      setError('Completá nombre, cupo y edades del grupo');
+      setError('Completá nombre, cupo, edades y profesor del grupo');
       return;
     }
     if (Number(newGroupCapacity) < 1) {
@@ -144,6 +147,7 @@ export default function CreateActivityForm({
         capacity: newGroupCapacity,
         minAge: newGroupMinAge,
         maxAge: newGroupMaxAge,
+        professorIds: [newGroupProfessorId],
       },
     ]);
     setNewGroupName('');
@@ -151,6 +155,7 @@ export default function CreateActivityForm({
     setNewGroupCapacity('');
     setNewGroupMinAge('');
     setNewGroupMaxAge('');
+    setNewGroupProfessorId('');
   }
 
   function removeGroupDraft(tempId: string) {
@@ -204,6 +209,7 @@ export default function CreateActivityForm({
     setNewGroupCapacity('');
     setNewGroupMinAge('');
     setNewGroupMaxAge('');
+    setNewGroupProfessorId('');
     setAnnualSchedules([]);
     setAnnualShared({
       geoLocation: '',
@@ -277,6 +283,7 @@ export default function CreateActivityForm({
             capacity: Number(group.capacity),
             minAge: Number(group.minAge),
             maxAge: Number(group.maxAge),
+            professorIds: group.professorIds,
           })),
           annualSchedules: normalizedAnnualSchedules,
           geoLocation:
@@ -404,6 +411,11 @@ export default function CreateActivityForm({
                     - Cupo {group.capacity} - {group.minAge} a {group.maxAge}{' '}
                     años
                   </span>
+                  <span className="ml-2 text-muted-foreground">
+                    - Profesor:{' '}
+                    {professors.find((p) => p.id === group.professorIds[0])
+                      ?.name ?? 'Sin nombre'}
+                  </span>
                 </span>
                 <button
                   type="button"
@@ -417,7 +429,7 @@ export default function CreateActivityForm({
           </ul>
         )}
 
-        <div className="grid items-end gap-2 sm:grid-cols-2 lg:grid-cols-[1fr_1fr_110px_110px_110px_auto]">
+        <div className="grid items-end gap-2 sm:grid-cols-2 lg:grid-cols-[1fr_1fr_130px_110px_110px_110px_auto]">
           <input
             type="text"
             placeholder="Nombre del grupo"
@@ -468,6 +480,18 @@ export default function CreateActivityForm({
             onChange={(e) => setNewGroupMaxAge(e.target.value)}
             className={inputClass}
           />
+          <select
+            value={newGroupProfessorId}
+            onChange={(e) => setNewGroupProfessorId(e.target.value)}
+            className={inputClass}
+          >
+            <option value="">Profesor del grupo</option>
+            {selectedProfessors.map((professor) => (
+              <option key={professor.id} value={professor.id}>
+                {professor.name ?? 'Sin nombre'} {professor.lastName ?? ''}
+              </option>
+            ))}
+          </select>
           <Button type="button" variant="outline" onClick={addGroupDraft}>
             Agregar
           </Button>

--- a/src/app/api/activities/[id]/groups/route.ts
+++ b/src/app/api/activities/[id]/groups/route.ts
@@ -54,6 +54,12 @@ export async function POST(
       maxAge: data.maxAge,
     },
   });
+  await prisma.activityGroupProfessor.createMany({
+    data: data.professorIds.map((userId) => ({
+      activityGroupId: group.id,
+      userId,
+    })),
+  });
 
   return NextResponse.json(group);
 }

--- a/src/app/api/activities/route.ts
+++ b/src/app/api/activities/route.ts
@@ -22,8 +22,11 @@ export async function POST(req: Request) {
   const annualProfessorIds = Array.from(
     new Set(data.annualSchedules.flatMap((schedule) => schedule.professorIds))
   );
+  const groupProfessorIds = Array.from(
+    new Set(data.groups.flatMap((group) => group.professorIds))
+  );
   const professorIdsToValidate = Array.from(
-    new Set([...professorIds, ...annualProfessorIds])
+    new Set([...professorIds, ...annualProfessorIds, ...groupProfessorIds])
   );
   if (professorIdsToValidate.length > 0) {
     const validProfessors = await prisma.user.findMany({
@@ -84,6 +87,12 @@ export async function POST(req: Request) {
             select: { id: true },
           });
           groupIdByTempId.set(group.tempId, createdGroup.id);
+          await tx.activityGroupProfessor.createMany({
+            data: group.professorIds.map((userId) => ({
+              activityGroupId: createdGroup.id,
+              userId,
+            })),
+          });
         }
       }
 

--- a/src/lib/validations/activity.ts
+++ b/src/lib/validations/activity.ts
@@ -55,6 +55,7 @@ const activityGroupBaseSchema = z
 const activityGroupDraftSchema = z
   .object({
     tempId: z.string().min(1),
+    professorIds: z.array(z.string().min(1)).min(1),
     ...activityGroupBaseShape,
   })
   .refine((data) => data.maxAge >= data.minAge, {
@@ -210,7 +211,9 @@ export const activityUpdateSchema = activityBaseSchema
     }
   });
 
-export const activityGroupCreateSchema = activityGroupBaseSchema;
+export const activityGroupCreateSchema = activityGroupBaseSchema.extend({
+  professorIds: z.array(z.string().min(1)).min(1),
+});
 
 export const activityDayCreateSchema = z.object({
   date: z


### PR DESCRIPTION
### Motivation
- Cambiar la asignación de profesores para actividades temporales para que el profesor se fije en cada `ActivityGroup` al crearlo/editarlo en lugar de hacerlo solo en sesiones, de modo que cada grupo tenga un profesor responsable.

### Description
- Añadido el modelo `ActivityGroupProfessor` y su relación con `User` y `ActivityGroup` en `prisma/schema.prisma`, y referenciado en `User` para persistir asignaciones profesor–grupo (requiere migración de Prisma en despliegue). 
- Validaciones actualizadas en `src/lib/validations/activity.ts` para exigir `professorIds` en los grupos enviados (`activityGroupDraftSchema` y `activityGroupCreateSchema`).
- En el endpoint de creación de actividades `POST /api/activities` (`src/app/api/activities/route.ts`) ahora se validan también los `professorIds` de los grupos y se persisten con `activityGroupProfessor.createMany` al crear cada grupo; además se incluyen estos ids en la validación general de profesores.
- En el endpoint de crear grupo desde la edición `POST /api/activities/[id]/groups` (`src/app/api/activities/[id]/groups/route.ts`) se guarda la(s) asignación(es) de profesor(es) junto con el `ActivityGroup` creado.
- UI: en `src/app/activities/new/form.tsx` y `src/app/activities/[id]/edit/form.tsx` se añadió un campo para seleccionar el `Profesor del grupo` al crear un grupo, se incluye esa información en el payload enviado al backend y se muestra el profesor seleccionado en la lista de grupos.

### Testing
- Ejecutado `pnpm -s lint`, la tarea finalizó correctamente y solo reportó warnings preexistentes de `prettier` en archivos no relacionados con este cambio.
- No se modificaron tests unitarios ni de integración existentes en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e352c02e483288eff833b318d68ff)