### PR TITLE
Allow COUNTER role to list users (enable accounting to start chats)

### DIFF
--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -4,14 +4,14 @@ import { hash } from 'bcrypt';
 import { authOptions } from '@/lib/auth';
 import { prisma } from '@/lib/prisma';
 import { registerSchema } from '@/lib/validations/auth';
-import { hasAdminCapability } from '@/lib/roles';
+import { hasAnyCapability } from '@/lib/roles';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
   if (!session?.user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
-  if (!hasAdminCapability(session)) {
+  if (!hasAnyCapability(session, ['COUNTER', 'ADMIN', 'SUPER_ADMIN'])) {
     return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
 


### PR DESCRIPTION
### Motivation
- Align the users listing API with existing chat/send-message rules so accounting (`COUNTER`) users can open chats and message any registered user just like admins can.

### Description
- Updated `GET /api/users` to use `hasAnyCapability(session, ['COUNTER', 'ADMIN', 'SUPER_ADMIN'])` (importing `hasAnyCapability`) so accounting roles can list users; this change touches `src/app/api/users/route.ts` and leaves `POST /api/users` (user creation) unchanged.

### Testing
- Ran `pnpm lint` which completed successfully (exit code 0) though unrelated Prettier warnings exist elsewhere in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ac40ec708328bf27c787f8c91a24)