### PR TITLE
Revert add teacher selection modal behavior

### DIFF
--- a/src/app/activities/professor-picker.tsx
+++ b/src/app/activities/professor-picker.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { ChevronDown } from 'lucide-react';
 import { useId, useMemo, useState } from 'react';
-import { Button } from '@/components/ui/button';
 
 type ProfessorOption = {
   id: string;
@@ -21,10 +21,11 @@ export default function ProfessorPicker({
   professors,
   value,
   onChange,
+  defaultCollapsed = false,
 }: ProfessorPickerProps) {
-  const dialogId = useId();
+  const listId = useId();
+  const [collapsed, setCollapsed] = useState(defaultCollapsed);
   const [search, setSearch] = useState('');
-  const [open, setOpen] = useState(false);
 
   const normalizedSearch = search.trim().toLocaleLowerCase();
   const filteredProfessors = useMemo(() => {
@@ -41,134 +42,118 @@ export default function ProfessorPicker({
     });
   }, [normalizedSearch, professors]);
 
-  const selectedProfessors = useMemo(
-    () => professors.filter((professor) => value.includes(professor.id)),
-    [professors, value]
-  );
-
   const selectedCountLabel =
     value.length === 1 ? '1 seleccionado' : `${value.length} seleccionados`;
 
+  const header = (
+    <div>
+      <h3 className="text-sm font-semibold">Profesores</h3>
+      <p className="text-xs text-muted-foreground">
+        Asigná uno o más profesores responsables de la actividad.
+      </p>
+    </div>
+  );
+
+  const professorList = (
+    <div id={listId}>
+      {professors.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          No hay usuarios con rol profesor disponibles.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          <input
+            type="search"
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="Buscar profesor por nombre o email"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+            aria-label="Buscar profesor"
+          />
+
+          {filteredProfessors.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No se encontraron profesores para &quot;{search.trim()}&quot;.
+            </p>
+          ) : (
+            <div className="grid gap-2 sm:grid-cols-2">
+              {filteredProfessors.map((professor) => {
+                const checked = value.includes(professor.id);
+                return (
+                  <label
+                    key={professor.id}
+                    className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={(e) => {
+                        if (e.target.checked) {
+                          onChange([...value, professor.id]);
+                          return;
+                        }
+                        onChange(value.filter((id) => id !== professor.id));
+                      }}
+                      className="mt-1 accent-primary"
+                    />
+                    <span>
+                      <span className="block font-medium">
+                        {professor.name ?? 'Sin nombre'}{' '}
+                        {professor.lastName ?? ''}
+                      </span>
+                      <span className="block text-xs text-muted-foreground">
+                        {professor.email}
+                      </span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+
+  if (defaultCollapsed) {
+    return (
+      <div className="space-y-2 rounded-lg border bg-muted/20 p-4">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between gap-3 text-left"
+          aria-expanded={!collapsed}
+          aria-controls={listId}
+          onClick={() => setCollapsed((current) => !current)}
+        >
+          <span>
+            <span className="block text-sm font-semibold">Profesores</span>
+            <span className="block text-xs text-muted-foreground">
+              {selectedCountLabel}
+            </span>
+          </span>
+          <ChevronDown
+            className={`h-4 w-4 shrink-0 text-muted-foreground transition-transform ${
+              collapsed ? '' : 'rotate-180'
+            }`}
+            aria-hidden="true"
+          />
+        </button>
+        {!collapsed && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Asigná uno o más profesores responsables de la actividad.
+            </p>
+            {professorList}
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-2 rounded-lg border bg-muted/20 p-4">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-semibold">Profesores</h3>
-          <p className="text-xs text-muted-foreground">{selectedCountLabel}</p>
-        </div>
-        <Button
-          type="button"
-          variant="outline"
-          onClick={() => setOpen(true)}
-          aria-controls={dialogId}
-          aria-expanded={open}
-          aria-haspopup="dialog"
-        >
-          Seleccionar profesores
-        </Button>
-      </div>
-
-      {selectedProfessors.length > 0 && (
-        <div className="flex flex-wrap gap-2">
-          {selectedProfessors.map((professor) => (
-            <span
-              key={professor.id}
-              className="rounded-full border bg-background px-3 py-1 text-xs"
-            >
-              {(professor.name ?? 'Sin nombre').trim()}{' '}
-              {professor.lastName ?? ''}
-            </span>
-          ))}
-        </div>
-      )}
-
-      {open && (
-        <div
-          id={dialogId}
-          role="dialog"
-          aria-modal="true"
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-        >
-          <div className="max-h-[85vh] w-full max-w-3xl overflow-hidden rounded-lg bg-background shadow-xl">
-            <div className="border-b p-4">
-              <h4 className="text-base font-semibold">
-                Seleccionar profesores
-              </h4>
-              <p className="text-xs text-muted-foreground">
-                Elegí uno o más profesores para la actividad.
-              </p>
-            </div>
-
-            <div className="space-y-3 overflow-y-auto p-4">
-              <input
-                type="search"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Buscar profesor por nombre o email"
-                className="w-full rounded-md border bg-background px-3 py-2 text-sm"
-                aria-label="Buscar profesor"
-              />
-
-              {professors.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No hay usuarios con rol profesor disponibles.
-                </p>
-              ) : filteredProfessors.length === 0 ? (
-                <p className="text-sm text-muted-foreground">
-                  No se encontraron profesores para &quot;{search.trim()}&quot;.
-                </p>
-              ) : (
-                <div className="grid gap-2 sm:grid-cols-2">
-                  {filteredProfessors.map((professor) => {
-                    const checked = value.includes(professor.id);
-                    return (
-                      <label
-                        key={professor.id}
-                        className="flex items-start gap-3 rounded-md border bg-background p-3 text-sm"
-                      >
-                        <input
-                          type="checkbox"
-                          checked={checked}
-                          onChange={(e) => {
-                            if (e.target.checked) {
-                              onChange([...value, professor.id]);
-                              return;
-                            }
-                            onChange(value.filter((id) => id !== professor.id));
-                          }}
-                          className="mt-1 accent-primary"
-                        />
-                        <span>
-                          <span className="block font-medium">
-                            {professor.name ?? 'Sin nombre'}{' '}
-                            {professor.lastName ?? ''}
-                          </span>
-                          <span className="block text-xs text-muted-foreground">
-                            {professor.email}
-                          </span>
-                        </span>
-                      </label>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-
-            <div className="flex justify-end gap-2 border-t p-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setOpen(false);
-                  setSearch('');
-                }}
-              >
-                Cerrar
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      {header}
+      {professorList}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Revertir la introducción del modal para la selección de profesores y restaurar el comportamiento inline/colapsable anterior en el flujo de edición de actividad para mantener la UX previa y evitar la nueva ventana emergente con botón/chips.

### Description
- Se restauró la implementación previa en `src/app/activities/professor-picker.tsx`: se removió la UI de modal/botón/chips y se reintrodujo el comportamiento inline/colapsable (`defaultCollapsed`) con la búsqueda y la selección múltiple por checkboxes preservadas; archivo modificado: `src/app/activities/professor-picker.tsx`.

### Testing
- Ejecuté `pnpm lint`, que finalizó correctamente; quedaron warnings de Prettier/ESLint en otros archivos del repositorio que no están relacionados con este revert.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1208108e4c83289ad273b2ce0887c9)