### PR TITLE
Mejora UX del selector de profesores en edición de actividades

### DIFF
--- a/src/app/activities/professor-picker.tsx
+++ b/src/app/activities/professor-picker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { ChevronDown } from 'lucide-react';
-import { useId, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
 
 type ProfessorOption = {
   id: string;
@@ -21,11 +21,9 @@ export default function ProfessorPicker({
   professors,
   value,
   onChange,
-  defaultCollapsed = false,
 }: ProfessorPickerProps) {
-  const listId = useId();
-  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [search, setSearch] = useState('');
+  const [open, setOpen] = useState(false);
 
   const normalizedSearch = search.trim().toLocaleLowerCase();
   const filteredProfessors = useMemo(() => {
@@ -42,118 +40,122 @@ export default function ProfessorPicker({
     });
   }, [normalizedSearch, professors]);
 
+  const selectedProfessors = useMemo(
+    () => professors.filter((professor) => value.includes(professor.id)),
+    [professors, value]
+  );
+
   const selectedCountLabel =
     value.length === 1 ? '1 seleccionado' : `${value.length} seleccionados`;
 
-  const header = (
-    <div>
-      <h3 className="text-sm font-semibold">Profesores</h3>
-      <p className="text-xs text-muted-foreground">
-        Asigná uno o más profesores responsables de la actividad.
-      </p>
-    </div>
-  );
-
-  const professorList = (
-    <div id={listId}>
-      {professors.length === 0 ? (
-        <p className="text-sm text-muted-foreground">
-          No hay usuarios con rol profesor disponibles.
-        </p>
-      ) : (
-        <div className="space-y-3">
-          <input
-            type="search"
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Buscar profesor por nombre o email"
-            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-            aria-label="Buscar profesor"
-          />
-
-          {filteredProfessors.length === 0 ? (
-            <p className="text-sm text-muted-foreground">
-              No se encontraron profesores para &quot;{search.trim()}&quot;.
-            </p>
-          ) : (
-            <div className="grid gap-2 sm:grid-cols-2">
-              {filteredProfessors.map((professor) => {
-                const checked = value.includes(professor.id);
-                return (
-                  <label
-                    key={professor.id}
-                    className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
-                  >
-                    <input
-                      type="checkbox"
-                      checked={checked}
-                      onChange={(e) => {
-                        if (e.target.checked) {
-                          onChange([...value, professor.id]);
-                          return;
-                        }
-                        onChange(value.filter((id) => id !== professor.id));
-                      }}
-                      className="mt-1 accent-primary"
-                    />
-                    <span>
-                      <span className="block font-medium">
-                        {professor.name ?? 'Sin nombre'}{' '}
-                        {professor.lastName ?? ''}
-                      </span>
-                      <span className="block text-xs text-muted-foreground">
-                        {professor.email}
-                      </span>
-                    </span>
-                  </label>
-                );
-              })}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-
-  if (defaultCollapsed) {
-    return (
-      <div className="space-y-2 rounded-lg border bg-muted/20 p-4">
-        <button
-          type="button"
-          className="flex w-full items-center justify-between gap-3 text-left"
-          aria-expanded={!collapsed}
-          aria-controls={listId}
-          onClick={() => setCollapsed((current) => !current)}
-        >
-          <span>
-            <span className="block text-sm font-semibold">Profesores</span>
-            <span className="block text-xs text-muted-foreground">
-              {selectedCountLabel}
-            </span>
-          </span>
-          <ChevronDown
-            className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
-              collapsed ? '' : 'rotate-180'
-            }`}
-            aria-hidden="true"
-          />
-        </button>
-        {!collapsed && (
-          <div className="space-y-2">
-            <p className="text-xs text-muted-foreground">
-              Asigná uno o más profesores responsables de la actividad.
-            </p>
-            {professorList}
-          </div>
-        )}
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-2 rounded-lg border bg-muted/20 p-4">
-      {header}
-      {professorList}
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold">Profesores</h3>
+          <p className="text-xs text-muted-foreground">{selectedCountLabel}</p>
+        </div>
+        <Button type="button" variant="outline" onClick={() => setOpen(true)}>
+          Seleccionar profesores
+        </Button>
+      </div>
+
+      {selectedProfessors.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedProfessors.map((professor) => (
+            <span
+              key={professor.id}
+              className="rounded-full border bg-background px-3 py-1 text-xs"
+            >
+              {(professor.name ?? 'Sin nombre').trim()}{' '}
+              {professor.lastName ?? ''}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-lg bg-background shadow-xl">
+            <div className="border-b p-4">
+              <h4 className="text-base font-semibold">
+                Seleccionar profesores
+              </h4>
+              <p className="text-xs text-muted-foreground">
+                Elegí uno o más profesores para la actividad.
+              </p>
+            </div>
+
+            <div className="space-y-3 overflow-y-auto p-4">
+              <input
+                type="search"
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Buscar profesor por nombre o email"
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                aria-label="Buscar profesor"
+              />
+
+              {professors.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No hay usuarios con rol profesor disponibles.
+                </p>
+              ) : filteredProfessors.length === 0 ? (
+                <p className="text-sm text-muted-foreground">
+                  No se encontraron profesores para &quot;{search.trim()}&quot;.
+                </p>
+              ) : (
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {filteredProfessors.map((professor) => {
+                    const checked = value.includes(professor.id);
+                    return (
+                      <label
+                        key={professor.id}
+                        className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={(e) => {
+                            if (e.target.checked) {
+                              onChange([...value, professor.id]);
+                              return;
+                            }
+                            onChange(value.filter((id) => id !== professor.id));
+                          }}
+                          className="mt-1 accent-primary"
+                        />
+                        <span>
+                          <span className="block font-medium">
+                            {professor.name ?? 'Sin nombre'}{' '}
+                            {professor.lastName ?? ''}
+                          </span>
+                          <span className="block text-xs text-muted-foreground">
+                            {professor.email}
+                          </span>
+                        </span>
+                      </label>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+
+            <div className="flex justify-end gap-2 border-t p-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setOpen(false);
+                  setSearch('');
+                }}
+              >
+                Cerrar
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Al editar una actividad, la selección de profesores debe permitir elegir varios responsables de forma sencilla y buscar por nombre/email, por eso se reemplazó el desplegable inline por una modal que facilita selección múltiple y búsqueda.

### Description
- Reemplacé el picker expandible por un botón `Seleccionar profesores` que abre una ventana emergente (modal) con la lista completa de profesores y checkboxes para selección múltiple.
- Añadí un campo de búsqueda dentro de la modal para filtrar por nombre o email y mostré los profesores ya asignados como chips en el formulario; la API de selección (`onChange`) y el soporte a múltiples IDs se mantienen.
- Archivo modificado: `src/app/activities/professor-picker.tsx`.
- Riesgos no resueltos: no se añadieron pruebas automáticas de UI/E2E para validar apertura de modal, búsqueda y selección, y existen warnings de Prettier en otros archivos no relacionados.

### Testing
- Ejecutado `pnpm prettier --write src/app/activities/professor-picker.tsx` que formateó el archivo objetivo correctamente.
- Ejecutado `pnpm lint` que finalizó con exit code 0 (se reportaron únicamente warnings de Prettier en archivos no modificados por este cambio).
- No se agregaron tests automatizados nuevos y por tanto no hay pruebas E2E/UI automáticas incluidas en este PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10e58b901c8328b901ba9a15aab5b6)